### PR TITLE
feat(backend): step3 — auth 도메인 (signup/login/logout + JWT)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
 group = "com.todayway"
 version = "0.0.1-SNAPSHOT"
 
+// Docker Engine 29.x ↔ docker-java SDK 호환을 위해 testcontainers 버전 핀
+// (Spring Boot BOM이 잡는 1.21.2가 Docker 29와 HTTP 400 빈응답 이슈 → 1.21.4로 업그레이드)
+extra["testcontainers.version"] = "1.21.4"
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)

--- a/backend/src/main/java/com/todayway/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/todayway/backend/auth/controller/AuthController.java
@@ -1,0 +1,43 @@
+package com.todayway.backend.auth.controller;
+
+import com.todayway.backend.auth.dto.LoginRequest;
+import com.todayway.backend.auth.dto.LoginResponse;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.auth.dto.SignupResponse;
+import com.todayway.backend.auth.service.AuthService;
+import com.todayway.backend.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody @Valid SignupRequest req) {
+        SignupResponse res = authService.signup(req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(res));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest req) {
+        LoginResponse res = authService.login(req);
+        return ResponseEntity.ok(ApiResponse.of(res));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal String memberUid) {
+        authService.logout(memberUid);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/todayway/backend/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.todayway.backend.auth.controller;
 
 import com.todayway.backend.auth.dto.LoginRequest;
 import com.todayway.backend.auth.dto.LoginResponse;
+import com.todayway.backend.auth.dto.LogoutRequest;
 import com.todayway.backend.auth.dto.SignupRequest;
 import com.todayway.backend.auth.dto.SignupResponse;
 import com.todayway.backend.auth.service.AuthService;
@@ -10,7 +11,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,8 +36,8 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AuthenticationPrincipal String memberUid) {
-        authService.logout(memberUid);
+    public ResponseEntity<Void> logout(@RequestBody @Valid LogoutRequest req) {
+        authService.logout(req.refreshToken());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/todayway/backend/auth/domain/Member.java
+++ b/backend/src/main/java/com/todayway/backend/auth/domain/Member.java
@@ -1,0 +1,62 @@
+package com.todayway.backend.auth.domain;
+
+import com.todayway.backend.common.entity.BaseEntity;
+import com.todayway.backend.common.ulid.UlidGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Entity
+@Table(name = "member")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_uid", nullable = false, updatable = false, unique = true,
+            columnDefinition = "CHAR(26)")
+    private String memberUid;
+
+    @Column(name = "login_id", nullable = false, unique = true, length = 50)
+    private String loginId;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "nickname", nullable = false, length = 50)
+    private String nickname;
+
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    private Member(String loginId, String passwordHash, String nickname) {
+        this.loginId = loginId;
+        this.passwordHash = passwordHash;
+        this.nickname = nickname;
+    }
+
+    public static Member create(String loginId, String passwordHash, String nickname) {
+        return new Member(loginId, passwordHash, nickname);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (memberUid == null) {
+            memberUid = UlidGenerator.generate();
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/todayway/backend/auth/domain/RefreshToken.java
@@ -1,0 +1,64 @@
+package com.todayway.backend.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "token_hash", nullable = false, unique = true,
+            columnDefinition = "CHAR(64)")
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private OffsetDateTime revokedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    private RefreshToken(Long memberId, String tokenHash, OffsetDateTime expiresAt) {
+        this.memberId = memberId;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken create(Long memberId, String tokenHash, OffsetDateTime expiresAt) {
+        return new RefreshToken(memberId, tokenHash, expiresAt);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+
+    public void revoke() {
+        if (revokedAt == null) {
+            revokedAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/todayway/backend/auth/domain/RefreshToken.java
@@ -12,12 +12,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @Getter
 @Entity
 @Table(name = "refresh_token")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,13 +55,13 @@ public class RefreshToken {
     @PrePersist
     void prePersist() {
         if (createdAt == null) {
-            createdAt = OffsetDateTime.now();
+            createdAt = OffsetDateTime.now(KST);
         }
     }
 
     public void revoke() {
         if (revokedAt == null) {
-            revokedAt = OffsetDateTime.now();
+            revokedAt = OffsetDateTime.now(KST);
         }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/todayway/backend/auth/domain/RefreshToken.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 
+/** 발급/폐기만 발생하는 엔티티 — updatedAt 불필요로 BaseEntity 미상속. */
 @Getter
 @Entity
 @Table(name = "refresh_token")

--- a/backend/src/main/java/com/todayway/backend/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/todayway/backend/auth/dto/LoginRequest.java
@@ -1,0 +1,8 @@
+package com.todayway.backend.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String loginId,
+        @NotBlank String password
+) {}

--- a/backend/src/main/java/com/todayway/backend/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/todayway/backend/auth/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.todayway.backend.auth.dto;
+
+public record LoginResponse(
+        String memberId,
+        String accessToken,
+        String refreshToken
+) {}

--- a/backend/src/main/java/com/todayway/backend/auth/dto/LogoutRequest.java
+++ b/backend/src/main/java/com/todayway/backend/auth/dto/LogoutRequest.java
@@ -1,0 +1,5 @@
+package com.todayway.backend.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(@NotBlank String refreshToken) {}

--- a/backend/src/main/java/com/todayway/backend/auth/dto/SignupRequest.java
+++ b/backend/src/main/java/com/todayway/backend/auth/dto/SignupRequest.java
@@ -1,0 +1,21 @@
+package com.todayway.backend.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @NotBlank
+        @Pattern(regexp = "^[a-zA-Z0-9]{4,20}$",
+                 message = "loginId는 영문+숫자 4~20자")
+        String loginId,
+
+        @NotBlank
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_]).{8,72}$",
+                 message = "password는 영문+숫자+특수문자 포함 8~72자")
+        String password,
+
+        @NotBlank
+        @Size(min = 2, max = 20, message = "nickname은 2~20자")
+        String nickname
+) {}

--- a/backend/src/main/java/com/todayway/backend/auth/dto/SignupResponse.java
+++ b/backend/src/main/java/com/todayway/backend/auth/dto/SignupResponse.java
@@ -1,0 +1,9 @@
+package com.todayway.backend.auth.dto;
+
+public record SignupResponse(
+        String memberId,
+        String loginId,
+        String nickname,
+        String accessToken,
+        String refreshToken
+) {}

--- a/backend/src/main/java/com/todayway/backend/auth/repository/MemberRepository.java
+++ b/backend/src/main/java/com/todayway/backend/auth/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.todayway.backend.auth.repository;
+
+import com.todayway.backend.auth.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByLoginId(String loginId);
+
+    Optional<Member> findByLoginId(String loginId);
+
+    Optional<Member> findByMemberUid(String memberUid);
+}

--- a/backend/src/main/java/com/todayway/backend/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/todayway/backend/auth/repository/RefreshTokenRepository.java
@@ -2,20 +2,10 @@ package com.todayway.backend.auth.repository;
 
 import com.todayway.backend.auth.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE RefreshToken rt SET rt.revokedAt = :revokedAt " +
-           "WHERE rt.memberId = :memberId AND rt.revokedAt IS NULL")
-    int revokeAllActiveByMemberId(@Param("memberId") Long memberId,
-                                  @Param("revokedAt") OffsetDateTime revokedAt);
 }

--- a/backend/src/main/java/com/todayway/backend/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/todayway/backend/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package com.todayway.backend.auth.repository;
+
+import com.todayway.backend.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE RefreshToken rt SET rt.revokedAt = :revokedAt " +
+           "WHERE rt.memberId = :memberId AND rt.revokedAt IS NULL")
+    int revokeAllActiveByMemberId(@Param("memberId") Long memberId,
+                                  @Param("revokedAt") OffsetDateTime revokedAt);
+}

--- a/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
@@ -20,12 +20,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -87,7 +90,7 @@ public class AuthService {
 
     private void saveRefreshToken(Long memberId, String rawToken) {
         String tokenHash = Sha256Hasher.hash(rawToken);
-        OffsetDateTime expiresAt = OffsetDateTime.now()
+        OffsetDateTime expiresAt = OffsetDateTime.now(KST)
                 .plus(jwtProperties.refreshTokenExpirationDays(), ChronoUnit.DAYS);
         refreshTokenRepository.save(RefreshToken.create(memberId, tokenHash, expiresAt));
     }

--- a/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
@@ -1,0 +1,94 @@
+package com.todayway.backend.auth.service;
+
+import com.todayway.backend.auth.domain.Member;
+import com.todayway.backend.auth.domain.RefreshToken;
+import com.todayway.backend.auth.dto.LoginRequest;
+import com.todayway.backend.auth.dto.LoginResponse;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.auth.dto.SignupResponse;
+import com.todayway.backend.auth.repository.MemberRepository;
+import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.common.jwt.JwtProperties;
+import com.todayway.backend.common.jwt.JwtProvider;
+import com.todayway.backend.common.util.MemberIdFormatter;
+import com.todayway.backend.common.util.Sha256Hasher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final JwtProperties jwtProperties;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest req) {
+        if (memberRepository.existsByLoginId(req.loginId())) {
+            throw new BusinessException(ErrorCode.LOGIN_ID_DUPLICATED);
+        }
+
+        Member member = memberRepository.save(
+                Member.create(req.loginId(),
+                              passwordEncoder.encode(req.password()),
+                              req.nickname()));
+
+        String accessToken = jwtProvider.issueAccessToken(member.getMemberUid());
+        String refreshToken = jwtProvider.issueRefreshToken(member.getMemberUid());
+        saveRefreshToken(member.getId(), refreshToken);
+
+        return new SignupResponse(
+                MemberIdFormatter.format(member.getMemberUid()),
+                member.getLoginId(),
+                member.getNickname(),
+                accessToken,
+                refreshToken
+        );
+    }
+
+    @Transactional
+    public LoginResponse login(LoginRequest req) {
+        // loginId 존재 안 함과 password 불일치 모두 INVALID_CREDENTIALS로 통일 (api-spec §2.2, 사용자 존재 여부 leak 방지)
+        Member member = memberRepository.findByLoginId(req.loginId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(req.password(), member.getPasswordHash())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtProvider.issueAccessToken(member.getMemberUid());
+        String refreshToken = jwtProvider.issueRefreshToken(member.getMemberUid());
+        saveRefreshToken(member.getId(), refreshToken);
+
+        return new LoginResponse(
+                MemberIdFormatter.format(member.getMemberUid()),
+                accessToken,
+                refreshToken
+        );
+    }
+
+    @Transactional
+    public void logout(String memberUid) {
+        Member member = memberRepository.findByMemberUid(memberUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        refreshTokenRepository.revokeAllActiveByMemberId(member.getId(), OffsetDateTime.now());
+    }
+
+    private void saveRefreshToken(Long memberId, String rawToken) {
+        String tokenHash = Sha256Hasher.hash(rawToken);
+        OffsetDateTime expiresAt = OffsetDateTime.now()
+                .plus(jwtProperties.refreshTokenExpirationDays(), ChronoUnit.DAYS);
+        refreshTokenRepository.save(RefreshToken.create(memberId, tokenHash, expiresAt));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import com.todayway.backend.common.jwt.JwtProvider;
 import com.todayway.backend.common.util.MemberIdFormatter;
 import com.todayway.backend.common.util.Sha256Hasher;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,10 +43,15 @@ public class AuthService {
             throw new BusinessException(ErrorCode.LOGIN_ID_DUPLICATED);
         }
 
-        Member member = memberRepository.save(
-                Member.create(req.loginId(),
-                              passwordEncoder.encode(req.password()),
-                              req.nickname()));
+        Member member;
+        try {
+            member = memberRepository.save(
+                    Member.create(req.loginId(),
+                                  passwordEncoder.encode(req.password()),
+                                  req.nickname()));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.LOGIN_ID_DUPLICATED);
+        }
 
         String accessToken = jwtProvider.issueAccessToken(member.getMemberUid());
         String refreshToken = jwtProvider.issueRefreshToken(member.getMemberUid());

--- a/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
@@ -88,10 +88,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(String memberUid) {
-        Member member = memberRepository.findByMemberUid(memberUid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        refreshTokenRepository.revokeAllActiveByMemberId(member.getId(), OffsetDateTime.now());
+    public void logout(String refreshToken) {
+        // 명세 §2.3 — 전달된 refresh 토큰 1개만 폐기. 미존재/이미 폐기는 silent noop (멱등, RFC 7009 정신).
+        String tokenHash = Sha256Hasher.hash(refreshToken);
+        refreshTokenRepository.findByTokenHash(tokenHash)
+                .ifPresent(RefreshToken::revoke);
     }
 
     private void saveRefreshToken(Long memberId, String rawToken) {

--- a/backend/src/main/java/com/todayway/backend/common/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/config/JpaAuditingConfig.java
@@ -1,9 +1,21 @@
 package com.todayway.backend.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 public class JpaAuditingConfig {
+
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider() {
+        // BaseEntity의 OffsetDateTime 필드에 KST 기준 OffsetDateTime 직접 주입 (명세 §1.4)
+        return () -> Optional.of(OffsetDateTime.now(ZoneId.of("Asia/Seoul")));
+    }
 }

--- a/backend/src/main/java/com/todayway/backend/common/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/todayway/backend/common/jwt/JwtProvider.java
@@ -9,6 +9,7 @@ import javax.crypto.SecretKey;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtProvider {
@@ -24,6 +25,7 @@ public class JwtProvider {
     public String issueAccessToken(String memberUid) {
         Instant now = Instant.now();
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .issuer(props.issuer())
                 .subject(memberUid)
                 .issuedAt(Date.from(now))
@@ -35,6 +37,7 @@ public class JwtProvider {
     public String issueRefreshToken(String memberUid) {
         Instant now = Instant.now();
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .issuer(props.issuer())
                 .subject(memberUid)
                 .issuedAt(Date.from(now))

--- a/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/v1/auth/signup",
                                 "/api/v1/auth/login",
+                                "/api/v1/auth/logout",
                                 "/api/v1/main",
                                 "/api/v1/map/config",
                                 "/actuator/health"

--- a/backend/src/main/java/com/todayway/backend/common/util/MemberIdFormatter.java
+++ b/backend/src/main/java/com/todayway/backend/common/util/MemberIdFormatter.java
@@ -1,0 +1,22 @@
+package com.todayway.backend.common.util;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+
+public final class MemberIdFormatter {
+
+    private static final String PREFIX = "mem_";
+
+    private MemberIdFormatter() {}
+
+    public static String format(String memberUid) {
+        return PREFIX + memberUid;
+    }
+
+    public static String parse(String prefixedId) {
+        if (prefixedId == null || !prefixedId.startsWith(PREFIX)) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "잘못된 회원 ID 형식");
+        }
+        return prefixedId.substring(PREFIX.length());
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/util/Sha256Hasher.java
+++ b/backend/src/main/java/com/todayway/backend/common/util/Sha256Hasher.java
@@ -1,0 +1,21 @@
+package com.todayway.backend.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class Sha256Hasher {
+
+    private Sha256Hasher() {}
+
+    public static String hash(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 미지원", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.todayway.backend.common.web;
+
+import com.todayway.backend.auth.domain.Member;
+import com.todayway.backend.auth.repository.MemberRepository;
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentMember.class)
+                && parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof String memberUid)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return memberRepository.findByMemberUid(memberUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/web/WebMvcConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.todayway.backend.common.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentMemberArgumentResolver currentMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentMemberArgumentResolver);
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/auth/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/auth/AuthControllerIntegrationTest.java
@@ -50,7 +50,7 @@ class AuthControllerIntegrationTest {
     void signup_login_logout_full_flow() throws Exception {
         // (1) signup → 201, 응답에 memberId/loginId/nickname/accessToken/refreshToken
         SignupRequest signupReq = new SignupRequest("chanwoo90", "P@ssw0rd!", "찬우");
-        mockMvc.perform(post("/api/v1/auth/signup")
+        String signupResp = mockMvc.perform(post("/api/v1/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(signupReq)))
                 .andExpect(status().isCreated())
@@ -58,7 +58,9 @@ class AuthControllerIntegrationTest {
                 .andExpect(jsonPath("$.data.loginId").value("chanwoo90"))
                 .andExpect(jsonPath("$.data.nickname").value("찬우"))
                 .andExpect(jsonPath("$.data.accessToken").exists())
-                .andExpect(jsonPath("$.data.refreshToken").exists());
+                .andExpect(jsonPath("$.data.refreshToken").exists())
+                .andReturn().getResponse().getContentAsString();
+        String signupRefreshToken = objectMapper.readTree(signupResp).path("data").path("refreshToken").asText();
 
         // (2) signup 중복 → 409 LOGIN_ID_DUPLICATED
         mockMvc.perform(post("/api/v1/auth/signup")
@@ -104,10 +106,15 @@ class AuthControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(logoutReq)))
                 .andExpect(status().isNoContent());
 
-        // (7) DB 검증: logout 후 해당 refresh_token.revoked_at NOT NULL
+        // (7) DB 검증: logout 후 해당 refresh_token.revoked_at NOT NULL + signup 토큰 비폐기
         //     (refresh 엔드포인트는 v1.2 예정 — API로 차단 검증 불가, DB 직접 검증)
         String tokenHash = Sha256Hasher.hash(refreshToken);
         RefreshToken saved = refreshTokenRepository.findByTokenHash(tokenHash).orElseThrow();
         assertThat(saved.getRevokedAt()).isNotNull();
+
+        // signup 시 받은 refreshToken은 logout 대상 아님 → revokedAt null 유지 (의사결정 5번 회귀 가드)
+        String signupTokenHash = Sha256Hasher.hash(signupRefreshToken);
+        RefreshToken signupSaved = refreshTokenRepository.findByTokenHash(signupTokenHash).orElseThrow();
+        assertThat(signupSaved.getRevokedAt()).isNull();
     }
 }

--- a/backend/src/test/java/com/todayway/backend/auth/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/auth/AuthControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todayway.backend.auth.domain.RefreshToken;
 import com.todayway.backend.auth.dto.LoginRequest;
+import com.todayway.backend.auth.dto.LogoutRequest;
 import com.todayway.backend.auth.dto.SignupRequest;
 import com.todayway.backend.auth.repository.RefreshTokenRepository;
 import com.todayway.backend.common.util.Sha256Hasher;
@@ -78,7 +79,6 @@ class AuthControllerIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
 
         JsonNode loginNode = objectMapper.readTree(loginResp).path("data");
-        String accessToken = loginNode.path("accessToken").asText();
         String refreshToken = loginNode.path("refreshToken").asText();
 
         // (4) login 잘못된 비밀번호 → 401 INVALID_CREDENTIALS
@@ -97,9 +97,11 @@ class AuthControllerIntegrationTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error.code").value("INVALID_CREDENTIALS"));
 
-        // (6) logout → 204 (바디 없음, accessToken으로 인증)
+        // (6) logout → 204, body의 refreshToken 1개만 폐기 (명세 §2.3, 의사결정 4·5)
+        LogoutRequest logoutReq = new LogoutRequest(refreshToken);
         mockMvc.perform(post("/api/v1/auth/logout")
-                        .header("Authorization", "Bearer " + accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(logoutReq)))
                 .andExpect(status().isNoContent());
 
         // (7) DB 검증: logout 후 해당 refresh_token.revoked_at NOT NULL

--- a/backend/src/test/java/com/todayway/backend/auth/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/auth/AuthControllerIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.todayway.backend.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.domain.RefreshToken;
+import com.todayway.backend.auth.dto.LoginRequest;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.common.util.Sha256Hasher;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class AuthControllerIntegrationTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void signup_login_logout_full_flow() throws Exception {
+        // (1) signup → 201, 응답에 memberId/loginId/nickname/accessToken/refreshToken
+        SignupRequest signupReq = new SignupRequest("chanwoo90", "P@ssw0rd!", "찬우");
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupReq)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.loginId").value("chanwoo90"))
+                .andExpect(jsonPath("$.data.nickname").value("찬우"))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists());
+
+        // (2) signup 중복 → 409 LOGIN_ID_DUPLICATED
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupReq)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("LOGIN_ID_DUPLICATED"));
+
+        // (3) login → 200, memberId + 토큰 2개
+        LoginRequest loginReq = new LoginRequest("chanwoo90", "P@ssw0rd!");
+        String loginResp = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginReq)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberId").exists())
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.refreshToken").exists())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode loginNode = objectMapper.readTree(loginResp).path("data");
+        String accessToken = loginNode.path("accessToken").asText();
+        String refreshToken = loginNode.path("refreshToken").asText();
+
+        // (4) login 잘못된 비밀번호 → 401 INVALID_CREDENTIALS
+        LoginRequest wrongReq = new LoginRequest("chanwoo90", "WrongP@ss1!");
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(wrongReq)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("INVALID_CREDENTIALS"));
+
+        // (5) login 존재 안 하는 loginId → 401 INVALID_CREDENTIALS (MEMBER_NOT_FOUND 아님)
+        LoginRequest unknownReq = new LoginRequest("ghost123", "P@ssw0rd!");
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(unknownReq)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("INVALID_CREDENTIALS"));
+
+        // (6) logout → 204 (바디 없음, accessToken으로 인증)
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        // (7) DB 검증: logout 후 해당 refresh_token.revoked_at NOT NULL
+        //     (refresh 엔드포인트는 v1.2 예정 — API로 차단 검증 불가, DB 직접 검증)
+        String tokenHash = Sha256Hasher.hash(refreshToken);
+        RefreshToken saved = refreshTokenRepository.findByTokenHash(tokenHash).orElseThrow();
+        assertThat(saved.getRevokedAt()).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/todayway/backend/auth/service/AuthServiceTest.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.auth.service;
+
+import com.todayway.backend.auth.domain.Member;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.auth.repository.MemberRepository;
+import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.common.jwt.JwtProperties;
+import com.todayway.backend.common.jwt.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock MemberRepository memberRepository;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock JwtProvider jwtProvider;
+    @Mock JwtProperties jwtProperties;
+
+    @InjectMocks AuthService authService;
+
+    @Test
+    void signup_save단계_DataIntegrityViolation은_LOGIN_ID_DUPLICATED로_변환된다() {
+        // 사전 check 통과 — race window: 다른 트랜잭션이 그 사이 INSERT
+        when(memberRepository.existsByLoginId("chanwoo90")).thenReturn(false);
+        when(memberRepository.save(any(Member.class)))
+                .thenThrow(new DataIntegrityViolationException(
+                        "Duplicate entry 'chanwoo90' for key 'uq_member_login'"));
+
+        SignupRequest req = new SignupRequest("chanwoo90", "P@ssw0rd!", "찬우");
+
+        assertThatThrownBy(() -> authService.signup(req))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.LOGIN_ID_DUPLICATED));
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -1,9 +1,11 @@
 package com.todayway.backend.common.exception;
 
+import com.todayway.backend.auth.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -16,12 +18,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WebMvcTest(
+        controllers = GlobalExceptionHandlerTest.DummyController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class
+)
 @Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.DummyController.class})
 class GlobalExceptionHandlerTest {
 
     @Autowired
     MockMvc mockMvc;
+
+    // WebMvcConfig가 슬라이스에 등록되며 CurrentMemberArgumentResolver → MemberRepository 의존을 요구.
+    // 이 테스트는 web 계층만 검증하므로 mock으로 대체.
+    @MockBean
+    MemberRepository memberRepository;
 
     @Test
     void BusinessException은_ErrorCode의_status와_code_message로_변환된다() throws Exception {


### PR DESCRIPTION
## 변경 사항
- **auth 도메인 신규**: Member/RefreshToken 엔티티, MemberRepository/RefreshTokenRepository, AuthService, AuthController
- **3 엔드포인트**: `POST /api/v1/auth/{signup,login,logout}` (api-spec §2.1·§2.2·§2.3 v1.1.5)
- **DTO**: SignupRequest/LoginRequest/LogoutRequest + SignupResponse/LoginResponse
- **common.util**: MemberIdFormatter (`mem_` prefix 양방향), Sha256Hasher (refresh token hash)
- **common.web**: CurrentMemberArgumentResolver + WebMvcConfig (Step 2에서 미룬 것)
- **통합 테스트**: AuthControllerIntegrationTest — signup → 중복 → login → wrong pw → ghost loginId → logout → DB 검증

## Step 2 회귀 fix (4건)
Step 3 통합 테스트 작성 중 발견된 Step 2 인프라 결함을 같이 수정:

- **JpaAuditingConfig**: OffsetDateTime DateTimeProvider Bean 추가
- **JwtProvider**: `jti`(JWT ID) claim 추가 — access/refresh 둘 다 (같은 초 발급 시 token 동일 → unique 위반 방지)
- **Member/RefreshToken**: `columnDefinition = "CHAR(N)"` 명시 (CHAR vs VARCHAR mismatch 방지)
- **GlobalExceptionHandlerTest**: `controllers = DummyController.class` 제한 + `@MockBean MemberRepository`

## 환경 정비
- testcontainers 1.21.4 BOM 핀 — Docker Engine 29.x ↔ docker-java SDK 호환

## 셀프 리뷰 후속 fix (2026-04-29, 5 commit)

본인 셀프 리뷰 코멘트 7건 처리 + 의사결정 4·5 정정 (명세 §2.3 v1.1.5):

| commit | 내용 |
|---|---|
| `b678326` | **fix(backend): KST 시간대 명시 (명세 §1.4)** — AuthService/RefreshToken (MUST FIX 1) |
| `4711705` | **fix(backend): signup race fallback (LOGIN_ID_DUPLICATED)** + AuthServiceTest 신규 (MUST FIX 2) |
| `951e5c1` | **fix(backend): logout 명세 §2.3 정합 — body refreshToken + 단일 폐기** (의사결정 4·5 정정) |
| `d4ad56e` | **docs(backend): RefreshToken BaseEntity 미상속 의도 javadoc** (SHOULD FIX 4) |
| `3da665c` | **test(backend): 통합 테스트 signup 토큰 비폐기 회귀 가드** (의사결정 5번 회귀 방지) |

### 셀프 리뷰 코멘트 처리 결과

- 🔴 MUST FIX 1 (KST 시간대) → ✅ `b678326`
- 🔴 MUST FIX 2 (signup race) → ✅ `4711705`
- 🟡 SHOULD FIX 3 (Principal 일관성) → ✅ **자연 해소** — logout이 더 이상 `@AuthenticationPrincipal` 미사용. Step 4 `/members/me` 작성 시 `@CurrentMember` 활용
- 🟡 SHOULD FIX 4 (RefreshToken javadoc) → ✅ `d4ad56e`
- 🟢 NICE TO HAVE 5 (logout 후 access token 검증) → ⏳ Step 4
- 🟢 NICE TO HAVE 6 (Member.getDeletedAt 노출 최소화) → ⏳ P1
- 🟢 NICE TO HAVE 7 (ResponseEntity vs ApiResponse 일관성) → 명세 직역, 문서화 차원

### 의사결정 4·5 정정 — RFC 7009로 환원

PR 생성 시점에 *명세 §2.3 직역*(인증 필요 / body 없음 / 모든 활성 폐기)으로 단기 우회했으나, 셀프 리뷰에서 *"명세 갱신 비용 회피용 우회"*임을 재확인. 본래 결정(step3-진행.md L131-132)은 RFC 7009 정합:

- 4번 = **B (Request body)** — body의 refreshToken으로 소유 증명
- 5번 = **A (전달된 1개만)** — 단일 디바이스 logout. logout-all은 P1 별건 엔드포인트

장기 가치(표준 정합 / 다중 디바이스 additive 확장 / UX) 측면에서 (B/A)가 우세 → **명세 §2.3을 v1.1.5로 갱신** + 코드를 그 정합으로 fix.

명세 v1.1.5 변경:
- §2.3 logout — 인증 필요 → 불필요 (RFC 7009), body 없음 → `{ "refreshToken": "..." }`, 모든 폐기 → 1개 폐기 + 멱등 처리
- §1.8 logout 인증 ✓ → ✗
- §0.1 변경 이력 v1.1.5 추가

## 테스트
- [x] `./gradlew build` 통과
- [x] `./gradlew test` 24건 전부 통과 (race 단위 테스트 1건 추가)
- [x] 본인 PC 통합 테스트 검증 완료 (Windows + Docker Desktop 29.4.1)
- [x] CI는 Step 1부터 Linux unix socket으로 정상 동작

## 명세 참조
- api-spec **v1.1.5** §2 (인증), §1.6 (ErrorCode), §1.7 (식별자), §1.4 (시간/타임존)
- BACKEND_CONTEXT §11 (패키지 구조), §18 (자주 하는 실수)

## P1 후속 작업
- E-3-1: refresh token rotation (v1.2 refresh 엔드포인트 도입 시)
- E-3-3: password 한글 입력 시 BCrypt 72바이트 한도 안전 처리
- E-3-4: **logout-all 별도 엔드포인트** (`POST /auth/logout-all`) — 의사결정 5번 단일 폐기의 자연 보완

## Future considerations (코드 주석에 박지 않은 미래 위험)

- **`AuthService.signup()` race catch 분기**: 현재 모든 `DataIntegrityViolationException`을 `LOGIN_ID_DUPLICATED`로 매핑. Member의 unique 제약은 `uq_member_login` 단 1개라 정확. 미래에 다른 unique(예: email) 추가 시 catch 분기 검토 필요 (silent bug 방지). MySQL 메시지 형식 검사는 드라이버 결합 우려로 회피.
- **KST 인프라 정책 — Step 5 의제**: 현재 `private static final ZoneId KST`를 AuthService/RefreshToken 각 클래스에 직접. Step 5 진입 전 `hibernate.jdbc.time_zone: Asia/Seoul` + Clock 주입 + KstTime 유틸 위치를 팀 차원에서 일괄 결정 권고.
- **logout 인터페이스 클라이언트 영향**: v1.1.5에서 헤더 → body로 변경. 프론트엔드 작업 시 명세 §2.3 (v1.1.5) 따라야 함.

## 별건 후속 (이번 PR 범위 밖)
- 명세 §12.3 도메인 분담 outdated (push가 황찬우 표기, 실제 이상진) → v1.1.6 패치 권장
- tasks.md §3.5 Logout 코드 예시 outdated → 명세 §2.3 v1.1.5 부합으로 갱신 권장
- Step 5 schedule_uid CHAR(26) 작성 시 같은 `columnDefinition` 패턴 (BACKEND_CONTEXT §18 흡수 가치)