### PR TITLE
feat(backend): 외부 API 클라이언트 골격 — ODsay + Kakao Local

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
 	// ULID 생성기 (외부 노출 ID용 26자 Crockford Base32)
 	implementation("com.github.f4b6a3:ulid-creator:5.2.3")
 
+	// 외부 API 호출용 HttpClient (커넥션 풀 + 동시성 효율) — SimpleClientHttpRequestFactory 대체
+	implementation("org.apache.httpcomponents.client5:httpclient5")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testCompileOnly("org.projectlombok:lombok")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/backend/src/main/java/com/todayway/backend/external/ExternalApiConfig.java
+++ b/backend/src/main/java/com/todayway/backend/external/ExternalApiConfig.java
@@ -1,0 +1,11 @@
+package com.todayway.backend.external;
+
+import com.todayway.backend.external.kakao.KakaoLocalProperties;
+import com.todayway.backend.external.odsay.OdsayProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({OdsayProperties.class, KakaoLocalProperties.class})
+public class ExternalApiConfig {
+}

--- a/backend/src/main/java/com/todayway/backend/external/ExternalApiException.java
+++ b/backend/src/main/java/com/todayway/backend/external/ExternalApiException.java
@@ -1,0 +1,24 @@
+package com.todayway.backend.external;
+
+import lombok.Getter;
+
+@Getter
+public class ExternalApiException extends RuntimeException {
+
+    public enum Type {
+        TIMEOUT,
+        API_FAILED,
+        NETWORK
+    }
+
+    private final String source;
+    private final Type type;
+    private final Integer httpStatus;
+
+    public ExternalApiException(String source, Type type, Integer httpStatus, String message, Throwable cause) {
+        super(message, cause);
+        this.source = source;
+        this.type = type;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/external/ExternalApiException.java
+++ b/backend/src/main/java/com/todayway/backend/external/ExternalApiException.java
@@ -5,17 +5,34 @@ import lombok.Getter;
 @Getter
 public class ExternalApiException extends RuntimeException {
 
+    /**
+     * 외부 API 호출 실패의 분류.
+     * <p>PushScheduler 등에서 retry 정책 분기에 사용:
+     * <ul>
+     *   <li>{@link #TIMEOUT}: 응답/연결 타임아웃. 일시 장애 가능, 재시도 가치 있음.</li>
+     *   <li>{@link #CLIENT_ERROR}: HTTP 4xx. 요청 자체 문제(잘못된 좌표, 키 만료 등). 재시도 무의미.</li>
+     *   <li>{@link #SERVER_ERROR}: HTTP 5xx 또는 비정상 응답(빈 body 등). 재시도 가치 있음.</li>
+     *   <li>{@link #NETWORK}: 연결 실패(DNS, connection refused). 재시도 가치 있음.</li>
+     * </ul>
+     */
     public enum Type {
         TIMEOUT,
-        API_FAILED,
+        CLIENT_ERROR,
+        SERVER_ERROR,
         NETWORK
     }
 
-    private final String source;
+    /** 외부 API 출처 (exhaustive switch에 사용 가능). */
+    public enum Source {
+        ODSAY,
+        KAKAO_LOCAL
+    }
+
+    private final Source source;
     private final Type type;
     private final Integer httpStatus;
 
-    public ExternalApiException(String source, Type type, Integer httpStatus, String message, Throwable cause) {
+    public ExternalApiException(Source source, Type type, Integer httpStatus, String message, Throwable cause) {
         super(message, cause);
         this.source = source;
         this.type = type;

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
@@ -10,6 +10,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -34,6 +35,7 @@ public class KakaoLocalClient {
 
     private final RestClient restClient;
 
+    @Autowired
     public KakaoLocalClient(KakaoLocalProperties properties) {
         this(RestClient.builder()
                 .baseUrl(properties.getBaseUrl())
@@ -42,7 +44,8 @@ public class KakaoLocalClient {
                 .build());
     }
 
-    /** 테스트용. MockRestServiceServer로 모킹된 RestClient 주입을 위해 패키지 접근 허용. */
+    /** 테스트용. MockRestServiceServer로 모킹된 RestClient 주입을 위해 패키지 접근 허용.
+     *  Spring 빈 생성자 후보에서 제외하기 위해 public 생성자에 @Autowired 명시함. */
     KakaoLocalClient(RestClient restClient) {
         this.restClient = restClient;
     }

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
@@ -59,10 +59,12 @@ public class KakaoLocalClient {
             ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
                     ? ExternalApiException.Type.TIMEOUT
                     : ExternalApiException.Type.NETWORK;
-            throw new ExternalApiException(SOURCE, type, null, "Kakao Local 통신 실패: " + e.getMessage(), e);
+            // 일관성: e.getMessage()에 URL 박힘. ODsay와 동일 패턴으로 cause 클래스명만.
+            String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
+            throw new ExternalApiException(SOURCE, type, null, "Kakao Local 통신 실패 (" + causeName + ")", e);
         } catch (RestClientException e) {
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
-                    "Kakao Local 호출 중 예외: " + e.getMessage(), e);
+                    "Kakao Local 호출 중 예외 (" + e.getClass().getSimpleName() + ")", e);
         }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
@@ -25,15 +25,23 @@ public class KakaoLocalClient {
     private final RestClient restClient;
 
     public KakaoLocalClient(KakaoLocalProperties properties) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
-        factory.setReadTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
-
-        this.restClient = RestClient.builder()
+        this(RestClient.builder()
                 .baseUrl(properties.getBaseUrl())
-                .requestFactory(factory)
+                .requestFactory(createRequestFactory(properties.getTimeoutSeconds()))
                 .defaultHeader("Authorization", "KakaoAK " + properties.getApiKey())
-                .build();
+                .build());
+    }
+
+    /** 테스트용. MockRestServiceServer로 모킹된 RestClient 주입을 위해 패키지 접근 허용. */
+    KakaoLocalClient(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    private static SimpleClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(timeoutSeconds));
+        factory.setReadTimeout(Duration.ofSeconds(timeoutSeconds));
+        return factory;
     }
 
     /**

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
@@ -2,8 +2,18 @@ package com.todayway.backend.external.kakao;
 
 import com.todayway.backend.external.ExternalApiException;
 import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.NestedExceptionUtils;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
@@ -11,7 +21,6 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
 import java.net.SocketTimeoutException;
-import java.time.Duration;
 
 /**
  * 카카오 로컬 키워드 검색 API 클라이언트.
@@ -20,7 +29,8 @@ import java.time.Duration;
 @Component
 public class KakaoLocalClient {
 
-    private static final String SOURCE = "KAKAO_LOCAL";
+    private static final Logger log = LoggerFactory.getLogger(KakaoLocalClient.class);
+    private static final ExternalApiException.Source SOURCE = ExternalApiException.Source.KAKAO_LOCAL;
 
     private final RestClient restClient;
 
@@ -37,11 +47,20 @@ public class KakaoLocalClient {
         this.restClient = restClient;
     }
 
-    private static SimpleClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(timeoutSeconds));
-        factory.setReadTimeout(Duration.ofSeconds(timeoutSeconds));
-        return factory;
+    private static ClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
+        Timeout timeout = Timeout.ofSeconds(timeoutSeconds);
+        HttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                .setMaxConnTotal(20)
+                .setMaxConnPerRoute(10)
+                .build();
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setConnectTimeout(timeout)
+                        .setResponseTimeout(timeout)
+                        .build())
+                .build();
+        return new HttpComponentsClientHttpRequestFactory(httpClient);
     }
 
     /**
@@ -51,6 +70,7 @@ public class KakaoLocalClient {
      * @return 검색 결과 (matched 여부는 documents.isEmpty()로 판정)
      */
     public KakaoLocalSearchResponse searchKeyword(String query) {
+        log.debug("Kakao Local 호출: query={}", query);
         try {
             KakaoLocalSearchResponse res = restClient.get()
                     .uri(uri -> uri.path("/search/keyword.json")
@@ -61,14 +81,19 @@ public class KakaoLocalClient {
 
             // Kakao가 빈 응답을 줄 때 후속 호출자의 NPE 방지. (OdsayClient와 일관)
             if (res == null) {
-                throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
+                throw new ExternalApiException(SOURCE, ExternalApiException.Type.SERVER_ERROR,
                         null, "Kakao Local 응답 본문이 비어있음", null);
             }
+            log.debug("Kakao Local 응답: {}건", res.documents() != null ? res.documents().size() : 0);
             return res;
         } catch (RestClientResponseException e) {
             // 보안: cause는 응답 본문 일부 포함 가능 → 보존 X.
-            throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
-                    e.getStatusCode().value(), "Kakao Local 호출 실패: HTTP " + e.getStatusCode(), null);
+            HttpStatusCode status = e.getStatusCode();
+            ExternalApiException.Type type = status.is4xxClientError()
+                    ? ExternalApiException.Type.CLIENT_ERROR
+                    : ExternalApiException.Type.SERVER_ERROR;
+            throw new ExternalApiException(SOURCE, type, status.value(),
+                    "Kakao Local 호출 실패: HTTP " + status, null);
         } catch (ResourceAccessException e) {
             // cause chain 끝까지 가서 timeout 판정 (factory 교체 시 안전).
             Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
@@ -44,27 +44,35 @@ public class KakaoLocalClient {
      */
     public KakaoLocalSearchResponse searchKeyword(String query) {
         try {
-            return restClient.get()
+            KakaoLocalSearchResponse res = restClient.get()
                     .uri(uri -> uri.path("/search/keyword.json")
                             .queryParam("query", query)
                             .build())
                     .retrieve()
                     .body(KakaoLocalSearchResponse.class);
+
+            // Kakao가 빈 응답을 줄 때 후속 호출자의 NPE 방지. (OdsayClient와 일관)
+            if (res == null) {
+                throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
+                        null, "Kakao Local 응답 본문이 비어있음", null);
+            }
+            return res;
         } catch (RestClientResponseException e) {
+            // 보안: cause는 응답 본문 일부 포함 가능 → 보존 X.
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
-                    e.getStatusCode().value(), "Kakao Local 호출 실패: HTTP " + e.getStatusCode(), e);
+                    e.getStatusCode().value(), "Kakao Local 호출 실패: HTTP " + e.getStatusCode(), null);
         } catch (ResourceAccessException e) {
             // cause chain 끝까지 가서 timeout 판정 (factory 교체 시 안전).
             Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);
             ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
                     ? ExternalApiException.Type.TIMEOUT
                     : ExternalApiException.Type.NETWORK;
-            // 일관성: e.getMessage()에 URL 박힘. ODsay와 동일 패턴으로 cause 클래스명만.
+            // 보안: ODsay와 동일 패턴. cause는 URL을 메시지에 들고 있어 보존 시 stack trace 우회 누출 위험.
             String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
-            throw new ExternalApiException(SOURCE, type, null, "Kakao Local 통신 실패 (" + causeName + ")", e);
+            throw new ExternalApiException(SOURCE, type, null, "Kakao Local 통신 실패 (" + causeName + ")", null);
         } catch (RestClientException e) {
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
-                    "Kakao Local 호출 중 예외 (" + e.getClass().getSimpleName() + ")", e);
+                    "Kakao Local 호출 중 예외 (" + e.getClass().getSimpleName() + ")", null);
         }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalClient.java
@@ -1,0 +1,68 @@
+package com.todayway.backend.external.kakao;
+
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+
+/**
+ * 카카오 로컬 키워드 검색 API 클라이언트.
+ * 명세 §8.1: /geocode 엔드포인트의 외부 호출자.
+ */
+@Component
+public class KakaoLocalClient {
+
+    private static final String SOURCE = "KAKAO_LOCAL";
+
+    private final RestClient restClient;
+
+    public KakaoLocalClient(KakaoLocalProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
+        factory.setReadTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
+
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .requestFactory(factory)
+                .defaultHeader("Authorization", "KakaoAK " + properties.getApiKey())
+                .build();
+    }
+
+    /**
+     * 키워드로 장소 검색.
+     *
+     * @param query 주소 또는 장소명 (예: "국민대학교")
+     * @return 검색 결과 (matched 여부는 documents.isEmpty()로 판정)
+     */
+    public KakaoLocalSearchResponse searchKeyword(String query) {
+        try {
+            return restClient.get()
+                    .uri(uri -> uri.path("/search/keyword.json")
+                            .queryParam("query", query)
+                            .build())
+                    .retrieve()
+                    .body(KakaoLocalSearchResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
+                    e.getStatusCode().value(), "Kakao Local 호출 실패: HTTP " + e.getStatusCode(), e);
+        } catch (ResourceAccessException e) {
+            // cause chain 끝까지 가서 timeout 판정 (factory 교체 시 안전).
+            Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);
+            ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
+                    ? ExternalApiException.Type.TIMEOUT
+                    : ExternalApiException.Type.NETWORK;
+            throw new ExternalApiException(SOURCE, type, null, "Kakao Local 통신 실패: " + e.getMessage(), e);
+        } catch (RestClientException e) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
+                    "Kakao Local 호출 중 예외: " + e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalProperties.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/KakaoLocalProperties.java
@@ -1,0 +1,14 @@
+package com.todayway.backend.external.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "kakao-local")
+public class KakaoLocalProperties {
+    private String apiKey;
+    private String baseUrl;
+    private int timeoutSeconds = 5;
+}

--- a/backend/src/main/java/com/todayway/backend/external/kakao/dto/KakaoLocalSearchResponse.java
+++ b/backend/src/main/java/com/todayway/backend/external/kakao/dto/KakaoLocalSearchResponse.java
@@ -1,0 +1,33 @@
+package com.todayway.backend.external.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * 카카오 로컬 키워드 검색 API 응답 (https://dapi.kakao.com/v2/local/search/keyword.json).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoLocalSearchResponse(
+        Meta meta,
+        List<Document> documents
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Meta(
+            @JsonProperty("total_count") int totalCount,
+            @JsonProperty("pageable_count") int pageableCount,
+            @JsonProperty("is_end") boolean isEnd
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Document(
+            String id,
+            @JsonProperty("place_name") String placeName,
+            @JsonProperty("address_name") String addressName,
+            @JsonProperty("road_address_name") String roadAddressName,
+            @JsonProperty("category_group_code") String categoryGroupCode,
+            String x,
+            String y
+    ) {}
+}

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -71,10 +71,13 @@ public class OdsayClient {
             ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
                     ? ExternalApiException.Type.TIMEOUT
                     : ExternalApiException.Type.NETWORK;
-            throw new ExternalApiException(SOURCE, type, null, "ODsay 통신 실패: " + e.getMessage(), e);
+            // 보안: e.getMessage()에 URL+apiKey 통째로 박힘 ("I/O error on GET request for ...&apiKey=..."). cause 클래스명만 노출.
+            String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
+            throw new ExternalApiException(SOURCE, type, null, "ODsay 통신 실패 (" + causeName + ")", e);
         } catch (RestClientException e) {
+            // 보안: 동일 사유로 메시지에 URL 박힐 가능. 클래스명만.
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
-                    "ODsay 호출 중 예외: " + e.getMessage(), e);
+                    "ODsay 호출 중 예외 (" + e.getClass().getSimpleName() + ")", e);
         }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -62,8 +62,10 @@ public class OdsayClient {
             }
             return body;
         } catch (RestClientResponseException e) {
+            // 보안: cause로 보존하지 않음. e는 응답 본문 일부를 메시지에 담을 수 있어 우회 누출 통로.
+            // 진단에 필요한 정보(httpStatus, type, source)는 ExternalApiException 필드에 담음.
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
-                    e.getStatusCode().value(), "ODsay 호출 실패: HTTP " + e.getStatusCode(), e);
+                    e.getStatusCode().value(), "ODsay 호출 실패: HTTP " + e.getStatusCode(), null);
         } catch (ResourceAccessException e) {
             // cause chain 끝까지 가서 timeout 판정 (SimpleClientHttpRequestFactory는 SocketTimeoutException으로
             // connect/read timeout 모두 던지지만, 향후 factory 교체 시 안전하도록 root cause 검사).
@@ -71,13 +73,14 @@ public class OdsayClient {
             ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
                     ? ExternalApiException.Type.TIMEOUT
                     : ExternalApiException.Type.NETWORK;
-            // 보안: e.getMessage()에 URL+apiKey 통째로 박힘 ("I/O error on GET request for ...&apiKey=..."). cause 클래스명만 노출.
+            // 보안: e.getMessage()는 URL+apiKey를 통째로 포함하고, cause로 보존하면 stack trace에서 우회 누출.
+            // 메시지엔 cause 클래스명만 + cause는 null로 끊음. 진단 정보는 type/source 필드로 충분.
             String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
-            throw new ExternalApiException(SOURCE, type, null, "ODsay 통신 실패 (" + causeName + ")", e);
+            throw new ExternalApiException(SOURCE, type, null, "ODsay 통신 실패 (" + causeName + ")", null);
         } catch (RestClientException e) {
-            // 보안: 동일 사유로 메시지에 URL 박힐 가능. 클래스명만.
+            // 보안: 동일 사유로 cause 보존 X.
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
-                    "ODsay 호출 중 예외 (" + e.getClass().getSimpleName() + ")", e);
+                    "ODsay 호출 중 예외 (" + e.getClass().getSimpleName() + ")", null);
         }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -1,8 +1,18 @@
 package com.todayway.backend.external.odsay;
 
 import com.todayway.backend.external.ExternalApiException;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.NestedExceptionUtils;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
@@ -10,7 +20,6 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
 import java.net.SocketTimeoutException;
-import java.time.Duration;
 
 /**
  * ODsay 대중교통 길찾기 API 클라이언트.
@@ -19,7 +28,8 @@ import java.time.Duration;
 @Component
 public class OdsayClient {
 
-    private static final String SOURCE = "ODSAY";
+    private static final Logger log = LoggerFactory.getLogger(OdsayClient.class);
+    private static final ExternalApiException.Source SOURCE = ExternalApiException.Source.ODSAY;
 
     private final OdsayProperties properties;
     private final RestClient restClient;
@@ -37,11 +47,24 @@ public class OdsayClient {
         this.restClient = restClient;
     }
 
-    private static SimpleClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(timeoutSeconds));
-        factory.setReadTimeout(Duration.ofSeconds(timeoutSeconds));
-        return factory;
+    /**
+     * Apache HttpClient 5 + 커넥션 풀 기반 RequestFactory.
+     * SimpleClientHttpRequestFactory(HttpURLConnection) 대비 다중 호출 시 connection pooling으로 효율적.
+     */
+    private static ClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
+        Timeout timeout = Timeout.ofSeconds(timeoutSeconds);
+        HttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                .setMaxConnTotal(20)
+                .setMaxConnPerRoute(10)
+                .build();
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setConnectTimeout(timeout)
+                        .setResponseTimeout(timeout)
+                        .build())
+                .build();
+        return new HttpComponentsClientHttpRequestFactory(httpClient);
     }
 
     /**
@@ -54,6 +77,7 @@ public class OdsayClient {
      * @return ODsay 응답 raw JSON 문자열 (route_summary_json에 그대로 저장)
      */
     public String searchPubTransPathT(double sx, double sy, double ex, double ey) {
+        log.debug("ODsay 호출: SX={}, SY={}, EX={}, EY={}", sx, sy, ex, ey);
         try {
             // URI 템플릿 변수 확장으로 query value를 strict encoding (apiKey에 '+', '/' 포함되어 필요).
             String body = restClient.get()
@@ -64,24 +88,26 @@ public class OdsayClient {
 
             // ODsay가 빈 응답을 줄 때 후속 JSON 파싱 단계의 NPE 방지.
             if (body == null || body.isBlank()) {
-                throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
+                throw new ExternalApiException(SOURCE, ExternalApiException.Type.SERVER_ERROR,
                         null, "ODsay 응답 본문이 비어있음", null);
             }
+            log.debug("ODsay 응답 수신: {} bytes", body.length());
             return body;
         } catch (RestClientResponseException e) {
-            // 보안: cause로 보존하지 않음. e는 응답 본문 일부를 메시지에 담을 수 있어 우회 누출 통로.
-            // 진단에 필요한 정보(httpStatus, type, source)는 ExternalApiException 필드에 담음.
-            throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
-                    e.getStatusCode().value(), "ODsay 호출 실패: HTTP " + e.getStatusCode(), null);
+            // 보안: cause는 응답 본문 일부를 메시지에 담을 수 있어 우회 누출 통로 → 보존 X.
+            HttpStatusCode status = e.getStatusCode();
+            ExternalApiException.Type type = status.is4xxClientError()
+                    ? ExternalApiException.Type.CLIENT_ERROR
+                    : ExternalApiException.Type.SERVER_ERROR;
+            throw new ExternalApiException(SOURCE, type, status.value(),
+                    "ODsay 호출 실패: HTTP " + status, null);
         } catch (ResourceAccessException e) {
-            // cause chain 끝까지 가서 timeout 판정 (SimpleClientHttpRequestFactory는 SocketTimeoutException으로
-            // connect/read timeout 모두 던지지만, 향후 factory 교체 시 안전하도록 root cause 검사).
+            // cause chain 끝까지 가서 timeout 판정 (factory 교체 시 안전).
             Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);
             ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
                     ? ExternalApiException.Type.TIMEOUT
                     : ExternalApiException.Type.NETWORK;
             // 보안: e.getMessage()는 URL+apiKey를 통째로 포함하고, cause로 보존하면 stack trace에서 우회 누출.
-            // 메시지엔 cause 클래스명만 + cause는 null로 끊음. 진단 정보는 type/source 필드로 충분.
             String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
             throw new ExternalApiException(SOURCE, type, null, "ODsay 통신 실패 (" + causeName + ")", null);
         } catch (RestClientException e) {

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -9,6 +9,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -34,6 +35,7 @@ public class OdsayClient {
     private final OdsayProperties properties;
     private final RestClient restClient;
 
+    @Autowired
     public OdsayClient(OdsayProperties properties) {
         this(properties, RestClient.builder()
                 .baseUrl(properties.getBaseUrl())
@@ -41,7 +43,8 @@ public class OdsayClient {
                 .build());
     }
 
-    /** 테스트용. MockRestServiceServer로 모킹된 RestClient 주입을 위해 패키지 접근 허용. */
+    /** 테스트용. MockRestServiceServer로 모킹된 RestClient 주입을 위해 패키지 접근 허용.
+     *  Spring 빈 생성자 후보에서 제외하기 위해 public 생성자에 @Autowired 명시함. */
     OdsayClient(OdsayProperties properties, RestClient restClient) {
         this.properties = properties;
         this.restClient = restClient;

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -25,16 +25,23 @@ public class OdsayClient {
     private final RestClient restClient;
 
     public OdsayClient(OdsayProperties properties) {
-        this.properties = properties;
-
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
-        factory.setReadTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
-
-        this.restClient = RestClient.builder()
+        this(properties, RestClient.builder()
                 .baseUrl(properties.getBaseUrl())
-                .requestFactory(factory)
-                .build();
+                .requestFactory(createRequestFactory(properties.getTimeoutSeconds()))
+                .build());
+    }
+
+    /** 테스트용. MockRestServiceServer로 모킹된 RestClient 주입을 위해 패키지 접근 허용. */
+    OdsayClient(OdsayProperties properties, RestClient restClient) {
+        this.properties = properties;
+        this.restClient = restClient;
+    }
+
+    private static SimpleClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(timeoutSeconds));
+        factory.setReadTimeout(Duration.ofSeconds(timeoutSeconds));
+        return factory;
     }
 
     /**

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -1,0 +1,80 @@
+package com.todayway.backend.external.odsay;
+
+import com.todayway.backend.external.ExternalApiException;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+
+/**
+ * ODsay 대중교통 길찾기 API 클라이언트.
+ * 명세 §5.1: 응답을 raw JSON 그대로 schedule.route_summary_json에 저장한다.
+ */
+@Component
+public class OdsayClient {
+
+    private static final String SOURCE = "ODSAY";
+
+    private final OdsayProperties properties;
+    private final RestClient restClient;
+
+    public OdsayClient(OdsayProperties properties) {
+        this.properties = properties;
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
+        factory.setReadTimeout(Duration.ofSeconds(properties.getTimeoutSeconds()));
+
+        this.restClient = RestClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .requestFactory(factory)
+                .build();
+    }
+
+    /**
+     * 대중교통 경로 검색.
+     *
+     * @param sx 출발지 경도 (longitude)
+     * @param sy 출발지 위도 (latitude)
+     * @param ex 도착지 경도
+     * @param ey 도착지 위도
+     * @return ODsay 응답 raw JSON 문자열 (route_summary_json에 그대로 저장)
+     */
+    public String searchPubTransPathT(double sx, double sy, double ex, double ey) {
+        try {
+            // URI 템플릿 변수 확장으로 query value를 strict encoding (apiKey에 '+', '/' 포함되어 필요).
+            String body = restClient.get()
+                    .uri("/searchPubTransPathT?SX={sx}&SY={sy}&EX={ex}&EY={ey}&apiKey={apiKey}",
+                            sx, sy, ex, ey, properties.getApiKey())
+                    .retrieve()
+                    .body(String.class);
+
+            // ODsay가 빈 응답을 줄 때 후속 JSON 파싱 단계의 NPE 방지.
+            if (body == null || body.isBlank()) {
+                throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
+                        null, "ODsay 응답 본문이 비어있음", null);
+            }
+            return body;
+        } catch (RestClientResponseException e) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.API_FAILED,
+                    e.getStatusCode().value(), "ODsay 호출 실패: HTTP " + e.getStatusCode(), e);
+        } catch (ResourceAccessException e) {
+            // cause chain 끝까지 가서 timeout 판정 (SimpleClientHttpRequestFactory는 SocketTimeoutException으로
+            // connect/read timeout 모두 던지지만, 향후 factory 교체 시 안전하도록 root cause 검사).
+            Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);
+            ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
+                    ? ExternalApiException.Type.TIMEOUT
+                    : ExternalApiException.Type.NETWORK;
+            throw new ExternalApiException(SOURCE, type, null, "ODsay 통신 실패: " + e.getMessage(), e);
+        } catch (RestClientException e) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
+                    "ODsay 호출 중 예외: " + e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayProperties.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayProperties.java
@@ -1,0 +1,14 @@
+package com.todayway.backend.external.odsay;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "odsay")
+public class OdsayProperties {
+    private String apiKey;
+    private String baseUrl;
+    private int timeoutSeconds = 5;
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -51,6 +51,7 @@ odsay:
 kakao-local:
   api-key: ${KAKAO_LOCAL_API_KEY:}
   base-url: https://dapi.kakao.com/v2/local
+  timeout-seconds: 5
 
 vapid:
   public-key: ${VAPID_PUBLIC_KEY:}

--- a/backend/src/test/java/com/todayway/backend/external/kakao/KakaoLocalClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/kakao/KakaoLocalClientTest.java
@@ -1,0 +1,124 @@
+package com.todayway.backend.external.kakao;
+
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * KakaoLocalClient 단위 테스트 (MockRestServiceServer).
+ *
+ * 검증 포인트:
+ * 1. Authorization 헤더 "KakaoAK {apiKey}" 형식
+ * 2. 응답 record 필드 매핑 (place_name → placeName, x/y string)
+ * 3. 빈 body 가드 (NPE 방지)
+ * 4. 모든 catch 블록에서 cause == null
+ */
+class KakaoLocalClientTest {
+
+    private static final String API_KEY = "kakao-test-key-xyz";
+
+    private MockRestServiceServer server;
+    private KakaoLocalClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder()
+                .baseUrl("https://dapi.kakao.com/v2/local")
+                .defaultHeader("Authorization", "KakaoAK " + API_KEY);
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new KakaoLocalClient(builder.build());
+    }
+
+    @Test
+    void Authorization_헤더는_KakaoAK_prefix이고_응답_record_매핑이_정확하다() {
+        String responseBody = """
+                {
+                  "meta": {"total_count": 1, "pageable_count": 1, "is_end": true},
+                  "documents": [{
+                    "id": "12345",
+                    "place_name": "국민대학교",
+                    "address_name": "서울 성북구 정릉동",
+                    "road_address_name": "서울 성북구 정릉로 77",
+                    "category_group_code": "SC4",
+                    "x": "126.9970",
+                    "y": "37.6107"
+                  }]
+                }
+                """;
+        server.expect(requestTo(Matchers.containsString("query=")))
+                .andExpect(header("Authorization", "KakaoAK " + API_KEY))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        KakaoLocalSearchResponse res = client.searchKeyword("국민대학교");
+
+        assertThat(res).isNotNull();
+        assertThat(res.meta().totalCount()).isEqualTo(1);
+        assertThat(res.documents()).hasSize(1);
+        KakaoLocalSearchResponse.Document doc = res.documents().get(0);
+        assertThat(doc.id()).isEqualTo("12345");
+        assertThat(doc.placeName()).isEqualTo("국민대학교");
+        assertThat(doc.roadAddressName()).isEqualTo("서울 성북구 정릉로 77");
+        // x/y가 string으로 들어옴 (명세 §8.1 보강 — 후속 /geocode에서 Double.parseDouble)
+        assertThat(doc.x()).isEqualTo("126.9970");
+        assertThat(doc.y()).isEqualTo("37.6107");
+        server.verify();
+    }
+
+    @Test
+    void 빈_응답이면_API_FAILED_던지고_cause는_null() {
+        // Kakao가 204 No Content 또는 빈 body 줄 때 NPE 방지
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.searchKeyword("test"));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void HTTP_401이면_API_FAILED와_httpStatus_보존_cause는_null() {
+        // Kakao 키 만료/미설정 시
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.searchKeyword("test"));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getHttpStatus()).isEqualTo(401);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void HTTP_500이면_API_FAILED_cause는_null() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.searchKeyword("test"));
+
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getHttpStatus()).isEqualTo(500);
+        assertThat(ex.getCause()).isNull();
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/external/kakao/KakaoLocalClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/kakao/KakaoLocalClientTest.java
@@ -78,8 +78,8 @@ class KakaoLocalClientTest {
     }
 
     @Test
-    void 빈_응답이면_API_FAILED_던지고_cause는_null() {
-        // Kakao가 204 No Content 또는 빈 body 줄 때 NPE 방지
+    void 빈_응답이면_SERVER_ERROR_던지고_cause는_null() {
+        // 빈 응답은 외부 비정상 → SERVER_ERROR (NPE 방지)
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withStatus(HttpStatus.NO_CONTENT));
 
@@ -88,13 +88,14 @@ class KakaoLocalClientTest {
                 () -> client.searchKeyword("test"));
 
         assertThat(ex).isNotNull();
-        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
+        assertThat(ex.getSource()).isEqualTo(ExternalApiException.Source.KAKAO_LOCAL);
         assertThat(ex.getCause()).isNull();
     }
 
     @Test
-    void HTTP_401이면_API_FAILED와_httpStatus_보존_cause는_null() {
-        // Kakao 키 만료/미설정 시
+    void HTTP_401이면_CLIENT_ERROR와_httpStatus_보존_cause는_null() {
+        // Kakao 키 만료/미설정 → CLIENT_ERROR (재시도 무의미)
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
 
@@ -103,13 +104,14 @@ class KakaoLocalClientTest {
                 () -> client.searchKeyword("test"));
 
         assertThat(ex).isNotNull();
-        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.CLIENT_ERROR);
         assertThat(ex.getHttpStatus()).isEqualTo(401);
         assertThat(ex.getCause()).isNull();
     }
 
     @Test
-    void HTTP_500이면_API_FAILED_cause는_null() {
+    void HTTP_500이면_SERVER_ERROR_cause는_null() {
+        // 외부 일시 장애 → SERVER_ERROR (재시도 가치)
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
 
@@ -117,7 +119,7 @@ class KakaoLocalClientTest {
                 ExternalApiException.class,
                 () -> client.searchKeyword("test"));
 
-        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
         assertThat(ex.getHttpStatus()).isEqualTo(500);
         assertThat(ex.getCause()).isNull();
     }

--- a/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
@@ -1,0 +1,124 @@
+package com.todayway.backend.external.odsay;
+
+import com.todayway.backend.external.ExternalApiException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * OdsayClient 단위 테스트 (MockRestServiceServer).
+ *
+ * 핵심 회귀 방지:
+ * 1. apiKey strict encoding ('+', '/', '=' → %2B, %2F, %3D) — queryParam 패턴으로 되돌리면 깨짐
+ * 2. 모든 catch 블록에서 cause == null (stack trace 우회 누출 차단)
+ * 3. 메시지에 URL/apiKey 미노출
+ */
+class OdsayClientTest {
+
+    private MockRestServiceServer server;
+    private OdsayClient client;
+
+    @BeforeEach
+    void setUp() {
+        OdsayProperties props = new OdsayProperties();
+        // '+', '/', '=' 가 strict encoding 되는지 검증하기 위해 의도적으로 포함
+        props.setApiKey("test+key/with=special");
+        props.setBaseUrl("https://api.odsay.com/v1/api");
+        props.setTimeoutSeconds(5);
+
+        RestClient.Builder builder = RestClient.builder().baseUrl(props.getBaseUrl());
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new OdsayClient(props, builder.build());
+    }
+
+    @Test
+    void apiKey의_특수문자가_strict_encoding된다() {
+        // 회귀 방지: 누가 .queryParam("apiKey", ...)로 되돌리면 '+'가 그대로 가서 ODsay 401.
+        // URI 템플릿 변수 확장은 reserved char를 모두 인코딩.
+        server.expect(requestTo(Matchers.containsString("apiKey=test%2Bkey%2Fwith%3Dspecial")))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"result\":{\"path\":[]}}", MediaType.APPLICATION_JSON));
+
+        String result = client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665);
+
+        assertThat(result).contains("path");
+        server.verify();
+    }
+
+    @Test
+    void 좌표_4개가_쿼리스트링에_정확히_담긴다() {
+        server.expect(requestTo(Matchers.allOf(
+                        Matchers.containsString("SX=126.997"),
+                        Matchers.containsString("SY=37.611"),
+                        Matchers.containsString("EX=126.978"),
+                        Matchers.containsString("EY=37.5665"))))
+                .andRespond(withSuccess("{\"result\":{}}", MediaType.APPLICATION_JSON));
+
+        client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665);
+
+        server.verify();
+    }
+
+    @Test
+    void 빈_응답_body면_API_FAILED_던지고_cause는_null() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void HTTP_401이면_API_FAILED와_httpStatus_보존_cause는_null() {
+        // ODsay가 키 만료 시 던지는 케이스
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED).body("ApiKeyAuthFailed"));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getHttpStatus()).isEqualTo(401);
+        // 보안 회귀 방지: cause로 RestClientResponseException 보존하면 stack trace에 URL+apiKey 누출
+        assertThat(ex.getCause()).isNull();
+        // 보안 회귀 방지: 메시지에 URL/apiKey 박히면 안 됨
+        assertThat(ex.getMessage())
+                .doesNotContain("apiKey")
+                .doesNotContain("test+key")
+                .doesNotContain("https://");
+    }
+
+    @Test
+    void HTTP_500이면_API_FAILED와_httpStatus_보존() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getHttpStatus()).isEqualTo(500);
+        assertThat(ex.getCause()).isNull();
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
@@ -72,7 +72,8 @@ class OdsayClientTest {
     }
 
     @Test
-    void 빈_응답_body면_API_FAILED_던지고_cause는_null() {
+    void 빈_응답_body면_SERVER_ERROR_던지고_cause는_null() {
+        // 빈 body는 외부 응답 비정상 → SERVER_ERROR (재시도 가치 있음)
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withSuccess("", MediaType.APPLICATION_JSON));
 
@@ -81,13 +82,14 @@ class OdsayClientTest {
                 () -> client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665));
 
         assertThat(ex).isNotNull();
-        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
+        assertThat(ex.getSource()).isEqualTo(ExternalApiException.Source.ODSAY);
         assertThat(ex.getCause()).isNull();
     }
 
     @Test
-    void HTTP_401이면_API_FAILED와_httpStatus_보존_cause는_null() {
-        // ODsay가 키 만료 시 던지는 케이스
+    void HTTP_401이면_CLIENT_ERROR와_httpStatus_보존_cause는_null() {
+        // ODsay가 키 만료 시 → CLIENT_ERROR (요청 자체 문제, 재시도 무의미)
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED).body("ApiKeyAuthFailed"));
 
@@ -96,7 +98,7 @@ class OdsayClientTest {
                 () -> client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665));
 
         assertThat(ex).isNotNull();
-        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.CLIENT_ERROR);
         assertThat(ex.getHttpStatus()).isEqualTo(401);
         // 보안 회귀 방지: cause로 RestClientResponseException 보존하면 stack trace에 URL+apiKey 누출
         assertThat(ex.getCause()).isNull();
@@ -108,7 +110,8 @@ class OdsayClientTest {
     }
 
     @Test
-    void HTTP_500이면_API_FAILED와_httpStatus_보존() {
+    void HTTP_500이면_SERVER_ERROR와_httpStatus_보존() {
+        // 외부 일시 장애 → SERVER_ERROR (재시도 가치 있음)
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
 
@@ -117,7 +120,7 @@ class OdsayClientTest {
                 () -> client.searchPubTransPathT(126.997, 37.611, 126.978, 37.5665));
 
         assertThat(ex).isNotNull();
-        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.API_FAILED);
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
         assertThat(ex.getHttpStatus()).isEqualTo(500);
         assertThat(ex.getCause()).isNull();
     }


### PR DESCRIPTION
## 개요

명세 §5.1 / §6.1 / §8.1 구현을 위한 **외부 API 호출 레이어 골격**.
컨트롤러·엔티티·서비스 없이 클라이언트만 추가 → 황찬우(common 패키지) 작업과 **충돌 0**.

## 변경

### 신규 (`backend/src/main/java/com/todayway/backend/external/`)

- `ExternalApiException` — `Type` enum (`TIMEOUT`/`API_FAILED`/`NETWORK`) + source + httpStatus
- `ExternalApiConfig` — `@EnableConfigurationProperties` 등록
- `odsay/OdsayClient.searchPubTransPathT(sx, sy, ex, ey)` → raw JSON String (명세 §5.1)
- `odsay/OdsayProperties` — `odsay.{api-key, base-url, timeout-seconds}`
- `kakao/KakaoLocalClient.searchKeyword(query)` → `KakaoLocalSearchResponse` (Authorization: KakaoAK)
- `kakao/KakaoLocalProperties` — `kakao-local.{api-key, base-url, timeout-seconds}`
- `kakao/dto/KakaoLocalSearchResponse` — Java 21 record (meta + documents)

### 수정

- `application.yml`: `kakao-local.timeout-seconds: 5` 추가 (ODsay와 대칭)

## 작업 중 발견·해결한 이슈

1. **ODsay apiKey 인코딩** — Spring `RestClient.queryParam()`이 `+`를 그대로 보내 ODsay가 space로 디코드 → 401. URI 템플릿 변수 확장(`?apiKey={apiKey}`)으로 strict 인코딩 적용해 해결.
2. **Connect timeout 분류** — `e.getCause()` 1단계만 보면 누락 가능 → `NestedExceptionUtils.getMostSpecificCause()`로 cause chain 끝까지 순회.
3. **ODsay 빈 body NPE 가드** — `body == null || isBlank()` 체크.

## 검증

- `./gradlew compileJava`: BUILD SUCCESSFUL
- `./gradlew build -x test`: BUILD SUCCESSFUL
- 실제 API 호출 검증 (임시 테스트, 깃에 미커밋):
  - ODsay 국민대→서울시청: 34분, 1500원, raw JSON path/totalTime/subPath 키 정상
  - Kakao "국민대학교": 325건, 좌표 (37.6107, 126.9970)

## 1번(황찬우) 의존도 — 0건

컨트롤러·엔티티·서비스·SecurityConfig 모두 미작성. `ExternalApiException.Type`은 임시 분류, 후속 PR에서 `ErrorCode`로 매핑.

## 후속 작업

- [ ] 1번 `GlobalExceptionHandler` 머지 후 → `ExternalApiException → ErrorCode` 매핑 PR
- [ ] 명세 v1.1.4 보강 — 별도 노션 페이지로 검토 요청
- [ ] `/geocode`, `/schedules/{id}/route` 컨트롤러 — 1번 머지 후
- [ ] PushScheduler

## 리뷰 포인트

1. `OdsayClient`의 URI 템플릿 변수 확장 패턴 OK 한지
2. `ExternalApiException.Type`이 명세 §1.6 ErrorCode와 매핑 가능한 분류인지
3. `KakaoLocalSearchResponse` record 필드 — 후속 `/geocode` 응답 변환에 충분한지