### PR TITLE
feat(backend): step4 — member 도메인 (GET/PATCH/DELETE me)

### DIFF
--- a/backend/src/main/java/com/todayway/backend/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/todayway/backend/auth/repository/RefreshTokenRepository.java
@@ -2,10 +2,23 @@ package com.todayway.backend.auth.repository;
 
 import com.todayway.backend.auth.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    /**
+     * 멤버의 활성 refresh token 일괄 폐기.
+     * 사용처: password 변경 시 (의사결정 3), 회원 탈퇴 시 (의사결정 4).
+     * 미래: logout-all 엔드포인트 (E-3-4).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE RefreshToken rt SET rt.revokedAt = :now WHERE rt.memberId = :memberId AND rt.revokedAt IS NULL")
+    int revokeAllActiveByMemberId(@Param("memberId") Long memberId, @Param("now") OffsetDateTime now);
 }

--- a/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/todayway/backend/auth/service/AuthService.java
@@ -1,13 +1,13 @@
 package com.todayway.backend.auth.service;
 
-import com.todayway.backend.auth.domain.Member;
 import com.todayway.backend.auth.domain.RefreshToken;
+import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.auth.dto.LoginRequest;
 import com.todayway.backend.auth.dto.LoginResponse;
 import com.todayway.backend.auth.dto.SignupRequest;
 import com.todayway.backend.auth.dto.SignupResponse;
-import com.todayway.backend.auth.repository.MemberRepository;
 import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.member.repository.MemberRepository;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import com.todayway.backend.common.jwt.JwtProperties;

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.todayway.backend.common.web;
 
-import com.todayway.backend.auth.domain.Member;
-import com.todayway.backend.auth.repository.MemberRepository;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/todayway/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/com/todayway/backend/member/controller/MemberController.java
@@ -1,0 +1,43 @@
+package com.todayway.backend.member.controller;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.dto.MemberResponse;
+import com.todayway.backend.member.dto.MemberUpdateRequest;
+import com.todayway.backend.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMe(@CurrentMember Member member) {
+        return ResponseEntity.ok(ApiResponse.of(memberService.getMe(member)));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> update(
+            @CurrentMember Member member,
+            @RequestBody @Valid MemberUpdateRequest req) {
+        return ResponseEntity.ok(ApiResponse.of(memberService.update(member, req)));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> delete(@CurrentMember Member member) {
+        memberService.softDelete(member);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/member/domain/Member.java
+++ b/backend/src/main/java/com/todayway/backend/member/domain/Member.java
@@ -1,4 +1,4 @@
-package com.todayway.backend.auth.domain;
+package com.todayway.backend.member.domain;
 
 import com.todayway.backend.common.entity.BaseEntity;
 import com.todayway.backend.common.ulid.UlidGenerator;

--- a/backend/src/main/java/com/todayway/backend/member/domain/Member.java
+++ b/backend/src/main/java/com/todayway/backend/member/domain/Member.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @Getter
 @Entity
@@ -22,6 +23,8 @@ import java.time.OffsetDateTime;
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");  // 명세 §1.4
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,6 +60,20 @@ public class Member extends BaseEntity {
     void prePersist() {
         if (memberUid == null) {
             memberUid = UlidGenerator.generate();
+        }
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public void softDelete() {
+        if (deletedAt == null) {
+            deletedAt = OffsetDateTime.now(KST);
         }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/member/dto/MemberResponse.java
+++ b/backend/src/main/java/com/todayway/backend/member/dto/MemberResponse.java
@@ -1,0 +1,22 @@
+package com.todayway.backend.member.dto;
+
+import com.todayway.backend.common.util.MemberIdFormatter;
+import com.todayway.backend.member.domain.Member;
+
+import java.time.OffsetDateTime;
+
+public record MemberResponse(
+        String memberId,
+        String loginId,
+        String nickname,
+        OffsetDateTime createdAt
+) {
+    public static MemberResponse from(Member member) {
+        return new MemberResponse(
+                MemberIdFormatter.format(member.getMemberUid()),
+                member.getLoginId(),
+                member.getNickname(),
+                member.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/member/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/com/todayway/backend/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.todayway.backend.member.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * PATCH /members/me 부분 업데이트 — null 필드는 무시 (의사결정 2).
+ * 둘 다 null이면 success no-op (200 OK + 변경 없음, 명세 §3.2 강제 X).
+ * loginId는 명세 §3.2상 수정 불가 — 본 record에 포함 X.
+ */
+public record MemberUpdateRequest(
+        @Size(min = 2, max = 20, message = "nickname은 2~20자")
+        String nickname,
+
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_]).{8,72}$",
+                 message = "password는 영문+숫자+특수문자 포함 8~72자")
+        String password
+) {}

--- a/backend/src/main/java/com/todayway/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/todayway/backend/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.todayway.backend.auth.repository;
+package com.todayway.backend.member.repository;
 
-import com.todayway.backend.auth.domain.Member;
+import com.todayway.backend.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.todayway.backend.member.service;
 
 import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
 import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.dto.MemberResponse;
 import com.todayway.backend.member.dto.MemberUpdateRequest;
+import com.todayway.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,24 +22,31 @@ public class MemberService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+    private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
 
     public MemberResponse getMe(Member member) {
+        // getMe는 단순 응답 — detached 객체의 getter만 호출하므로 재조회 불필요
         return MemberResponse.from(member);
     }
 
     @Transactional
     public MemberResponse update(Member member, MemberUpdateRequest req) {
+        // CurrentMemberArgumentResolver가 반환한 Member는 트랜잭션 외부에서 조회된 detached entity.
+        // 변경을 dirty marking으로 반영시키려면 트랜잭션 내에서 재조회해 managed 상태로 attach.
+        Member managed = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
         if (req.nickname() != null) {
-            member.updateNickname(req.nickname());
+            managed.updateNickname(req.nickname());
         }
         if (req.password() != null) {
-            member.updatePasswordHash(passwordEncoder.encode(req.password()));
+            managed.updatePasswordHash(passwordEncoder.encode(req.password()));
             // 의사결정 3 — password 변경 시 모든 활성 refresh token 폐기 (보안 ↑, 다른 디바이스 강제 로그아웃)
-            refreshTokenRepository.revokeAllActiveByMemberId(member.getId(), OffsetDateTime.now(KST));
+            refreshTokenRepository.revokeAllActiveByMemberId(managed.getId(), OffsetDateTime.now(KST));
         }
-        return MemberResponse.from(member);
+        return MemberResponse.from(managed);
     }
 
     @Transactional
@@ -46,7 +56,9 @@ public class MemberService {
         //   ✅ refresh_token.revoked_at 일괄
         //   ⏳ schedule.deleted_at — Step 5 진입 시 ScheduleRepository 주입 + cascade 추가
         //   ⏳ push_subscription.revoked_at — 이상진 Step 7 진입 시 추가
-        member.softDelete();
-        refreshTokenRepository.revokeAllActiveByMemberId(member.getId(), OffsetDateTime.now(KST));
+        Member managed = memberRepository.findById(member.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        managed.softDelete();
+        refreshTokenRepository.revokeAllActiveByMemberId(managed.getId(), OffsetDateTime.now(KST));
     }
 }

--- a/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
@@ -1,0 +1,52 @@
+package com.todayway.backend.member.service;
+
+import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.dto.MemberResponse;
+import com.todayway.backend.member.dto.MemberUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberResponse getMe(Member member) {
+        return MemberResponse.from(member);
+    }
+
+    @Transactional
+    public MemberResponse update(Member member, MemberUpdateRequest req) {
+        if (req.nickname() != null) {
+            member.updateNickname(req.nickname());
+        }
+        if (req.password() != null) {
+            member.updatePasswordHash(passwordEncoder.encode(req.password()));
+            // 의사결정 3 — password 변경 시 모든 활성 refresh token 폐기 (보안 ↑, 다른 디바이스 강제 로그아웃)
+            refreshTokenRepository.revokeAllActiveByMemberId(member.getId(), OffsetDateTime.now(KST));
+        }
+        return MemberResponse.from(member);
+    }
+
+    @Transactional
+    public void softDelete(Member member) {
+        // 의사결정 4 (가-1) — Step 4 시점 가능한 cascade 2개:
+        //   ✅ Member.deleted_at (자체)
+        //   ✅ refresh_token.revoked_at 일괄
+        //   ⏳ schedule.deleted_at — Step 5 진입 시 ScheduleRepository 주입 + cascade 추가
+        //   ⏳ push_subscription.revoked_at — 이상진 Step 7 진입 시 추가
+        member.softDelete();
+        refreshTokenRepository.revokeAllActiveByMemberId(member.getId(), OffsetDateTime.now(KST));
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/todayway/backend/auth/service/AuthServiceTest.java
@@ -1,8 +1,8 @@
 package com.todayway.backend.auth.service;
 
-import com.todayway.backend.auth.domain.Member;
 import com.todayway.backend.auth.dto.SignupRequest;
-import com.todayway.backend.auth.repository.MemberRepository;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
 import com.todayway.backend.auth.repository.RefreshTokenRepository;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;

--- a/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -1,6 +1,6 @@
 package com.todayway.backend.common.exception;
 
-import com.todayway.backend.auth.repository.MemberRepository;
+import com.todayway.backend.member.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;

--- a/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -30,7 +30,7 @@ class GlobalExceptionHandlerTest {
 
     // WebMvcConfig가 슬라이스에 등록되며 CurrentMemberArgumentResolver → MemberRepository 의존을 요구.
     // 이 테스트는 web 계층만 검증하므로 mock으로 대체.
-    @MockBean
+    @MockitoBean
     MemberRepository memberRepository;
 
     @Test

--- a/backend/src/test/java/com/todayway/backend/member/MemberControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/member/MemberControllerIntegrationTest.java
@@ -1,0 +1,127 @@
+package com.todayway.backend.member;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.domain.RefreshToken;
+import com.todayway.backend.auth.dto.LogoutRequest;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.auth.repository.RefreshTokenRepository;
+import com.todayway.backend.common.util.Sha256Hasher;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MemberControllerIntegrationTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void member_도메인_전체_흐름_및_회귀_가드() throws Exception {
+        // (1) signup → 토큰 발급 (Step 3 흐름 재사용)
+        SignupRequest signupReq = new SignupRequest("chanwoo90", "P@ssw0rd!", "찬우");
+        String signupResp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupReq)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode signupNode = objectMapper.readTree(signupResp).path("data");
+        String accessToken = signupNode.path("accessToken").asText();
+        String signupRefreshToken = signupNode.path("refreshToken").asText();
+        String memberId = signupNode.path("memberId").asText();
+        String authHeader = "Bearer " + accessToken;
+
+        // (2) GET /members/me — 본인 정보 조회 (명세 §3.1)
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberId").value(memberId))
+                .andExpect(jsonPath("$.data.loginId").value("chanwoo90"))
+                .andExpect(jsonPath("$.data.nickname").value("찬우"))
+                .andExpect(jsonPath("$.data.createdAt").exists());
+
+        // (A+ 1) 인증 헤더 누락 → 401 UNAUTHORIZED (회귀 가드 — JwtFilter chain → SecurityConfig entrypoint)
+        mockMvc.perform(get("/api/v1/members/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+
+        // (3) PATCH nickname만 변경 → 200 (명세 §3.2)
+        mockMvc.perform(patch("/api/v1/members/me")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\":\"찬우개명\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("찬우개명"));
+
+        // (A+ 4) PATCH body에 loginId 포함 — Jackson record unknown field 자동 무시 (loginId 수정 X 회귀 가드)
+        mockMvc.perform(patch("/api/v1/members/me")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"loginId\":\"hacker99\",\"nickname\":\"찬우3\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.loginId").value("chanwoo90"))   // 기존 유지
+                .andExpect(jsonPath("$.data.nickname").value("찬우3"));      // nickname만 갱신
+
+        // (4) PATCH password 변경 → 200 + 의사결정 3: signup 시 받은 refresh token 모두 폐기
+        mockMvc.perform(patch("/api/v1/members/me")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\":\"NewP@ss123!\"}"))
+                .andExpect(status().isOk());
+
+        // (A+ 3) 의사결정 3 회귀 가드 — password 변경으로 signup refresh token이 폐기됐어야 함
+        String signupTokenHash = Sha256Hasher.hash(signupRefreshToken);
+        RefreshToken signupSavedToken = refreshTokenRepository.findByTokenHash(signupTokenHash).orElseThrow();
+        assertThat(signupSavedToken.getRevokedAt()).isNotNull();
+
+        // 폐기된 token에 logout 호출 시 silent 204 (RFC 7009 멱등성)
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LogoutRequest(signupRefreshToken))))
+                .andExpect(status().isNoContent());
+
+        // (5) DELETE /members/me → 204 소프트 삭제 (명세 §3.3)
+        mockMvc.perform(delete("/api/v1/members/me")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isNoContent());
+
+        // (A+ 2) 탈퇴 후 동일 access token 사용 시 → 404 MEMBER_NOT_FOUND
+        //   JWT 자체는 유효하지만 Member.deleted_at IS NULL 필터로 Resolver가 못 찾음
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("MEMBER_NOT_FOUND"));
+    }
+}


### PR DESCRIPTION
## 변경 사항

명세 §3 회원 도메인 — `/api/v1/members/me` 3 엔드포인트 (GET/PATCH/DELETE).
Step 3에서 만든 `@CurrentMember` Resolver 첫 사용처.

- **member 패키지 신규**: MemberController / MemberService / MemberResponse / MemberUpdateRequest
- **Member 위치 이동**: `auth/domain/Member` → `member/domain/Member` (의사결정 1, 나)
- **Member 비즈니스 메서드**: KST 상수 + updateNickname/updatePasswordHash/softDelete (멱등 가드)
- **RefreshTokenRepository**: `revokeAllActiveByMemberId` 부활 — Step 3 PR #4에서 의사결정 5(단일 폐기) 정합으로 제거됐던 메서드. password 변경/탈퇴 cascade에 사용
- **통합 테스트** `MemberControllerIntegrationTest`: A+ 4 케이스 보강
- **셀프 리뷰 fix**: `@CurrentMember` detached entity attach (commit 4)
- **deprecation 정리**: `@MockBean` → `@MockitoBean` (commit 5, CI 5 warnings 제거)

## 5 commit 분할

| # | commit | 내용 |
|---|---|---|
| 1 | `92a6f1d` | **refactor**: Member 도메인 위치 이동 — auth → member 패키지 (git mv + 5 의존자 import 갱신) |
| 2 | `35055c7` | **feat**: Member 비즈니스 메서드 + RefreshTokenRepository 일괄 폐기 부활 |
| 3 | `0f4e3f9` | **feat**: step4 — member 도메인 (DTO + Service + Controller + 통합 테스트) |
| 4 | `b3491ee` | **fix**: `@CurrentMember` detached entity attach (셀프 리뷰 발견) |
| 5 | `4021826` | **chore**: `@MockBean` → `@MockitoBean` 마이그레이션 (Spring Boot 3.4+ 정합) |

## 의사결정 정합 (Step 4 게이트 [3] 응답 7건)

| # | 결정 | 코드 위치 |
|---|---|---|
| 1 | (나) `member/domain/Member` 이동 | commit 1, 5 의존자 import |
| 2 | (가) nullable record + null 체크 | `MemberUpdateRequest`, `MemberService.update` if 분기 |
| 3 | (가) password 변경 시 모든 활성 token 폐기 | `MemberService.update` + 통합 테스트 (A+ 3) |
| 4 | (가-1) Step 4 시점 cascade 2개 (Member.deleted_at + refresh_token) | `MemberService.softDelete` + 통합 테스트 (A+ 2) |
| 5 | (가) record `@Size`/`@Pattern` only | `MemberUpdateRequest` |
| 6 | E-3-2 별건 PR / E-3-5 데모 직전 | tasks.md 부록 C 환기 줄 추가 (별건) |
| 7 | (A+) 4 케이스 보강 | 통합 테스트 |

## 셀프 리뷰 발견 (commit 4)

`@CurrentMember`로 받은 Member는 MVC argument resolution 단계 (트랜잭션 외부)에서 조회된 **detached entity**. Service `@Transactional` 메서드에 들어가도 자동 attach 안 됨 → setter 호출해도 dirty marking 안 됨 → DB 미반영.

- 컴파일/단위 테스트 PASS, 통합 테스트 (A+ 2 탈퇴 후 GET → 404) 시나리오에서 발견.
- 의사결정 3 검증 (A+ 3)이 처음에도 통과한 이유: `revokeAllActiveByMemberId`는 `@Modifying @Query` 직접 UPDATE라 영속성 컨텍스트 우회.
- **해결**: MemberService의 update / softDelete에서 `findById(member.getId())`로 재조회해 managed 상태로 attach.

## 첫 CI 후 deprecation 정리 (commit 5)

CI 출력에 `@MockBean ... deprecated and marked for removal` × 5 warnings 발생.
Spring Boot 3.4부터 `org.springframework.boot.test.mock.mockito.MockBean` deprecated → 신 API `org.springframework.test.context.bean.override.mockito.MockitoBean`로 마이그레이션. 기능 동일.

## 테스트

- [x] `./gradlew compileJava compileTestJava` BUILD SUCCESSFUL
- [x] `./gradlew test` 전체 PASS — 단위(Ulid/Jwt×2/AuthService/GlobalExceptionHandler/KakaoLocal/Odsay) + 통합(BackendApplicationTests/AuthControllerIntegrationTest/MemberControllerIntegrationTest)
- [x] 통합 테스트 (A+) 4 케이스 모두 검증
- [x] commit 5 후 deprecation 5 warnings 제거 검증

## 명세 참조

- api-spec **v1.1.5** §3 (회원), §1.4 KST, §1.6 ErrorCode, §1.7 mem_ prefix, §1.3 응답 포맷
- BACKEND_CONTEXT §11 (패키지 구조), §18 (자주 하는 실수)

## 후속 작업 (P1+, 머지 후)

- **Step 5 schedule cascade 추가** (의사결정 4 가-1 미완분) — `MemberService.softDelete`에 schedule cascade 한 줄. tasks.md 환기 박힘.
- **이상진 Step 7 push cascade** — push_subscription cascade. 이상진 도메인.
- **E-3-2 별건 PR** — logout 멱등 통합 테스트 보강 (Step 4와 무관, 별 PR로 처리).
- **E-3-5 데모 직전** — CORS 정책 명시. tasks.md 부록 C 환기 박힘.
- **Step 5 schedule_uid CHAR(26)** — patterns 패턴 3 적용 (자동 환기됨).

## 별건 (이번 PR 범위 밖)

- tasks.md 부록 A에 안티패턴 추가됨 (`@CurrentMember` detached entity 변경) — 메모리 폴더 (PR 외).