### PR TITLE
feat(backend): step2 — common 패키지 (응답/예외/JWT/시큐리티/유틸)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Build & test
         run: ./gradlew build
         env:
-          JWT_SECRET: ci-test-secret-base64-padded-32bytes-long==
+          JWT_SECRET: Y2ktdGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
 	implementation("nl.martijndwars:web-push:5.1.1")
 	implementation("org.bouncycastle:bcprov-jdk18on:1.78")
 
+	// ULID 생성기 (외부 노출 ID용 26자 Crockford Base32)
+	implementation("com.github.f4b6a3:ulid-creator:5.2.3")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testCompileOnly("org.projectlombok:lombok")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/backend/src/main/java/com/todayway/backend/BackendApplication.java
+++ b/backend/src/main/java/com/todayway/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.todayway.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/todayway/backend/common/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.todayway.backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/todayway/backend/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/todayway/backend/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.todayway.backend.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/todayway/backend/common/exception/BusinessException.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.todayway.backend.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/ErrorCode.java
@@ -1,0 +1,29 @@
+package com.todayway.backend.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청이 유효하지 않습니다"),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "로그인 정보가 올바르지 않습니다"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),
+    FORBIDDEN_RESOURCE(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"),
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다"),
+    ROUTE_NOT_CALCULATED(HttpStatus.NOT_FOUND, "경로가 계산되지 않았습니다"),
+    GEOCODE_NO_MATCH(HttpStatus.NOT_FOUND, "지오코딩 결과가 없습니다"),
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "푸시 구독을 찾을 수 없습니다"),
+    LOGIN_ID_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다"),
+    EXTERNAL_ROUTE_API_FAILED(HttpStatus.BAD_GATEWAY, "경로 API 호출에 실패했습니다"),
+    MAP_PROVIDER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "지도 설정을 가져올 수 없습니다"),
+    EXTERNAL_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "외부 API 응답 시간이 초과되었습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/backend/src/main/java/com/todayway/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "푸시 구독을 찾을 수 없습니다"),
     LOGIN_ID_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다"),
     EXTERNAL_ROUTE_API_FAILED(HttpStatus.BAD_GATEWAY, "경로 API 호출에 실패했습니다"),
+    EXTERNAL_AUTH_MISCONFIGURED(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 인증 설정에 문제가 있습니다"),
     MAP_PROVIDER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "지도 설정을 가져올 수 없습니다"),
     EXTERNAL_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "외부 API 응답 시간이 초과되었습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 오류가 발생했습니다");

--- a/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.todayway.backend.common.exception;
+
+import com.todayway.backend.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
+        ErrorCode code = e.getErrorCode();
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst()
+                .orElse("validation failed");
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), detail));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException e) {
+        ErrorCode code = ErrorCode.UNAUTHORIZED;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException e) {
+        ErrorCode code = ErrorCode.FORBIDDEN_RESOURCE;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnknown(Exception e) {
+        log.error("예상치 못한 예외 발생", e);
+        ErrorCode code = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/todayway/backend/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.todayway.backend.common.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String EXPIRED_BODY =
+            "{\"error\":{\"code\":\"TOKEN_EXPIRED\",\"message\":\"토큰이 만료되었습니다\",\"details\":null}}";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(BEARER_PREFIX.length());
+        try {
+            String memberUid = jwtProvider.parseSubject(token);
+            Authentication auth = new UsernamePasswordAuthenticationToken(memberUid, null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } catch (ExpiredJwtException e) {
+            SecurityContextHolder.clearContext();
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(EXPIRED_BODY);
+            return;
+        } catch (JwtException | IllegalArgumentException e) {
+            SecurityContextHolder.clearContext();
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/jwt/JwtProperties.java
+++ b/backend/src/main/java/com/todayway/backend/common/jwt/JwtProperties.java
@@ -1,0 +1,12 @@
+package com.todayway.backend.common.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenExpirationMinutes,
+        long refreshTokenExpirationDays,
+        String issuer
+) {
+}

--- a/backend/src/main/java/com/todayway/backend/common/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/todayway/backend/common/jwt/JwtProvider.java
@@ -1,0 +1,54 @@
+package com.todayway.backend.common.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+    private final JwtProperties props;
+
+    public JwtProvider(JwtProperties props) {
+        this.props = props;
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(props.secret()));
+    }
+
+    public String issueAccessToken(String memberUid) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .issuer(props.issuer())
+                .subject(memberUid)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(props.accessTokenExpirationMinutes(), ChronoUnit.MINUTES)))
+                .signWith(key)
+                .compact();
+    }
+
+    public String issueRefreshToken(String memberUid) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .issuer(props.issuer())
+                .subject(memberUid)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(props.refreshTokenExpirationDays(), ChronoUnit.DAYS)))
+                .signWith(key)
+                .compact();
+    }
+
+    public String parseSubject(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/pagination/CursorRequest.java
+++ b/backend/src/main/java/com/todayway/backend/common/pagination/CursorRequest.java
@@ -1,0 +1,13 @@
+package com.todayway.backend.common.pagination;
+
+public record CursorRequest(int limit, String cursor) {
+
+    private static final int DEFAULT_LIMIT = 20;
+    private static final int MAX_LIMIT = 100;
+
+    public CursorRequest {
+        if (limit <= 0 || limit > MAX_LIMIT) {
+            limit = DEFAULT_LIMIT;
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/pagination/CursorResponse.java
+++ b/backend/src/main/java/com/todayway/backend/common/pagination/CursorResponse.java
@@ -1,0 +1,10 @@
+package com.todayway.backend.common.pagination;
+
+import java.util.List;
+
+public record CursorResponse<T>(List<T> items, String nextCursor, boolean hasMore) {
+
+    public static <T> CursorResponse<T> of(List<T> items, String nextCursor) {
+        return new CursorResponse<>(items, nextCursor, nextCursor != null);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/response/ApiResponse.java
+++ b/backend/src/main/java/com/todayway/backend/common/response/ApiResponse.java
@@ -1,0 +1,8 @@
+package com.todayway.backend.common.response;
+
+public record ApiResponse<T>(T data) {
+
+    public static <T> ApiResponse<T> of(T data) {
+        return new ApiResponse<>(data);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/response/ErrorResponse.java
+++ b/backend/src/main/java/com/todayway/backend/common/response/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.todayway.backend.common.response;
+
+public record ErrorResponse(ErrorBody error) {
+
+    public record ErrorBody(String code, String message, Object details) {}
+
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(new ErrorBody(code, message, null));
+    }
+
+    public static ErrorResponse of(String code, String message, Object details) {
+        return new ErrorResponse(new ErrorBody(code, message, details));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
@@ -1,0 +1,83 @@
+package com.todayway.backend.common.security;
+
+import com.todayway.backend.common.jwt.JwtAuthenticationFilter;
+import com.todayway.backend.common.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private static final String UNAUTHORIZED_BODY =
+            "{\"error\":{\"code\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다\",\"details\":null}}";
+    private static final String FORBIDDEN_BODY =
+            "{\"error\":{\"code\":\"FORBIDDEN_RESOURCE\",\"message\":\"접근 권한이 없습니다\",\"details\":null}}";
+
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/signup",
+                                "/api/v1/auth/login",
+                                "/api/v1/main",
+                                "/api/v1/map/config",
+                                "/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(eh -> eh
+                        .authenticationEntryPoint(jsonAuthenticationEntryPoint())
+                        .accessDeniedHandler(jsonAccessDeniedHandler())
+                );
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    private AuthenticationEntryPoint jsonAuthenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(UNAUTHORIZED_BODY);
+        };
+    }
+
+    private AccessDeniedHandler jsonAccessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(FORBIDDEN_BODY);
+        };
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/ulid/UlidGenerator.java
+++ b/backend/src/main/java/com/todayway/backend/common/ulid/UlidGenerator.java
@@ -1,0 +1,12 @@
+package com.todayway.backend.common.ulid;
+
+import com.github.f4b6a3.ulid.Ulid;
+
+public final class UlidGenerator {
+
+    private UlidGenerator() {}
+
+    public static String generate() {
+        return Ulid.fast().toString();
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMember.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMember.java
@@ -1,0 +1,11 @@
+package com.todayway.backend.common.web;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMember {
+}

--- a/backend/src/test/java/com/todayway/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/todayway/backend/BackendApplicationTests.java
@@ -21,7 +21,7 @@ class BackendApplicationTests {
 		registry.add("spring.datasource.url", mysql::getJdbcUrl);
 		registry.add("spring.datasource.username", mysql::getUsername);
 		registry.add("spring.datasource.password", mysql::getPassword);
-		registry.add("jwt.secret", () -> "test-secret-base64-padded-32bytes-long==");
+		registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
 	}
 
 	@Test

--- a/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+package com.todayway.backend.common.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.DummyController.class})
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void BusinessException은_ErrorCode의_status와_code_message로_변환된다() throws Exception {
+        mockMvc.perform(get("/dummy/business"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error.code").value("MEMBER_NOT_FOUND"))
+                .andExpect(jsonPath("$.error.message").value("회원을 찾을 수 없습니다"))
+                .andExpect(jsonPath("$.error.details").doesNotExist());
+    }
+
+    @Test
+    void AccessDeniedException은_403_FORBIDDEN_RESOURCE로_변환된다() throws Exception {
+        mockMvc.perform(get("/dummy/forbidden"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN_RESOURCE"));
+    }
+
+    @Test
+    void 알수없는_예외는_500_INTERNAL_SERVER_ERROR로_변환된다() throws Exception {
+        mockMvc.perform(get("/dummy/boom"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_SERVER_ERROR"));
+    }
+
+    @RestController
+    static class DummyController {
+        @GetMapping("/dummy/business")
+        public String business() {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        @GetMapping("/dummy/forbidden")
+        public String forbidden() {
+            throw new AccessDeniedException("denied");
+        }
+
+        @GetMapping("/dummy/boom")
+        public String boom() {
+            throw new IllegalStateException("unexpected");
+        }
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/common/jwt/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,94 @@
+package com.todayway.backend.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String TEST_SECRET = "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==";
+    private static final String ISSUER = "todayway-test";
+    private static final String MEMBER_UID = "01HXYA3K9G7ZRCB1234567890V";
+
+    private JwtProvider jwtProvider;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+        jwtProvider = new JwtProvider(new JwtProperties(TEST_SECRET, 30, 14, ISSUER));
+        filter = new JwtAuthenticationFilter(jwtProvider);
+    }
+
+    @Test
+    void 헤더에_Authorization이_없으면_SecurityContext가_비어있고_체인이_그대로_진행된다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/main");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void 유효한_토큰이면_SecurityContext에_memberUid가_저장되고_체인이_진행된다() throws Exception {
+        String token = jwtProvider.issueAccessToken(MEMBER_UID);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/schedules");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+                .isEqualTo(MEMBER_UID);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void 만료된_토큰이면_체인을_차단하고_401_TOKEN_EXPIRED_JSON을_응답한다() throws Exception {
+        JwtProvider expiredProvider = new JwtProvider(new JwtProperties(TEST_SECRET, 0, 0, ISSUER));
+        String expiredToken = expiredProvider.issueAccessToken(MEMBER_UID);
+        Thread.sleep(50);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/schedules");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("TOKEN_EXPIRED");
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void 위조된_토큰이면_SecurityContext만_비우고_체인은_진행한다_401은_EntryPoint가_담당() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/schedules");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer this.is.not.a.valid.jwt");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/common/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/jwt/JwtProviderTest.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.common.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtProviderTest {
+
+    private static final String TEST_SECRET = "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==";
+    private static final String ISSUER = "todayway-test";
+
+    @Test
+    void issueAccessToken_으로_발급한_토큰을_parseSubject로_복호화하면_동일한_memberUid를_얻는다() {
+        JwtProperties props = new JwtProperties(TEST_SECRET, 30, 14, ISSUER);
+        JwtProvider provider = new JwtProvider(props);
+        String memberUid = "01HXYA3K9G7ZRCB1234567890V";
+
+        String token = provider.issueAccessToken(memberUid);
+        String parsed = provider.parseSubject(token);
+
+        assertThat(parsed).isEqualTo(memberUid);
+    }
+
+    @Test
+    void issueRefreshToken_으로_발급한_토큰도_동일하게_복호화된다() {
+        JwtProperties props = new JwtProperties(TEST_SECRET, 30, 14, ISSUER);
+        JwtProvider provider = new JwtProvider(props);
+        String memberUid = "01HXYA3K9G7ZRCB1234567890V";
+
+        String token = provider.issueRefreshToken(memberUid);
+        String parsed = provider.parseSubject(token);
+
+        assertThat(parsed).isEqualTo(memberUid);
+    }
+
+    @Test
+    void 만료된_토큰을_parse하면_ExpiredJwtException이_발생한다() throws InterruptedException {
+        // 만료시각 즉시(0분) 설정 → 발급 직후 만료
+        JwtProperties props = new JwtProperties(TEST_SECRET, 0, 0, ISSUER);
+        JwtProvider provider = new JwtProvider(props);
+        String token = provider.issueAccessToken("01HXYA3K9G7ZRCB1234567890V");
+
+        Thread.sleep(50);
+
+        assertThatThrownBy(() -> provider.parseSubject(token))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/common/ulid/UlidGeneratorTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/ulid/UlidGeneratorTest.java
@@ -1,0 +1,34 @@
+package com.todayway.backend.common.ulid;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UlidGeneratorTest {
+
+    private static final Pattern CROCKFORD_BASE32 = Pattern.compile("^[0-9A-HJKMNP-TV-Z]{26}$");
+
+    @Test
+    void 생성된_ULID는_길이가_26이고_Crockford_Base32_문자만_포함한다() {
+        for (int i = 0; i < 1000; i++) {
+            String ulid = UlidGenerator.generate();
+            assertThat(ulid).hasSize(26);
+            assertThat(CROCKFORD_BASE32.matcher(ulid).matches())
+                    .as("ULID는 Crockford Base32 문자만 포함해야 한다: %s", ulid)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void 만회_생성해도_중복이_없다() {
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < 10_000; i++) {
+            seen.add(UlidGenerator.generate());
+        }
+        assertThat(seen).hasSize(10_000);
+    }
+}


### PR DESCRIPTION
## 변경 사항

`com.todayway.backend.common` 하위 8개 서브패키지에 공통 인프라 클래스 추가. Step 3~9의 모든 도메인이 import만으로 사용 가능한 베이스.

| 서브패키지 | 핵심 클래스 |
|---|---|
| `response` | `ApiResponse<T>`, `ErrorResponse` (record, 명세 §1.3) |
| `exception` | `ErrorCode` (15개 enum), `BusinessException`, `GlobalExceptionHandler` |
| `entity` | `BaseEntity` (JPA Auditing, `OffsetDateTime`) |
| `config` | `JpaAuditingConfig` (`@EnableJpaAuditing` 분리) |
| `ulid` | `UlidGenerator` (`com.github.f4b6a3:ulid-creator` 5.2.3) |
| `jwt` | `JwtProperties`, `JwtProvider` (JJWT 0.12.x), `JwtAuthenticationFilter` |
| `security` | `SecurityConfig` (STATELESS, permitAll 5개, JSON 401/403), `PasswordEncoder` |
| `web` | `@CurrentMember` (어노테이션 정의만, Resolver는 Step 3) |
| `pagination` | `CursorRequest`, `CursorResponse<T>` (record) |

`BackendApplication`에 `@ConfigurationPropertiesScan` 추가 (JwtProperties 등록용).

## 명세 외 결정 사항

1. **`ErrorCode`에 `INTERNAL_SERVER_ERROR` 1개 추가** — 명세 §1.6의 14개 + `Exception.class` catch-all 핸들러용 1개. 클라이언트 응답에선 일반화된 메시지만 노출, 서버 로그엔 `log.error`로 stack trace 보존
2. **`@EnableJpaAuditing`을 `JpaAuditingConfig` 클래스로 분리** — `BackendApplication`에 직접 두면 `@WebMvcTest` 슬라이스 테스트가 메인 클래스 자동 로드 시 `JPA metamodel must not be empty` 폭발. 운영 동작은 동일
3. **JWT 필터의 토큰 처리** — `ExpiredJwtException`은 필터에서 직접 401 + `TOKEN_EXPIRED` JSON 응답 (클라이언트가 refresh token 흐름 분기 가능). 그 외 `JwtException`/`IllegalArgumentException`은 `SecurityContext`만 비우고 `AuthenticationEntryPoint`에 위임 → `UNAUTHORIZED`로 응답

## 테스트
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test --tests \"com.todayway.backend.common.*\"` — **12/12 통과**
  - `UlidGeneratorTest` (Crockford 26자 + 1만회 무중복) 2개
  - `JwtProviderTest` (access/refresh 라운드트립 + 만료) 3개
  - `JwtAuthenticationFilterTest` (헤더 없음/유효/만료/위조) 4개
  - `GlobalExceptionHandlerTest` (BusinessException/AccessDenied/Unknown) 3개
- [ ] `./gradlew bootRun` 직접 호출 검증 — Step 3 진입 시 함께 진행 예정

## 명세 참조
- API 명세 §1.3 (응답 래퍼), §1.5 (cursor 페이지네이션), §1.6 (ErrorCode)
- BACKEND_CONTEXT §11 (패키지 구조), §18 (자주 하는 실수)
- DB-SQL.txt CHAR(26) (ULID)

## 알려진 한계
- `BackendApplicationTests` (Testcontainers) 본인 PC 미실행 — Windows Docker named pipe 별건 이슈 (PR #1 본문 참조). CI(Linux)에서 정상 동작 예상
- `@CurrentMember` Resolver/`WebMvcConfig`는 Step 3에서 같이 (Member 엔티티 의존)

## 후속 작업 (Step 3 auth)
- `Member`/`RefreshToken` 엔티티 (`BaseEntity` 상속, `UlidGenerator.generate()`)
- `AuthService` (`JwtProvider`/`PasswordEncoder` 사용)
- `@CurrentMemberArgumentResolver` + `WebMvcConfig`