### PR TITLE
chore(backend): step1 인프라 셋업 (flyway + security + jwt + webpush + V1 스키마)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,31 @@
+name: CI
+
 on:
   pull_request:
+    branches: [main, feat/backend]
+  push:
+    branches: [main, feat/backend]
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
     steps:
-      - run: echo "ok"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      - name: Build & test
+        run: ./gradlew build
+        env:
+          JWT_SECRET: ci-test-secret-base64-padded-32bytes-long==

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,13 @@ DB_PASSWORD=
 # 서버 포트 (기본 8080)
 SERVER_PORT=8080
 
-# 도메인 담당자가 본인 작업 시 외부 API 키 등을 여기에 추가
-# 예: KAKAO_REST_API_KEY=...   (지도 도메인)
-# 예: ODSAY_API_KEY=...        (경로 도메인)
+# JWT (256-bit Base64-encoded — openssl rand -base64 32 로 생성)
+JWT_SECRET=changeme-base64-encoded-256bit-secret
+
+# 외부 API 키 (도메인 담당자가 본인 작업 시 채움)
+ODSAY_API_KEY=
+KAKAO_LOCAL_API_KEY=
+
+# Web Push (VAPID 키페어 — web-push generate-vapid-keys 로 생성)
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -27,10 +27,31 @@ dependencies {
 	runtimeOnly("com.mysql:mysql-connector-j")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.projectlombok:lombok")
+
+	// DB 마이그레이션 (Flyway)
+	implementation("org.flywaydb:flyway-core")
+	implementation("org.flywaydb:flyway-mysql")
+
+	// 인증 (Spring Security + JJWT 0.12.x)
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+	// Web Push (VAPID) — Step 7 이상진 사용 예정, 의존성만 미리
+	implementation("nl.martijndwars:web-push:5.1.1")
+	implementation("org.bouncycastle:bcprov-jdk18on:1.78")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testCompileOnly("org.projectlombok:lombok")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testAnnotationProcessor("org.projectlombok:lombok")
+
+	// 통합 테스트 (Testcontainers MySQL)
+	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation("org.testcontainers:junit-jupiter")
+	testImplementation("org.testcontainers:mysql")
+	testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
       enabled: true   # Java 21 Virtual Threads
   jackson:
     time-zone: Asia/Seoul
+    serialization:
+      write-dates-as-timestamps: false   # ISO 8601 문자열 직렬화
   lifecycle:
     timeout-per-shutdown-phase: 30s
   datasource:
@@ -20,6 +22,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
     open-in-view: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
 
 server:
   port: ${SERVER_PORT:8080}
@@ -30,3 +36,23 @@ management:
     web:
       exposure:
         include: health,info
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration-minutes: 30
+  refresh-token-expiration-days: 14
+  issuer: todayway
+
+odsay:
+  api-key: ${ODSAY_API_KEY:}
+  base-url: https://api.odsay.com/v1/api
+  timeout-seconds: 5
+
+kakao-local:
+  api-key: ${KAKAO_LOCAL_API_KEY:}
+  base-url: https://dapi.kakao.com/v2/local
+
+vapid:
+  public-key: ${VAPID_PUBLIC_KEY:}
+  private-key: ${VAPID_PRIVATE_KEY:}
+  subject: mailto:contact@todayway.example

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,227 @@
+-- =====================================================================
+-- DB 스키마 v1.1-MVP — Spring 단일 백엔드 (MySQL 8.x / utf8mb4)
+-- 작성: 황찬우, 2026-04-23
+-- =====================================================================
+--
+-- 🗑 삭제된 테이블 (10개)
+--   - member_calendar_link        외부 캘린더 OAuth → 자체 캘린더로 전환
+--   - member_preferences          선호도 → MVP에선 사용처 없음 (랭킹 알고리즘 부재)
+--   - favorite_route              즐겨찾기 → P1, MVP 범위 밖
+--   - route_set                   경로 후보 묶음 → ODsay 응답을 schedule.route_summary_json에 저장
+--   - route_candidate             경로 후보 → 단일 경로 표시 (후보 리랭킹 없음)
+--   - route_segment               경로 구간 → JSON 필드로 흡수
+--   - subway_congestion_lookup    지하철 혼잡도 → MVP에서 혼잡도 계산 안 함
+--   - bus_congestion_lookup       버스 혼잡도 → 동일 사유
+--   - ranking_weight              랭킹 가중치 학습 → 랭킹 알고리즘 부재로 불필요
+--   - feedback                    피드백 → P1, MVP 범위 밖
+--
+-- 🔧 단순화된 테이블 (1개)
+--   - member: calendar_linked 컬럼 삭제
+--
+-- ♻️ v1.0-MVP에서 다시 복구된 테이블 (3개)
+--   - push_subscription           Web Push 구독 (알림 기능 유지 결정)
+--   - push_log                    푸시 발송 이력
+--   - geocode_cache               지오코딩 캐시 (ODsay 좌표 입력 가정)
+--
+-- ✨ 남은 테이블 (6개)
+--   1. member             회원
+--   2. refresh_token      JWT 인증 (S1 결정에 따라 변경 가능)
+--   3. schedule           일정/루틴 + ODsay 응답 캐시
+--   4. push_subscription  Web Push 구독
+--   5. push_log           푸시 발송 이력
+--   6. geocode_cache      지오코딩 결과 캐시
+--
+-- =====================================================================
+-- MVP 사용자 흐름
+--
+--   1. 회원가입/로그인              → member, refresh_token
+--   2. 푸시 알림 구독                → push_subscription
+--   3. 일정 등록                    → schedule (출/도착지, 출발시각, 도착희망시각)
+--      └ 출/도착지 텍스트 → 좌표 변환 → geocode_cache (캐시 미스 시 카카오/네이버 호출)
+--   4. 서버가 ODsay 호출            → schedule.route_summary_json에 응답 저장
+--   5. 권장 출발시각 안내            → schedule.recommended_departure_time 계산 후 표시
+--   6. 스케줄러가 reminder_at 시점에 푸시 발송 → push_log에 기록
+--   7. 일정 조회/수정/삭제           → schedule
+--
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. 회원 / 인증
+-- =====================================================================
+
+CREATE TABLE member (
+  id            BIGINT       NOT NULL AUTO_INCREMENT,
+  member_uid    CHAR(26)     NOT NULL                COMMENT 'ULID, 외부 노출용',
+  login_id      VARCHAR(50)  NOT NULL                COMMENT '로그인 아이디',
+  password_hash VARCHAR(255) NOT NULL                COMMENT 'bcrypt 등',
+  nickname      VARCHAR(50)  NOT NULL,
+  created_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  deleted_at    DATETIME(3)  NULL                    COMMENT '탈퇴 시각 (소프트 삭제)',
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_member_uid   (member_uid),
+  UNIQUE KEY uq_member_login (login_id)
+) ENGINE=InnoDB COMMENT='회원';
+
+
+-- Refresh Token (JWT 사용 가정.)
+CREATE TABLE refresh_token (
+  id         BIGINT      NOT NULL AUTO_INCREMENT,
+  member_id  BIGINT      NOT NULL,
+  token_hash CHAR(64)    NOT NULL                  COMMENT 'SHA-256 해시',
+  expires_at DATETIME(3) NOT NULL,
+  revoked_at DATETIME(3) NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_refresh_hash   (token_hash),
+  KEY        ix_refresh_member (member_id, revoked_at),
+  CONSTRAINT fk_refresh_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+) ENGINE=InnoDB COMMENT='리프레시 토큰';
+
+
+-- =====================================================================
+-- 2. 일정 / 루틴 + ODsay 응답 캐시
+-- =====================================================================
+
+CREATE TABLE schedule (
+  id                          BIGINT        NOT NULL AUTO_INCREMENT,
+  schedule_uid                CHAR(26)      NOT NULL,
+  member_id                   BIGINT        NOT NULL,
+  title                       VARCHAR(100)  NOT NULL,
+
+  -- 출발지
+  origin_name                 VARCHAR(100)  NOT NULL,
+  origin_lat                  DECIMAL(10,7) NOT NULL,
+  origin_lng                  DECIMAL(10,7) NOT NULL,
+  origin_address              VARCHAR(255)  NULL,
+  origin_place_id             VARCHAR(100)  NULL,
+  origin_provider             ENUM('NAVER','KAKAO','ODSAY','MANUAL') NULL,
+
+  -- 도착지
+  destination_name            VARCHAR(100)  NOT NULL,
+  destination_lat             DECIMAL(10,7) NOT NULL,
+  destination_lng             DECIMAL(10,7) NOT NULL,
+  destination_address         VARCHAR(255)  NULL,
+  destination_place_id        VARCHAR(100)  NULL,
+  destination_provider        ENUM('NAVER','KAKAO','ODSAY','MANUAL') NULL,
+
+  -- 시간 (사용자 입력)
+  user_departure_time         DATETIME(3)   NOT NULL  COMMENT '사용자가 입력한 출발 시각',
+  arrival_time                DATETIME(3)   NOT NULL  COMMENT '도착 희망 시각',
+
+  -- ODsay 호출 결과 (서버가 채움)
+  estimated_duration_minutes  INT           NULL      COMMENT 'ODsay 응답 소요시간 (분)',
+  recommended_departure_time  DATETIME(3)   NULL      COMMENT '서버가 권장하는 출발시각',
+  departure_advice            ENUM('EARLIER','ON_TIME','LATER') NULL COMMENT '출발시각 조정 안내',
+  route_summary_json          JSON          NULL      COMMENT 'ODsay 응답 통째 저장',
+  route_calculated_at         DATETIME(3)   NULL      COMMENT 'ODsay 호출 시각',
+
+  -- 알림 (푸시 복구로 재추가)
+  reminder_offset_minutes     INT           NOT NULL DEFAULT 5  COMMENT '권장 출발시각 몇 분 전 알림',
+  reminder_at                 DATETIME(3)   NULL                COMMENT 'recommended_departure_time - offset',
+
+  -- 루틴 (NULL이면 단발성)
+  routine_type                ENUM('ONCE','DAILY','WEEKLY','CUSTOM') NULL,
+  routine_days_of_week        VARCHAR(20)   NULL      COMMENT 'MON,TUE,...',
+  routine_interval_days       INT           NULL,
+
+  created_at                  DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at                  DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  deleted_at                  DATETIME(3)   NULL,
+
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_schedule_uid    (schedule_uid),
+  KEY        ix_sch_member_arrival (member_id, arrival_time),
+  KEY        ix_sch_reminder    (reminder_at, deleted_at) COMMENT '스케줄러용',
+  CONSTRAINT fk_sch_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+) ENGINE=InnoDB COMMENT='일정/루틴 + ODsay 응답 캐시';
+
+
+-- =====================================================================
+-- 3. 알림 / 푸시
+-- =====================================================================
+
+CREATE TABLE push_subscription (
+  id               BIGINT       NOT NULL AUTO_INCREMENT,
+  subscription_uid CHAR(26)     NOT NULL,
+  member_id        BIGINT       NOT NULL,
+  endpoint         VARCHAR(500) NOT NULL                COMMENT '브라우저 푸시 서버 URL',
+  p256dh_key       VARCHAR(255) NOT NULL                COMMENT '암호화 공개키 (P-256 ECDH)',
+  auth_key         VARCHAR(255) NOT NULL                COMMENT '인증 비밀',
+  user_agent       VARCHAR(255) NULL,
+  created_at       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  revoked_at       DATETIME(3)  NULL                    COMMENT '구독 해제 시각',
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_push_uid      (subscription_uid),
+  UNIQUE KEY uq_push_endpoint (endpoint),
+  KEY        ix_push_member   (member_id, revoked_at),
+  CONSTRAINT fk_push_member FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE
+) ENGINE=InnoDB COMMENT='Web Push 구독 (사용자 1명 = 기기당 1행)';
+
+
+-- 푸시 발송 이력 (재시도/디버깅용)
+CREATE TABLE push_log (
+  id              BIGINT      NOT NULL AUTO_INCREMENT,
+  subscription_id BIGINT      NOT NULL,
+  schedule_id     BIGINT      NULL                    COMMENT '어느 일정 알림인지',
+  push_type       ENUM('REMINDER') NOT NULL DEFAULT 'REMINDER' COMMENT 'MVP에선 출발시각 알림만',
+  payload_json    JSON        NULL                    COMMENT '실제 전송한 메시지 본문',
+  status          ENUM('SENT','FAILED','EXPIRED') NOT NULL,
+  http_status     INT         NULL                    COMMENT '푸시 서버 응답 코드',
+  sent_at         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  KEY ix_pushlog_sub (subscription_id, sent_at DESC),
+  CONSTRAINT fk_pushlog_sub      FOREIGN KEY (subscription_id) REFERENCES push_subscription(id) ON DELETE CASCADE,
+  CONSTRAINT fk_pushlog_schedule FOREIGN KEY (schedule_id)     REFERENCES schedule(id)          ON DELETE SET NULL
+) ENGINE=InnoDB COMMENT='푸시 발송 이력';
+
+
+-- =====================================================================
+-- 4. 외부 API 캐시
+-- =====================================================================
+
+-- 지오코딩 캐시 (사용자 텍스트 → 좌표 변환 결과)
+-- ODsay에 좌표를 직접 전달하는 흐름 가정. 텍스트 직접 전달이면 사용 빈도 낮음.
+CREATE TABLE geocode_cache (
+  id         BIGINT        NOT NULL AUTO_INCREMENT,
+  query_hash CHAR(64)      NOT NULL              COMMENT 'SHA-256(query)',
+  query_text VARCHAR(255)  NOT NULL,
+  matched    BOOLEAN       NOT NULL,
+  name       VARCHAR(100)  NULL,
+  address    VARCHAR(255)  NULL,
+  lat        DECIMAL(10,7) NULL,
+  lng        DECIMAL(10,7) NULL,
+  place_id   VARCHAR(100)  NULL,
+  provider   ENUM('NAVER','KAKAO_LOCAL') NOT NULL,
+  cached_at  DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_geo_hash   (query_hash, provider),
+  KEY        ix_geo_cached (cached_at)
+) ENGINE=InnoDB COMMENT='지오코딩 결과 캐시 (TTL 30일 권장)';
+
+
+-- =====================================================================
+-- ERD 요약 (텍스트)
+--
+-- member ──┬── refresh_token       (1:N)
+--          ├── schedule            (1:N) ── push_log (1:N, schedule_id로 연결)
+--          └── push_subscription   (1:N) ── push_log (1:N, subscription_id로 연결)
+--
+-- 독립 테이블:
+--   - geocode_cache (회원과 무관, 전역 공유 캐시)
+-- =====================================================================
+
+
+-- =====================================================================
+-- 향후 추가 예정 (시간 여유 시 5/22 데모 전 복구)
+-- =====================================================================
+--   P1: feedback                  사용자 평가 기록
+--   P1: favorite_route            즐겨찾기 - 추가 예정?
+--   P1: member_preferences        선호도 (랭킹 알고리즘 도입 시)
+--   P2: subway_congestion_lookup  혼잡도 통계
+--   P2: bus_congestion_lookup     혼잡도 통계
+--   P2: ranking_weight            랭킹 가중치 학습
+--   P2: route_set / route_candidate / route_segment   후보 리랭킹 도입 시 정규화
+--   P2: odsay_cache               ODsay 호출 비용 최적화
+-- =====================================================================

--- a/backend/src/test/java/com/todayway/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/todayway/backend/BackendApplicationTests.java
@@ -2,9 +2,27 @@ package com.todayway.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
+@Testcontainers
 class BackendApplicationTests {
+
+	@Container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+			.withDatabaseName("routine_commute");
+
+	@DynamicPropertySource
+	static void mysqlProps(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", mysql::getJdbcUrl);
+		registry.add("spring.datasource.username", mysql::getUsername);
+		registry.add("spring.datasource.password", mysql::getPassword);
+		registry.add("jwt.secret", () -> "test-secret-base64-padded-32bytes-long==");
+	}
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## 개요

Step 1 — 코드 작성 시작 전 인프라 셋업. 의존성/설정/DB 스키마/CI를 한꺼번에 깔아 이후 Step 2~9 진입 가능 상태로 만든다.

데모(2026-05-22) 일정에 맞춰 황찬우 Step 1~5 진행 중 첫 단계. 이 PR이 머지되면 본인 도메인(common/auth/member/schedule)과 이상진 도메인(route/push/geocode/display) 모두 unblock.

---

## 변경 사항

### 1. `backend/build.gradle.kts` — 의존성 5개 그룹 추가
- **DB 마이그레이션**: `flyway-core`, `flyway-mysql`
- **인증**: `spring-boot-starter-security`, `jjwt-api/impl/jackson 0.12.6`
- **Web Push (VAPID)**: `nl.martijndwars:web-push:5.1.1`, `bcprov-jdk18on:1.78` — Step 7(이상진) 사용 예정, 의존성만 미리
- **통합 테스트**: `spring-boot-testcontainers`, `testcontainers/junit-jupiter/mysql`, `spring-security-test`
- 기존 의존성(starter-web/jpa/validation/actuator/lombok/devtools/mysql-connector) 보존

### 2. `backend/src/main/resources/application.yml` — 설정 블록 6개 추가
- `spring.jackson.serialization.write-dates-as-timestamps: false` (ISO 8601 직렬화)
- `spring.flyway.{enabled, baseline-on-migrate, locations}`
- `jwt.{secret, access-token-expiration-minutes:30, refresh-token-expiration-days:14, issuer:todayway}`
- `odsay.{api-key, base-url, timeout-seconds:5}` — Step 6(이상진)
- `kakao-local.{api-key, base-url}` — Step 8(이상진)
- `vapid.{public-key, private-key, subject}` — Step 7(이상진)
- 기존 yml 블록(time-zone, virtual threads, lifecycle, datasource, jpa.ddl-auto:validate, server.shutdown:graceful, management) 보존
- `${VAR:}` 빈 default로 외부 API 키 미설정 상태에서도 startup 가능. `JWT_SECRET`만 필수

### 3. `backend/.env.example` — 환경변수 라인 추가
- `JWT_SECRET=changeme-base64-encoded-256bit-secret` (`openssl rand -base64 32`로 생성 가이드 주석)
- `ODSAY_API_KEY=`, `KAKAO_LOCAL_API_KEY=`
- `VAPID_PUBLIC_KEY=`, `VAPID_PRIVATE_KEY=`
- 기존 DB_*/SERVER_PORT 보존

### 4. `backend/src/main/resources/db/migration/V1__init.sql` — **신규** (6개 테이블)
- `member` — 회원 (ULID + 소프트 삭제)
- `refresh_token` — JWT 리프레시 (SHA-256 해시, FK CASCADE)
- `schedule` — 일정/루틴 + ODsay 응답 캐시 (`route_summary_json` JSON 컬럼, `ix_sch_reminder` 스케줄러용 인덱스)
- `push_subscription` — Web Push 구독 (endpoint UNIQUE)
- `push_log` — 푸시 발송 이력 (`schedule_id` ON DELETE SET NULL — 일정 삭제돼도 이력 남김)
- `geocode_cache` — 지오코딩 결과 캐시 (TTL 30일 권장, `query_hash` SHA-256)
- DB-SQL 원본 헤더 주석(삭제/단순화/복구 이력 + ERD + MVP 사용자 흐름 + 향후 추가 예정) 그대로 보존
- ⚠️ `CREATE DATABASE`/`USE` 줄은 제외 (DB는 docker/RDS에서 외부 생성)

### 5. `.github/workflows/ci.yml` — `echo \"ok\"` → 실 빌드로 교체
- `actions/checkout@v4`, `actions/setup-java@v4` (Temurin 21)
- Gradle 캐시 (`~/.gradle/caches`, `~/.gradle/wrapper`)
- `working-directory: backend`에서 `./gradlew build`
- CI 전용 더미 `JWT_SECRET=ci-test-secret-base64-padded-32bytes-long==` 환경변수 주입 (운영 키 X)
- 트리거: `pull_request`/`push` to `main` 또는 `feat/backend`

### 6. `backend/src/test/java/.../BackendApplicationTests.java` — Testcontainers MySQL 적용
- `@Testcontainers` + `MySQLContainer<>("mysql:8.0").withDatabaseName(\"routine_commute\")`
- `@DynamicPropertySource`로 datasource url/username/password + jwt.secret 동적 주입
- CI에서 실제 DB로 contextLoads 검증 + Flyway V1 적용 자동 검증

---

## 의사결정 기록

| # | 결정 | 결과 |
|---|---|---|
| 1 | 9개 sub-task를 단일 PR로 묶어 진행 | 이 PR (`feat/backend-step1-infra`) |
| 2 | JWT_SECRET을 본인 PC에서 `openssl rand -base64 32`로 생성 → `backend/.env`에 채움 | 완료 (.gitignore 보호, 커밋 X) |
| 3 | CI yml에 평문 더미 JWT_SECRET 하드코딩 (운영 키 X) | `ci-test-secret-base64-padded-32bytes-long==` |
| 4 | `V1__init.sql`에 DB-SQL 헤더 주석 보존 | 삭제/단순화/복구 이력 + 사용자 흐름 + ERD 모두 포함 |
| 5 | 단일 커밋 (의미 분리 안 함) | `59196a5` |
| 6 | PR 생성은 `gh` CLI | 본 PR |
| 7 | 로컬 검증 범위 = **B** (build + bootRun + Flyway 적용 + /actuator/health 200) | 통과 (아래 \"로컬 검증 결과\" 참조) |

---

## 로컬 검증 결과

```
$ ./gradlew clean build -x test
BUILD SUCCESSFUL in 16s
```

```
$ ./gradlew bootRun
o.f.core.internal.command.DbValidate     : Successfully validated 1 migration
o.f.core.internal.command.DbMigrate      : Migrating schema `routine_commute` to version \"1 - init\"
o.f.core.internal.command.DbMigrate      : Successfully applied 1 migration to schema `routine_commute`, now at version v1 (execution time 00:00.443s)
c.todayway.backend.BackendApplication    : Started BackendApplication in 6.66 seconds
```

```
$ curl http://localhost:8080/actuator/health
{\"status\":\"UP\"}
```

```
$ docker exec todayway-mysql mysql -uroot -proot routine_commute -e \"SHOW TABLES;\"
flyway_schema_history
geocode_cache
member
push_log
push_subscription
refresh_token
schedule
```

→ Flyway가 V1__init.sql을 정상 적용, 6개 도메인 테이블 + flyway 메타 테이블 생성 확인.

---

## ⚠️ 알려진 이슈 / 주의 사항

### 1. Windows 로컬 Testcontainers 미동작 — CI에서는 정상 예상
- **현상**: 본인 Windows PC에서 `./gradlew test` 실행 시 `Could not find a valid Docker environment`로 실패
- **원인**: Docker Desktop 29.4.1의 named pipe 라우팅(`docker_cli` proxy)과 testcontainers 자동 탐색 로직 충돌. `.testcontainers.properties`/`DOCKER_HOST` 환경변수 모두 무시하고 CLI proxy 파이프로 강제 redirect
- **이번 PR 처리**: 별건으로 분리 (Step 1 본질과 무관). CI는 Linux ubuntu-latest의 unix socket 사용 → 정상 동작 기대
- **이상진 영향**: 머지 후 본인 PC가 Windows + Docker Desktop 동일 버전이면 같은 이슈 가능. macOS/Linux면 무관. Step 7(푸시 워밍업) 진입 시점에 본인이 결정해서 우회

### 2. 기존 `application.yml` 보존 방식
- BACKEND_CONTEXT 2.4의 baseline yml은 timezone/virtual threads 누락 표기로 outdated. 실제 레포가 더 앞서 있어 이번 PR은 **덮어쓰지 않고 추가만**
- yml 들여쓰기 단계 주의해서 검토 부탁

### 3. JJWT 0.12.x 의존성만 추가, 사용은 Step 2
- 옛날 코드(`Jwts.builder().setSubject()`) 패턴은 0.12부터 deprecated. Step 2에서 `builder().subject()` 새 API 사용 예정

### 4. V1__init.sql 머지 후 수정 금지
- 한 번 적용된 V1을 수정하면 Flyway 체크섬 mismatch → startup 실패
- 변경은 V2 추가로. 머지 전 발견된 이슈는 force-push로 V1 수정 가능 (현 단계)

---

## 명세 참조

- API 명세 §0.2 (DB 스키마 v1.1-MVP)
- BACKEND_CONTEXT §3 (의존성), §4 (application.yml), §5 (.env), §7.1 (Flyway), §13.2 (Testcontainers), §15 (CI), §18 (자주 하는 실수)
- DB-SQL.txt — 6개 테이블 (10개 삭제 + 3개 복구된 v1.1-MVP)

---

## 후속 작업

- **Step 2** (`feat/backend-step2-common`): common 패키지 — `ApiResponse<T>`, `ErrorResponse`, `ErrorCode` enum, `BusinessException`, `GlobalExceptionHandler`, `BaseEntity` + JPA Auditing, `UlidGenerator`, `JwtProperties` + `JwtProvider` + `JwtAuthenticationFilter`, `SecurityConfig`, `@CurrentMember` 등
- **이상진 머지 후 액션**:
  ```bash
  git switch feat/backend && git pull
  cd backend && cp .env.example .env  # 본인 값 채움
  docker run --name todayway-mysql ... mysql:8.0
  ./gradlew bootRun
  ```
  로 본인 로컬 환경 동기화 가능

---

## 리뷰 포인트 (특히 봐주실 부분)

1. **build.gradle.kts** 의존성 버전 (jjwt 0.12.6, web-push 5.1.1, bcprov-jdk18on 1.78) — 최신/호환성 검토
2. **application.yml** 들여쓰기 (jackson.serialization 안에 write-dates-as-timestamps 위치)
3. **V1__init.sql** ↔ DB-SQL.txt 1:1 매칭 (CREATE DATABASE/USE 외 차이 없는지)
4. **ci.yml** 더미 JWT_SECRET이 운영 키와 절대 헷갈리지 않는 형태인지
5. **BackendApplicationTests** Testcontainers 패턴 (DynamicPropertySource로 datasource + jwt.secret 모두 주입했는지)