### PR TITLE
refactor(backend): step4 외부 리뷰 후속 β — Resolver String memberUid 마이그레이션 + 명세 v1.1.7 SSoT 단일화

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.6-MVP
-> **최종 수정**: 2026-04-30 (황찬우 — Step 4 외부 리뷰 흡수: ErrorCode fallback 명시 / JWT sub claim 명시 / password 정책 정합 / PATCH 둘 다 null → 400 / token 폐기 비고 / DELETE 멱등성 비고)
+> **버전**: v1.1.7-MVP
+> **최종 수정**: 2026-04-30 (황찬우 — β PR Resolver 마이그레이션: §1.7 Resolver 동작 단순화 명시 + §3.3 탈퇴 회원 응답 404 → 401)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -23,6 +23,7 @@
 | v1.1.4 | 2026-04-28 | 외부 API 매핑 보강 (이상진): ODsay→Route 매핑표 (§6.1), Kakao 응답 변환·provider 변환·query_hash 정규화 (§8.1), `EXTERNAL_AUTH_MISCONFIGURED` ErrorCode 추가 (§1.6) |
 | **v1.1.5** | **2026-04-29** | **§2.3 logout 인터페이스 RFC 7009 정합 — Authorization 헤더 인증 → body의 refreshToken (소유 증명), 멤버 모든 활성 토큰 폐기 → 전달된 1개만 폐기 (단일 디바이스). logout-all은 P1 별도 엔드포인트로 분리. §1.8 logout 인증 ✓ → ✗** |
 | **v1.1.6** | **2026-04-30** | **§1.6 `INTERNAL_SERVER_ERROR` 행 추가(fallback 명시), §1.7 JWT sub claim raw ULID 명시, §3.2 password 정규식 §2.1 정합 + 둘 다 null/생략 → 400 + password 변경 시 token 폐기 비고, §3.3 DELETE 멱등성 비고. (Step 4 PR #5 이상진 리뷰 보강 5건 + Q1-B/Q8-1 흡수)** |
+| **v1.1.7** | **2026-04-30** | **§1.7 Resolver 동작 정정 — `Authentication.getName()`으로 raw `member_uid` 반환만(DB 호출 X), Service가 `findByMemberUid` 1회 조회. §3.3 탈퇴 회원 응답: 404 `MEMBER_NOT_FOUND` → **401 `UNAUTHORIZED`** (Service 부재 시 응답). β PR Resolver 마이그레이션 (이상진 PR #5 I-1 + claude.ai P1).** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -143,9 +144,9 @@ Authorization: Bearer {accessToken}
 | `sch_` | 일정 | `schedule.schedule_uid` |
 | `sub_` | 푸시 구독 | `push_subscription.subscription_uid` |
 
-#### 비고 — JWT sub claim (v1.1.6 추가)
+#### 비고 — JWT sub claim (v1.1.6 / v1.1.7 정정)
 
-JWT의 `sub` claim에는 `member.member_uid` 값(prefix 없는 raw ULID 26자, Crockford Base32)이 박힌다. 외부 응답 ID `mem_<uid>`의 `mem_` prefix는 응답 직렬화 단계에서 부착되며, JWT subject 자체에는 포함되지 않는다. 서버 측 `CurrentMemberArgumentResolver`는 `Authentication.getName()`으로 raw `member_uid`를 직접 받아 `findByMemberUid`로 조회한다.
+JWT의 `sub` claim에는 `member.member_uid` 값(prefix 없는 raw ULID 26자, Crockford Base32)이 박힌다. 외부 응답 ID `mem_<uid>`의 `mem_` prefix는 응답 직렬화 단계에서 부착되며, JWT subject 자체에는 포함되지 않는다. 서버 측 `CurrentMemberArgumentResolver`는 `Authentication.getName()`으로 raw `member_uid`를 반환만 한다 (DB 호출 X). Service가 진입 시 `findByMemberUid`로 1회 조회 — 부재 시 401 `UNAUTHORIZED`.
 
 ### 1.8 엔드포인트 한눈에 보기
 
@@ -360,9 +361,9 @@ JWT의 `sub` claim에는 `member.member_uid` 값(prefix 없는 raw ULID 26자, C
 - 소프트 삭제: `member.deleted_at = NOW()`
 - 관련 `schedule`, `push_subscription`은 FK ON DELETE CASCADE이지만 소프트 삭제 시점엔 별도 로직으로 deleted_at/revoked_at 갱신
 
-#### 비고 — 멱등성 (v1.1.6 추가)
+#### 비고 — 멱등성 (v1.1.6 / v1.1.7 정정)
 
-본 API는 인증 토큰의 회원이 이미 탈퇴 처리된 경우(`deleted_at IS NOT NULL`) `CurrentMemberArgumentResolver`에서 회원 조회 실패 → **404 `MEMBER_NOT_FOUND`** 응답. RFC 9110의 일반 DELETE 멱등성과 달리, 본 API는 인증 정책 우선 설계의 결과로 두 번째 DELETE 요청은 404로 응답된다.
+본 API는 인증 토큰의 회원이 이미 탈퇴 처리된 경우(`deleted_at IS NOT NULL`) Service의 `findByMemberUid`에서 회원 조회 실패 → **401 `UNAUTHORIZED`** 응답. RFC 9110의 일반 DELETE 멱등성과 달리, 본 API는 인증 정책 우선 설계의 결과로 두 번째 DELETE 요청은 401로 응답된다 (JWT는 유효하지만 가리키는 회원이 무효).
 
 ---
 

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -31,7 +31,7 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !(auth.getPrincipal() instanceof String memberUid)) {
+        if (auth == null || !(auth.getPrincipal() instanceof String memberUid) || memberUid.isBlank()) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
         return memberUid;

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -1,10 +1,7 @@
 package com.todayway.backend.common.web;
 
-import com.todayway.backend.member.domain.Member;
-import com.todayway.backend.member.repository.MemberRepository;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,16 +11,18 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+/**
+ * @CurrentMember 가 붙은 String 파라미터에 SecurityContext의 raw memberUid 주입.
+ * DB 호출 0회 — Authentication.getName() 만 호출. 멤버 존재 검증은 Service의 findByMemberUid 책임.
+ * 명세 §1.7: JWT sub claim = prefix 없는 raw ULID 26자.
+ */
 @Component
-@RequiredArgsConstructor
 public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(CurrentMember.class)
-                && parameter.getParameterType().equals(Member.class);
+                && parameter.getParameterType().equals(String.class);
     }
 
     @Override
@@ -35,7 +34,6 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
         if (auth == null || !(auth.getPrincipal() instanceof String memberUid)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
-        return memberRepository.findByMemberUid(memberUid)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        return memberUid;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/com/todayway/backend/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.todayway.backend.member.controller;
 
 import com.todayway.backend.common.response.ApiResponse;
 import com.todayway.backend.common.web.CurrentMember;
-import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.dto.MemberResponse;
 import com.todayway.backend.member.dto.MemberUpdateRequest;
 import com.todayway.backend.member.service.MemberService;
@@ -24,20 +23,20 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<MemberResponse>> getMe(@CurrentMember Member member) {
-        return ResponseEntity.ok(ApiResponse.of(memberService.getMe(member)));
+    public ResponseEntity<ApiResponse<MemberResponse>> getMe(@CurrentMember String memberUid) {
+        return ResponseEntity.ok(ApiResponse.of(memberService.getMe(memberUid)));
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<MemberResponse>> update(
-            @CurrentMember Member member,
+            @CurrentMember String memberUid,
             @RequestBody @Valid MemberUpdateRequest req) {
-        return ResponseEntity.ok(ApiResponse.of(memberService.update(member, req)));
+        return ResponseEntity.ok(ApiResponse.of(memberService.update(memberUid, req)));
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<Void> delete(@CurrentMember Member member) {
-        memberService.softDelete(member);
+    public ResponseEntity<Void> delete(@CurrentMember String memberUid) {
+        memberService.softDelete(memberUid);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
@@ -28,41 +28,40 @@ public class MemberService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public MemberResponse getMe(Member member) {
-        // getMe는 단순 응답 — detached 객체의 getter만 호출하므로 재조회 불필요
-        return MemberResponse.from(member);
+    public MemberResponse getMe(String memberUid) {
+        Member m = memberRepository.findByMemberUid(memberUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+        return MemberResponse.from(m);
     }
 
     @Transactional
-    public MemberResponse update(Member member, MemberUpdateRequest req) {
-        // CurrentMemberArgumentResolver가 반환한 Member는 트랜잭션 외부에서 조회된 detached entity.
-        // 변경을 dirty marking으로 반영시키려면 트랜잭션 내에서 재조회해 managed 상태로 attach.
-        Member managed = memberRepository.findById(member.getId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    public MemberResponse update(String memberUid, MemberUpdateRequest req) {
+        Member m = memberRepository.findByMemberUid(memberUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
 
         if (req.nickname() != null) {
-            managed.updateNickname(req.nickname());
+            m.updateNickname(req.nickname());
         }
         if (req.password() != null) {
-            managed.updatePasswordHash(passwordEncoder.encode(req.password()));
+            m.updatePasswordHash(passwordEncoder.encode(req.password()));
             // 의사결정 3 — password 변경 시 모든 활성 refresh token 폐기 (보안 ↑, 다른 디바이스 강제 로그아웃)
-            int revoked = refreshTokenRepository.revokeAllActiveByMemberId(managed.getId(), OffsetDateTime.now(KST));
-            log.info("revoked {} active refresh tokens for memberId={} (password change)", revoked, managed.getId());
+            int revoked = refreshTokenRepository.revokeAllActiveByMemberId(m.getId(), OffsetDateTime.now(KST));
+            log.info("revoked {} active refresh tokens for memberId={} (password change)", revoked, m.getId());
         }
-        return MemberResponse.from(managed);
+        return MemberResponse.from(m);
     }
 
     @Transactional
-    public void softDelete(Member member) {
+    public void softDelete(String memberUid) {
         // 의사결정 4 (가-1) — Step 4 시점 가능한 cascade 2개:
         //   ✅ Member.deleted_at (자체)
         //   ✅ refresh_token.revoked_at 일괄
         //   ⏳ schedule.deleted_at — Step 5 진입 시 ScheduleRepository 주입 + cascade 추가
         //   ⏳ push_subscription.revoked_at — 이상진 Step 7 진입 시 추가
-        Member managed = memberRepository.findById(member.getId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        managed.softDelete();
-        int revoked = refreshTokenRepository.revokeAllActiveByMemberId(managed.getId(), OffsetDateTime.now(KST));
-        log.info("revoked {} active refresh tokens for memberId={} (soft delete)", revoked, managed.getId());
+        Member m = memberRepository.findByMemberUid(memberUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+        m.softDelete();
+        int revoked = refreshTokenRepository.revokeAllActiveByMemberId(m.getId(), OffsetDateTime.now(KST));
+        log.info("revoked {} active refresh tokens for memberId={} (soft delete)", revoked, m.getId());
     }
 }

--- a/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
@@ -1,0 +1,64 @@
+package com.todayway.backend.common.web;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Resolver 단위 테스트 (claude.ai PR #7 리뷰 P2 흡수).
+ * SecurityFilterChain의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
+ */
+class CurrentMemberArgumentResolverTest {
+
+    private final CurrentMemberArgumentResolver resolver = new CurrentMemberArgumentResolver();
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void resolveArgument_whenAuthenticationNull_throwsUnauthorized() {
+        SecurityContextHolder.clearContext();
+        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    void resolveArgument_whenPrincipalNotString_throwsUnauthorized() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(new Object(), null, List.of()));
+        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    void resolveArgument_whenMemberUidBlank_throwsUnauthorized() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("   ", null, List.of()));
+        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    void resolveArgument_whenValidPrincipal_returnsMemberUid() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("01HAA0123456789ABCDEFGHJK", null, List.of()));
+        Object result = resolver.resolveArgument(null, null, null, null);
+        assertThat(result).isEqualTo("01HAA0123456789ABCDEFGHJK");
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/member/MemberControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/member/MemberControllerIntegrationTest.java
@@ -119,12 +119,13 @@ class MemberControllerIntegrationTest {
                         .header("Authorization", authHeader))
                 .andExpect(status().isNoContent());
 
-        // (A+ 2) 탈퇴 후 동일 access token 사용 시 → 404 MEMBER_NOT_FOUND
-        //   JWT 자체는 유효하지만 Member.deleted_at IS NULL 필터로 Resolver가 못 찾음
+        // (A+ 2) 탈퇴 후 동일 access token 사용 시 → 401 UNAUTHORIZED (β PR 후 명세 §3.3 v1.1.7)
+        //   JWT 자체는 유효하지만 Service의 findByMemberUid가 @SQLRestriction("deleted_at IS NULL")로
+        //   None 반환 → throw BusinessException(UNAUTHORIZED). Resolver는 raw memberUid 반환만, DB 호출 X.
         mockMvc.perform(get("/api/v1/members/me")
                         .header("Authorization", authHeader))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error.code").value("MEMBER_NOT_FOUND"));
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
     }
 
     // ──────────── happy path + validation 5 케이스 (이상진 B-6/B-7 + Q1-B 정책 검증) ────────────

--- a/backend/src/test/java/com/todayway/backend/member/domain/MemberInvariantTest.java
+++ b/backend/src/test/java/com/todayway/backend/member/domain/MemberInvariantTest.java
@@ -8,11 +8,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Member 비즈니스 메서드 invariant 가드 단위 테스트.
+ * Member 도메인 invariant 가드 단위 테스트.
  * α-c2 (PR #6) deleted 가드 회귀 보호선 — 정상 흐름에서 도달 불가능한 코드라
- * 통합 테스트로는 검증 불가 (claude.ai PR #6 리뷰 P1 흡수, β PR에서 추가).
+ * 통합 테스트로는 검증 불가 (claude.ai PR #6 리뷰 P1, claude.ai PR #7 리뷰 P3 클래스 명명 정정).
  */
-class MemberTest {
+class MemberInvariantTest {
 
     @Test
     void updateNickname_whenActive_updates() {

--- a/backend/src/test/java/com/todayway/backend/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/todayway/backend/member/domain/MemberTest.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.member.domain;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Member 비즈니스 메서드 invariant 가드 단위 테스트.
+ * α-c2 (PR #6) deleted 가드 회귀 보호선 — 정상 흐름에서 도달 불가능한 코드라
+ * 통합 테스트로는 검증 불가 (claude.ai PR #6 리뷰 P1 흡수, β PR에서 추가).
+ */
+class MemberTest {
+
+    @Test
+    void updateNickname_whenActive_updates() {
+        Member m = Member.create("loginid01", "hash", "초기");
+        m.updateNickname("변경후");
+        assertThat(m.getNickname()).isEqualTo("변경후");
+    }
+
+    @Test
+    void updateNickname_whenDeleted_throwsMemberNotFound() {
+        Member m = Member.create("loginid02", "hash", "초기");
+        m.softDelete();
+        assertThatThrownBy(() -> m.updateNickname("변경후"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    void updatePasswordHash_whenActive_updates() {
+        Member m = Member.create("loginid03", "hash", "초기");
+        m.updatePasswordHash("newHash");
+        assertThat(m.getPasswordHash()).isEqualTo("newHash");
+    }
+
+    @Test
+    void updatePasswordHash_whenDeleted_throwsMemberNotFound() {
+        Member m = Member.create("loginid04", "hash", "초기");
+        m.softDelete();
+        assertThatThrownBy(() -> m.updatePasswordHash("newHash"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 요약

Step 4 외부 리뷰 후속 β PR (α/β 분할 중 β). `CurrentMemberArgumentResolver`를 `String memberUid` 반환으로 마이그레이션 — SELECT 2회 → 1회 절감 + detached 함정 컴파일 강제 차단.

Step 5 진입 전 마이그레이션 비용 최저점 (Step 5 `ScheduleController`에 같은 패턴 박히기 전).

부수: 명세 SSoT 단일화 — 메모리 폴더 명세 파일 삭제, `backend/docs/api-spec.md`가 단일 SSoT (claude.ai PR #6 리뷰 P3 이중화 부채 본질 해소).

## 변경 사항

| Commit | 내용 |
|---|---|
| β-c1 | Resolver `Member` → `String memberUid` (DB 호출 0회, `MemberRepository` 의존 제거) |
| β-c2 | MemberController 3 메서드 시그니처 |
| β-c3 | MemberService 3 메서드 시그니처 + `findByMemberUid` 1회 + 부재 시 401 `UNAUTHORIZED` |
| β-c4 | 통합 테스트 (A+ 2) 탈퇴 후 응답 401로 변경 |
| β-c5 | `MemberTest` 단위 테스트 4건 (P1, α-c2 invariant 가드 회귀 보호선) |
| β-c6 | 명세 v1.1.6 → v1.1.7 patch (§1.7 Resolver 동작 + §3.3 탈퇴 응답 + §0.1 변경 이력) |

## 효과

| 항목 | α 후 (PR #6) | β 후 (본 PR) |
|---|---|---|
| 변경 메서드 (PATCH/DELETE) SELECT | Resolver 1회 + Service 1회 = **2회** | Resolver 0회 + Service 1회 = **1회 (50% 절감)** |
| `getMe` SELECT 패턴 | Resolver 1회 + Service 0회 (비대칭) | Resolver 0회 + Service 1회 (변경 메서드와 동일) ✅ |
| detached entity 함정 | `findById` 재조회로 우회 (사람 의지) | 시그니처에 entity 없음 → 컴파일 강제 차단 ✅ |
| 명세 SSoT | 메모리 + backend mirror (이중화 부채) | backend 단일 (drift 위험 0) ✅ |

→ **이전 외부 리뷰 P4 (getMe SELECT 비대칭) + claude.ai PR #6 P3 (SSoT 이중화 부채) 자연 해결** (claude.ai PR #6 리뷰 P5).

## 외부 계약 변경 (break change)

탈퇴 회원 토큰 사용 시: `404 MEMBER_NOT_FOUND` → **`401 UNAUTHORIZED`** (Service의 `findByMemberUid` 부재 시 응답). 프론트 미구현이라 외부 영향 0. 명세 §3.3 v1.1.7로 명시.

## 외부 리뷰 처리 매핑

| 리뷰 | 처리 |
|---|---|
| 이상진 PR #5 I-1 (Resolver `String memberUid`) | β-c1+c2+c3 ✅ |
| claude.ai PR #6 P1 (α-c2 단위 테스트) | β-c5 ✅ |
| claude.ai PR #6 P3 (SSoT 부채) | D8-(나) backend SSoT 단일화로 자연 해소 ✅ |
| claude.ai PR #6 P5 (이전 P4 자연 해결) | 본 PR description 명시 ✅ |

## Step 5 인계

- β-c1의 `@CurrentMember String memberUid` 시그니처를 `ScheduleController` 3+ 메서드에 default 적용
- Service 첫 줄의 `findByMemberUid(uid).orElseThrow(UNAUTHORIZED)` 패턴도 default
- 패턴 3 (`Schedule.scheduleUid CHAR(26)` columnDefinition) 적용 필수

## 검증

- `./gradlew build` BUILD SUCCESSFUL (1m 56s, 로컬 win32 + Docker tcp:2375)
- 단위 테스트 + α-c5 통합 테스트 9 메서드 + β-c5 신규 4 단위 테스트 = 모두 PASS
- (A+ 2) 통합 테스트의 expected status 변경 검증 PASS