### PR TITLE
feat(backend/schedule): step5 — 일정 CRUD + 루틴 + RouteService 인터페이스 (closes #8)

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.7-MVP
-> **최종 수정**: 2026-04-30 (황찬우 — β PR Resolver 마이그레이션: §1.7 Resolver 동작 단순화 명시 + §3.3 탈퇴 회원 응답 404 → 401)
+> **버전**: v1.1.8-MVP
+> **최종 수정**: 2026-04-30 (황찬우 — Step 5 외부 리뷰 흡수: §5.4 PATCH 시 NOW() 검사를 arrivalTime 포함 시에만 적용)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -24,6 +24,7 @@
 | **v1.1.5** | **2026-04-29** | **§2.3 logout 인터페이스 RFC 7009 정합 — Authorization 헤더 인증 → body의 refreshToken (소유 증명), 멤버 모든 활성 토큰 폐기 → 전달된 1개만 폐기 (단일 디바이스). logout-all은 P1 별도 엔드포인트로 분리. §1.8 logout 인증 ✓ → ✗** |
 | **v1.1.6** | **2026-04-30** | **§1.6 `INTERNAL_SERVER_ERROR` 행 추가(fallback 명시), §1.7 JWT sub claim raw ULID 명시, §3.2 password 정규식 §2.1 정합 + 둘 다 null/생략 → 400 + password 변경 시 token 폐기 비고, §3.3 DELETE 멱등성 비고. (Step 4 PR #5 이상진 리뷰 보강 5건 + Q1-B/Q8-1 흡수)** |
 | **v1.1.7** | **2026-04-30** | **§1.7 Resolver 동작 정정 — `Authentication.getName()`으로 raw `member_uid` 반환만(DB 호출 X), Service가 `findByMemberUid` 1회 조회. §3.3 탈퇴 회원 응답: 404 `MEMBER_NOT_FOUND` → **401 `UNAUTHORIZED`** (Service 부재 시 응답). β PR Resolver 마이그레이션 (이상진 PR #5 I-1 + claude.ai P1).** |
+| **v1.1.8** | **2026-04-30** | **§5.4 PATCH 검증 정정 — `arrivalTime`의 NOW() 검사는 `arrivalTime`이 요청에 포함된 경우에만 적용. 지난 일정의 `title` 등 메모 편집 허용. (Step 5 PR #10 claude.ai 리뷰 P1 흡수)** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -692,6 +693,7 @@ LIMIT ?
 - 출/도착지 또는 `arrivalTime`이 변경되면 ODsay를 **재호출**하여 경로 관련 필드를 재계산한다 (5.1과 동일 graceful degradation 적용).
 - `userDepartureTime`만 변경된 경우는 ODsay 재호출 **불필요**. 동일 출/도착·동일 도착시각이면 경로/소요시간이 같으므로 `departureAdvice`만 재계산하면 된다.
 - 변경 사항이 시간/경로 관련이 아닌 경우 (예: `title`, `reminderOffsetMinutes`만 변경) ODsay 재호출 불필요. 단, `reminderOffsetMinutes` 변경 시 `reminder_at`은 재계산.
+- **`arrivalTime` 검증 (v1.1.8)**: `arrivalTime <= NOW()` 검사는 요청에 `arrivalTime`이 포함된 경우에만 적용된다. 지난 일정의 `title` 등 메모 편집은 허용. 사용자가 명시적으로 `arrivalTime`을 NOW() 이전으로 변경하는 시도는 거절.
 
 #### Response — `200 OK`
 

--- a/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.dto.MemberResponse;
 import com.todayway.backend.member.dto.MemberUpdateRequest;
 import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,6 +27,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final ScheduleRepository scheduleRepository;
     private final PasswordEncoder passwordEncoder;
 
     public MemberResponse getMe(String memberUid) {
@@ -53,15 +55,18 @@ public class MemberService {
 
     @Transactional
     public void softDelete(String memberUid) {
-        // 의사결정 4 (가-1) — Step 4 시점 가능한 cascade 2개:
+        // 의사결정 4 (가-1) cascade — Step 5 진입으로 schedule 추가 (Issue #8):
         //   ✅ Member.deleted_at (자체)
         //   ✅ refresh_token.revoked_at 일괄
-        //   ⏳ schedule.deleted_at — Step 5 진입 시 ScheduleRepository 주입 + cascade 추가
-        //   ⏳ push_subscription.revoked_at — 이상진 Step 7 진입 시 추가
+        //   ✅ schedule.deleted_at 일괄 (β PR + Step 5 — closes #8)
+        //   ⏳ push_subscription.revoked_at — 이상진 Step 7 진입 시 추가 (#9)
         Member m = memberRepository.findByMemberUid(memberUid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
         m.softDelete();
-        int revoked = refreshTokenRepository.revokeAllActiveByMemberId(m.getId(), OffsetDateTime.now(KST));
-        log.info("revoked {} active refresh tokens for memberId={} (soft delete)", revoked, m.getId());
+        OffsetDateTime now = OffsetDateTime.now(KST);
+        int revoked = refreshTokenRepository.revokeAllActiveByMemberId(m.getId(), now);
+        int deletedSchedules = scheduleRepository.softDeleteByMemberId(m.getId(), now);
+        log.info("revoked {} active refresh tokens, soft-deleted {} schedules for memberId={} (member soft delete)",
+                revoked, deletedSchedules, m.getId());
     }
 }

--- a/backend/src/main/java/com/todayway/backend/route/NoOpRouteService.java
+++ b/backend/src/main/java/com/todayway/backend/route/NoOpRouteService.java
@@ -1,0 +1,34 @@
+package com.todayway.backend.route;
+
+import com.todayway.backend.schedule.domain.Schedule;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Step 6 (이상진 OdsayRouteService) 진입 전 임시 구현체.
+ * 모든 호출 false / null 반환 → ScheduleService의 graceful degradation 흐름 자체 검증 가능.
+ *
+ * Step 6 PR 머지 시: 이상진이 OdsayRouteService를 @Component로 등록하면
+ * RouteServiceConfig의 @ConditionalOnMissingBean이 NoOp 미생성 → 자연 비활성.
+ * 이후 본 클래스는 cleanup 대상 (이상진 Step 6 PR에서 삭제 권장).
+ */
+@Slf4j
+public class NoOpRouteService implements RouteService {
+
+    @Override
+    public boolean refreshRouteSync(Schedule schedule) {
+        log.info("NoOpRouteService.refreshRouteSync — OdsayRouteService 미구현 (graceful degradation, scheduleUid={})",
+                schedule.getScheduleUid());
+        return false;
+    }
+
+    @Override
+    public RouteResponse getRoute(Schedule schedule, boolean forceRefresh) {
+        log.info("NoOpRouteService.getRoute — OdsayRouteService 미구현 (scheduleUid={}, forceRefresh={})",
+                schedule.getScheduleUid(), forceRefresh);
+        return new RouteResponse(
+                "sch_" + schedule.getScheduleUid(),
+                null,
+                null
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/route/RouteResponse.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteResponse.java
@@ -1,0 +1,13 @@
+package com.todayway.backend.route;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 임시 시그니처 — Step 6 (이상진)에서 명세 §11.4 Route 도메인 record로 좁힘.
+ * 본 시점엔 ScheduleService 컴파일을 위한 placeholder.
+ */
+public record RouteResponse(
+        String scheduleId,
+        Object route,
+        OffsetDateTime calculatedAt
+) {}

--- a/backend/src/main/java/com/todayway/backend/route/RouteService.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteService.java
@@ -1,0 +1,26 @@
+package com.todayway.backend.route;
+
+import com.todayway.backend.schedule.domain.Schedule;
+
+/**
+ * ODsay 호출 + 응답 매핑 + DB 저장 책임의 인터페이스.
+ *
+ * Step 5 (황찬우)에서 인터페이스만 정의. 구현체는 Step 6 (이상진)에서 OdsayRouteService로 작성.
+ * 이상진 인계: ExternalApiException은 RuntimeException 상속 (BusinessException 아님) →
+ * 호출자(본 인터페이스 구현체)에서 catch + BusinessException 변환 책임 (명세 §1.6 502/503/504 정합).
+ */
+public interface RouteService {
+
+    /**
+     * Schedule 등록/수정 시 호출. ODsay 호출 → schedule 엔티티의 경로 관련 필드 갱신.
+     * 실패 시 graceful degradation — Schedule은 그대로 두고 false 반환.
+     *
+     * @return ODsay 호출 성공 + Schedule 필드 갱신 완료 여부
+     */
+    boolean refreshRouteSync(Schedule schedule);
+
+    /**
+     * 캐시 hit/miss 처리 후 단일 Route DTO 반환. 명세 §6.1 GET /schedules/{id}/route용.
+     */
+    RouteResponse getRoute(Schedule schedule, boolean forceRefresh);
+}

--- a/backend/src/main/java/com/todayway/backend/route/RouteServiceConfig.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteServiceConfig.java
@@ -1,0 +1,20 @@
+package com.todayway.backend.route;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * RouteService Bean 등록.
+ * 이상진이 Step 6에서 OdsayRouteService를 @Component / @Service로 등록하면
+ * @ConditionalOnMissingBean이 NoOpRouteService 미생성 → 자연 비활성 (chicken-and-egg 우회).
+ */
+@Configuration
+public class RouteServiceConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(RouteService.class)
+    public RouteService noOpRouteService() {
+        return new NoOpRouteService();
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/controller/ScheduleController.java
@@ -1,0 +1,89 @@
+package com.todayway.backend.schedule.controller;
+
+import com.todayway.backend.common.pagination.CursorRequest;
+import com.todayway.backend.common.pagination.CursorResponse;
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.schedule.dto.CreateScheduleRequest;
+import com.todayway.backend.schedule.dto.ScheduleListItem;
+import com.todayway.backend.schedule.dto.ScheduleResponse;
+import com.todayway.backend.schedule.dto.UpdateScheduleRequest;
+import com.todayway.backend.schedule.service.ScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.OffsetDateTime;
+
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private static final String SCHEDULE_PREFIX = "sch_";
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ScheduleResponse>> create(
+            @CurrentMember String memberUid,
+            @RequestBody @Valid CreateScheduleRequest req) {
+        ScheduleResponse resp = scheduleService.create(memberUid, req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(resp));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CursorResponse<ScheduleListItem>>> list(
+            @CurrentMember String memberUid,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
+            @RequestParam(defaultValue = "20") int limit,
+            @RequestParam(required = false) String cursor) {
+        CursorResponse<ScheduleListItem> resp = scheduleService.list(
+                memberUid, from, to, new CursorRequest(limit, cursor));
+        return ResponseEntity.ok(ApiResponse.of(resp));
+    }
+
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ApiResponse<ScheduleResponse>> get(
+            @CurrentMember String memberUid,
+            @PathVariable String scheduleId) {
+        ScheduleResponse resp = scheduleService.get(memberUid, stripPrefix(scheduleId));
+        return ResponseEntity.ok(ApiResponse.of(resp));
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<ApiResponse<ScheduleResponse>> update(
+            @CurrentMember String memberUid,
+            @PathVariable String scheduleId,
+            @RequestBody @Valid UpdateScheduleRequest req) {
+        ScheduleResponse resp = scheduleService.update(memberUid, stripPrefix(scheduleId), req);
+        return ResponseEntity.ok(ApiResponse.of(resp));
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(
+            @CurrentMember String memberUid,
+            @PathVariable String scheduleId) {
+        scheduleService.delete(memberUid, stripPrefix(scheduleId));
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 클라이언트는 명세 §1.7 응답 형식("sch_{ULID}")으로 요청 → DB의 raw scheduleUid로 변환.
+     */
+    private static String stripPrefix(String scheduleId) {
+        return scheduleId.startsWith(SCHEDULE_PREFIX) ? scheduleId.substring(SCHEDULE_PREFIX.length()) : scheduleId;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/DayOfWeekMapper.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/DayOfWeekMapper.java
@@ -1,0 +1,49 @@
+package com.todayway.backend.schedule.domain;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+
+import java.time.DayOfWeek;
+import java.util.Map;
+
+/**
+ * "MON" 같은 짧은 표기 ↔ DayOfWeek 변환.
+ * DayOfWeek.MONDAY.toString()은 "MONDAY"라 직접 매핑 X — 정적 맵 필요.
+ * 명세 §11.2 RoutineRule.daysOfWeek 정합.
+ */
+public final class DayOfWeekMapper {
+
+    private static final Map<String, DayOfWeek> SHORT_TO_DAY = Map.of(
+            "MON", DayOfWeek.MONDAY,
+            "TUE", DayOfWeek.TUESDAY,
+            "WED", DayOfWeek.WEDNESDAY,
+            "THU", DayOfWeek.THURSDAY,
+            "FRI", DayOfWeek.FRIDAY,
+            "SAT", DayOfWeek.SATURDAY,
+            "SUN", DayOfWeek.SUNDAY
+    );
+
+    private static final Map<DayOfWeek, String> DAY_TO_SHORT = Map.of(
+            DayOfWeek.MONDAY, "MON",
+            DayOfWeek.TUESDAY, "TUE",
+            DayOfWeek.WEDNESDAY, "WED",
+            DayOfWeek.THURSDAY, "THU",
+            DayOfWeek.FRIDAY, "FRI",
+            DayOfWeek.SATURDAY, "SAT",
+            DayOfWeek.SUNDAY, "SUN"
+    );
+
+    private DayOfWeekMapper() {}
+
+    public static DayOfWeek fromShortCode(String code) {
+        DayOfWeek d = SHORT_TO_DAY.get(code);
+        if (d == null) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+        return d;
+    }
+
+    public static String toShortCode(DayOfWeek day) {
+        return DAY_TO_SHORT.get(day);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/DepartureAdvice.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/DepartureAdvice.java
@@ -1,0 +1,11 @@
+package com.todayway.backend.schedule.domain;
+
+/**
+ * 출발시각 조정 안내. 명세 §5.1 ±3분 윈도우 기준.
+ *  - EARLIER: recommendedDepartureTime < userDepartureTime - 3min
+ *  - ON_TIME: |diff| <= 3min
+ *  - LATER:   recommendedDepartureTime > userDepartureTime + 3min
+ */
+public enum DepartureAdvice {
+    EARLIER, ON_TIME, LATER
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/PlaceProvider.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/PlaceProvider.java
@@ -1,0 +1,9 @@
+package com.todayway.backend.schedule.domain;
+
+/**
+ * 장소 정보의 출처 (origin_provider / destination_provider).
+ * DB ENUM과 정합 (V1__init.sql).
+ */
+public enum PlaceProvider {
+    NAVER, KAKAO, ODSAY, MANUAL
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/RoutineCalculator.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/RoutineCalculator.java
@@ -1,0 +1,48 @@
+package com.todayway.backend.schedule.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.OffsetDateTime;
+import java.util.Set;
+
+/**
+ * 루틴 일정의 다음 occurrence 계산기. 이상진 Step 7 PushScheduler가 알림 발송 후 호출.
+ * 명세 §9.2 / BACKEND_CONTEXT §9.3 의사코드 정합.
+ *
+ *  - ONCE: null
+ *  - DAILY: current + 1일
+ *  - WEEKLY: 다음 daysOfWeek 도래 (1~7일 탐색, 없으면 null)
+ *  - CUSTOM: current + intervalDays
+ */
+@Component
+public class RoutineCalculator {
+
+    public OffsetDateTime calculateNextOccurrence(Schedule s) {
+        OffsetDateTime current = s.getArrivalTime();
+        RoutineType type = s.getRoutineType();
+
+        if (type == null || type == RoutineType.ONCE) return null;
+
+        return switch (type) {
+            case DAILY -> current.plusDays(1);
+            case WEEKLY -> nextWeeklyOccurrence(current, s.getDaysOfWeekSet());
+            case CUSTOM -> nextCustomOccurrence(current, s.getRoutineIntervalDays());
+            case ONCE -> null;
+        };
+    }
+
+    private OffsetDateTime nextWeeklyOccurrence(OffsetDateTime current, Set<DayOfWeek> days) {
+        if (days.isEmpty()) return null;
+        for (int delta = 1; delta <= 7; delta++) {
+            OffsetDateTime cand = current.plusDays(delta);
+            if (days.contains(cand.getDayOfWeek())) return cand;
+        }
+        return null;
+    }
+
+    private OffsetDateTime nextCustomOccurrence(OffsetDateTime current, Integer intervalDays) {
+        if (intervalDays == null || intervalDays <= 0) return null;
+        return current.plusDays(intervalDays);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/RoutineType.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/RoutineType.java
@@ -1,0 +1,12 @@
+package com.todayway.backend.schedule.domain;
+
+/**
+ * 루틴 타입.
+ *  - ONCE: 단발성 (default 효과)
+ *  - DAILY: 매일
+ *  - WEEKLY: 특정 요일 (routine_days_of_week 사용)
+ *  - CUSTOM: N일 간격 (routine_interval_days 사용)
+ */
+public enum RoutineType {
+    ONCE, DAILY, WEEKLY, CUSTOM
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
@@ -278,11 +278,12 @@ public class Schedule extends BaseEntity {
     }
 
     /**
-     * RouteService가 ODsay 호출 후 결과 반영. reminderAt 자동 재계산.
+     * RouteService가 ODsay 호출 후 결과 반영. departureAdvice / reminderAt 자동 재계산.
+     * Step 6 OdsayRouteService와의 ON_TIME_WINDOW_MINUTES silent drift 차단
+     * (claude.ai PR #10 P2 — invariant 통합으로 컴파일 강제 일관성).
      */
     public void updateRouteInfo(Integer estimatedDurationMinutes,
                                 OffsetDateTime recommendedDepartureTime,
-                                DepartureAdvice departureAdvice,
                                 String routeSummaryJson,
                                 OffsetDateTime routeCalculatedAt) {
         if (deletedAt != null) {
@@ -290,9 +291,9 @@ public class Schedule extends BaseEntity {
         }
         this.estimatedDurationMinutes = estimatedDurationMinutes;
         this.recommendedDepartureTime = recommendedDepartureTime;
-        this.departureAdvice = departureAdvice;
         this.routeSummaryJson = routeSummaryJson;
         this.routeCalculatedAt = routeCalculatedAt;
+        recalculateDepartureAdvice();
         recalculateReminderAt();
     }
 

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
@@ -1,0 +1,347 @@
+package com.todayway.backend.schedule.domain;
+
+import com.todayway.backend.common.entity.BaseEntity;
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.common.ulid.UlidGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 일정 도메인. 출/도착지 + 시간 + ODsay 응답(raw JSON) + 루틴 + 알림 시각.
+ * 명세 §5 / §11.3 / V1__init.sql `schedule` 테이블 정합.
+ *
+ * 주요 책임:
+ *  - 비즈니스 invariant 가드 (deleted 후 변경 차단)
+ *  - 부분 업데이트 변경 영향도 도출 (ODsay 재호출 분기)
+ *  - reminderAt 자동 재계산
+ */
+@Getter
+@Entity
+@Table(name = "schedule")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule extends BaseEntity {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final long ON_TIME_WINDOW_MINUTES = 3;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "schedule_uid", nullable = false, updatable = false, unique = true,
+            columnDefinition = "CHAR(26)")
+    private String scheduleUid;
+
+    @Column(name = "member_id", nullable = false, updatable = false)
+    private Long memberId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    // ─── 출발지 ───
+    @Column(name = "origin_name", nullable = false, length = 100)
+    private String originName;
+
+    @Column(name = "origin_lat", nullable = false, precision = 10, scale = 7)
+    private BigDecimal originLat;
+
+    @Column(name = "origin_lng", nullable = false, precision = 10, scale = 7)
+    private BigDecimal originLng;
+
+    @Column(name = "origin_address", length = 255)
+    private String originAddress;
+
+    @Column(name = "origin_place_id", length = 100)
+    private String originPlaceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "origin_provider", columnDefinition = "ENUM('NAVER','KAKAO','ODSAY','MANUAL')")
+    private PlaceProvider originProvider;
+
+    // ─── 도착지 ───
+    @Column(name = "destination_name", nullable = false, length = 100)
+    private String destinationName;
+
+    @Column(name = "destination_lat", nullable = false, precision = 10, scale = 7)
+    private BigDecimal destinationLat;
+
+    @Column(name = "destination_lng", nullable = false, precision = 10, scale = 7)
+    private BigDecimal destinationLng;
+
+    @Column(name = "destination_address", length = 255)
+    private String destinationAddress;
+
+    @Column(name = "destination_place_id", length = 100)
+    private String destinationPlaceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "destination_provider", columnDefinition = "ENUM('NAVER','KAKAO','ODSAY','MANUAL')")
+    private PlaceProvider destinationProvider;
+
+    // ─── 시간 ───
+    @Column(name = "user_departure_time", nullable = false)
+    private OffsetDateTime userDepartureTime;
+
+    @Column(name = "arrival_time", nullable = false)
+    private OffsetDateTime arrivalTime;
+
+    // ─── ODsay 결과 ───
+    @Column(name = "estimated_duration_minutes")
+    private Integer estimatedDurationMinutes;
+
+    @Column(name = "recommended_departure_time")
+    private OffsetDateTime recommendedDepartureTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "departure_advice", columnDefinition = "ENUM('EARLIER','ON_TIME','LATER')")
+    private DepartureAdvice departureAdvice;
+
+    @Column(name = "route_summary_json", columnDefinition = "JSON")
+    private String routeSummaryJson;
+
+    @Column(name = "route_calculated_at")
+    private OffsetDateTime routeCalculatedAt;
+
+    // ─── 알림 ───
+    @Column(name = "reminder_offset_minutes", nullable = false)
+    private Integer reminderOffsetMinutes;
+
+    @Column(name = "reminder_at")
+    private OffsetDateTime reminderAt;
+
+    // ─── 루틴 ───
+    @Enumerated(EnumType.STRING)
+    @Column(name = "routine_type", columnDefinition = "ENUM('ONCE','DAILY','WEEKLY','CUSTOM')")
+    private RoutineType routineType;
+
+    @Column(name = "routine_days_of_week", length = 20)
+    private String routineDaysOfWeek;
+
+    @Column(name = "routine_interval_days")
+    private Integer routineIntervalDays;
+
+    // ─── 소프트 삭제 ───
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    private Schedule(Long memberId, String title,
+                     String originName, BigDecimal originLat, BigDecimal originLng,
+                     String originAddress, String originPlaceId, PlaceProvider originProvider,
+                     String destinationName, BigDecimal destinationLat, BigDecimal destinationLng,
+                     String destinationAddress, String destinationPlaceId, PlaceProvider destinationProvider,
+                     OffsetDateTime userDepartureTime, OffsetDateTime arrivalTime,
+                     Integer reminderOffsetMinutes,
+                     RoutineType routineType, String routineDaysOfWeek, Integer routineIntervalDays) {
+        this.memberId = memberId;
+        this.title = title;
+        this.originName = originName;
+        this.originLat = originLat;
+        this.originLng = originLng;
+        this.originAddress = originAddress;
+        this.originPlaceId = originPlaceId;
+        this.originProvider = originProvider;
+        this.destinationName = destinationName;
+        this.destinationLat = destinationLat;
+        this.destinationLng = destinationLng;
+        this.destinationAddress = destinationAddress;
+        this.destinationPlaceId = destinationPlaceId;
+        this.destinationProvider = destinationProvider;
+        this.userDepartureTime = userDepartureTime;
+        this.arrivalTime = arrivalTime;
+        this.reminderOffsetMinutes = reminderOffsetMinutes != null ? reminderOffsetMinutes : 5;
+        this.routineType = routineType;
+        this.routineDaysOfWeek = routineDaysOfWeek;
+        this.routineIntervalDays = routineIntervalDays;
+    }
+
+    public static Schedule create(Long memberId, String title,
+                                  String originName, BigDecimal originLat, BigDecimal originLng,
+                                  String originAddress, String originPlaceId, PlaceProvider originProvider,
+                                  String destinationName, BigDecimal destinationLat, BigDecimal destinationLng,
+                                  String destinationAddress, String destinationPlaceId, PlaceProvider destinationProvider,
+                                  OffsetDateTime userDepartureTime, OffsetDateTime arrivalTime,
+                                  Integer reminderOffsetMinutes,
+                                  RoutineType routineType, String routineDaysOfWeek, Integer routineIntervalDays) {
+        return new Schedule(memberId, title,
+                originName, originLat, originLng, originAddress, originPlaceId, originProvider,
+                destinationName, destinationLat, destinationLng, destinationAddress, destinationPlaceId, destinationProvider,
+                userDepartureTime, arrivalTime, reminderOffsetMinutes,
+                routineType, routineDaysOfWeek, routineIntervalDays);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (this.scheduleUid == null) {
+            this.scheduleUid = UlidGenerator.generate();
+        }
+    }
+
+    public boolean belongsTo(Long memberId) {
+        return Objects.equals(this.memberId, memberId);
+    }
+
+    public boolean hasCalculatedRoute() {
+        return this.routeSummaryJson != null;
+    }
+
+    public Set<DayOfWeek> getDaysOfWeekSet() {
+        if (routineDaysOfWeek == null || routineDaysOfWeek.isBlank()) return Set.of();
+        return Arrays.stream(routineDaysOfWeek.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(DayOfWeekMapper::fromShortCode)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 부분 업데이트. 출/도착지 또는 arrivalTime 변경 시 true 반환 (ODsay 재호출 분기 trigger).
+     * 명세 §5.4 정합. D8: deleted invariant 가드.
+     *
+     * @return placeOrArrivalChanged — 출/도착지 또는 arrivalTime 변경 여부
+     */
+    public boolean applyUpdate(String title,
+                               PlaceUpdate origin,
+                               PlaceUpdate destination,
+                               OffsetDateTime userDepartureTime,
+                               OffsetDateTime arrivalTime,
+                               Integer reminderOffsetMinutes,
+                               RoutineUpdate routine) {
+        if (deletedAt != null) {
+            throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
+        }
+        boolean placeOrArrivalChanged = false;
+
+        if (title != null) this.title = title;
+
+        if (origin != null) {
+            this.originName = origin.name();
+            this.originLat = origin.lat();
+            this.originLng = origin.lng();
+            this.originAddress = origin.address();
+            this.originPlaceId = origin.placeId();
+            this.originProvider = origin.provider();
+            placeOrArrivalChanged = true;
+        }
+
+        if (destination != null) {
+            this.destinationName = destination.name();
+            this.destinationLat = destination.lat();
+            this.destinationLng = destination.lng();
+            this.destinationAddress = destination.address();
+            this.destinationPlaceId = destination.placeId();
+            this.destinationProvider = destination.provider();
+            placeOrArrivalChanged = true;
+        }
+
+        if (userDepartureTime != null) this.userDepartureTime = userDepartureTime;
+
+        if (arrivalTime != null) {
+            this.arrivalTime = arrivalTime;
+            placeOrArrivalChanged = true;
+        }
+
+        if (reminderOffsetMinutes != null) {
+            this.reminderOffsetMinutes = reminderOffsetMinutes;
+            recalculateReminderAt();
+        }
+
+        if (routine != null) {
+            this.routineType = routine.type();
+            this.routineDaysOfWeek = routine.daysOfWeek();
+            this.routineIntervalDays = routine.intervalDays();
+        }
+
+        return placeOrArrivalChanged;
+    }
+
+    /**
+     * RouteService가 ODsay 호출 후 결과 반영. reminderAt 자동 재계산.
+     */
+    public void updateRouteInfo(Integer estimatedDurationMinutes,
+                                OffsetDateTime recommendedDepartureTime,
+                                DepartureAdvice departureAdvice,
+                                String routeSummaryJson,
+                                OffsetDateTime routeCalculatedAt) {
+        if (deletedAt != null) {
+            throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
+        }
+        this.estimatedDurationMinutes = estimatedDurationMinutes;
+        this.recommendedDepartureTime = recommendedDepartureTime;
+        this.departureAdvice = departureAdvice;
+        this.routeSummaryJson = routeSummaryJson;
+        this.routeCalculatedAt = routeCalculatedAt;
+        recalculateReminderAt();
+    }
+
+    /**
+     * userDepartureTime만 변경 시 — ODsay 재호출 X, departureAdvice만 재계산. 명세 §5.4 비고.
+     */
+    public void recalculateDepartureAdvice() {
+        if (recommendedDepartureTime == null || userDepartureTime == null) {
+            this.departureAdvice = null;
+            return;
+        }
+        long diffMinutes = Duration.between(userDepartureTime, recommendedDepartureTime).toMinutes();
+        if (diffMinutes < -ON_TIME_WINDOW_MINUTES) {
+            this.departureAdvice = DepartureAdvice.LATER;
+        } else if (diffMinutes > ON_TIME_WINDOW_MINUTES) {
+            this.departureAdvice = DepartureAdvice.EARLIER;
+        } else {
+            this.departureAdvice = DepartureAdvice.ON_TIME;
+        }
+    }
+
+    private void recalculateReminderAt() {
+        if (recommendedDepartureTime != null && reminderOffsetMinutes != null) {
+            this.reminderAt = recommendedDepartureTime.minusMinutes(reminderOffsetMinutes);
+        } else {
+            this.reminderAt = null;
+        }
+    }
+
+    public void softDelete() {
+        if (deletedAt == null) {
+            this.deletedAt = OffsetDateTime.now(KST);
+        }
+    }
+
+    /** PATCH 부분 업데이트용 입력 DTO — 출/도착지 묶음. */
+    public record PlaceUpdate(
+            String name,
+            BigDecimal lat,
+            BigDecimal lng,
+            String address,
+            String placeId,
+            PlaceProvider provider
+    ) {}
+
+    /** PATCH 부분 업데이트용 입력 DTO — 루틴 묶음. */
+    public record RoutineUpdate(
+            RoutineType type,
+            String daysOfWeek,
+            Integer intervalDays
+    ) {}
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/dto/CreateScheduleRequest.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/dto/CreateScheduleRequest.java
@@ -1,0 +1,25 @@
+package com.todayway.backend.schedule.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.OffsetDateTime;
+
+/**
+ * POST /schedules — 명세 §5.1 Request Body.
+ */
+public record CreateScheduleRequest(
+        @NotBlank @Size(min = 1, max = 100) String title,
+
+        @NotNull @Valid PlaceDto origin,
+        @NotNull @Valid PlaceDto destination,
+
+        @NotNull OffsetDateTime userDepartureTime,
+        @NotNull OffsetDateTime arrivalTime,
+
+        Integer reminderOffsetMinutes,
+
+        @Valid RoutineRuleDto routineRule
+) {}

--- a/backend/src/main/java/com/todayway/backend/schedule/dto/PlaceDto.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/dto/PlaceDto.java
@@ -1,0 +1,35 @@
+package com.todayway.backend.schedule.dto;
+
+import com.todayway.backend.schedule.domain.PlaceProvider;
+import com.todayway.backend.schedule.domain.Schedule;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+/**
+ * 명세 §11.1 Place 정합. Schedule의 origin/destination 양쪽에서 사용.
+ */
+public record PlaceDto(
+        @NotBlank @Size(max = 100) String name,
+        @NotNull BigDecimal lat,
+        @NotNull BigDecimal lng,
+        @Size(max = 255) String address,
+        @Size(max = 100) String placeId,
+        PlaceProvider provider
+) {
+    public static PlaceDto fromOrigin(Schedule s) {
+        return new PlaceDto(
+                s.getOriginName(), s.getOriginLat(), s.getOriginLng(),
+                s.getOriginAddress(), s.getOriginPlaceId(), s.getOriginProvider()
+        );
+    }
+
+    public static PlaceDto fromDestination(Schedule s) {
+        return new PlaceDto(
+                s.getDestinationName(), s.getDestinationLat(), s.getDestinationLng(),
+                s.getDestinationAddress(), s.getDestinationPlaceId(), s.getDestinationProvider()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/dto/RoutineRuleDto.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/dto/RoutineRuleDto.java
@@ -1,0 +1,42 @@
+package com.todayway.backend.schedule.dto;
+
+import com.todayway.backend.schedule.domain.RoutineType;
+import com.todayway.backend.schedule.domain.Schedule;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 명세 §11.2 RoutineRule 정합.
+ *  - WEEKLY: daysOfWeek 사용
+ *  - CUSTOM: intervalDays 사용
+ *  - DAILY/ONCE: 둘 다 사용 X
+ */
+public record RoutineRuleDto(
+        @NotNull RoutineType type,
+        List<String> daysOfWeek,
+        Integer intervalDays
+) {
+    public static RoutineRuleDto from(Schedule s) {
+        if (s.getRoutineType() == null) return null;
+        return new RoutineRuleDto(
+                s.getRoutineType(),
+                csvToList(s.getRoutineDaysOfWeek()),
+                s.getRoutineIntervalDays()
+        );
+    }
+
+    private static List<String> csvToList(String csv) {
+        if (csv == null || csv.isBlank()) return null;
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(x -> !x.isEmpty())
+                .toList();
+    }
+
+    public String toCsv() {
+        if (daysOfWeek == null || daysOfWeek.isEmpty()) return null;
+        return String.join(",", daysOfWeek);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/dto/ScheduleListItem.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/dto/ScheduleListItem.java
@@ -1,0 +1,31 @@
+package com.todayway.backend.schedule.dto;
+
+import com.todayway.backend.schedule.domain.Schedule;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 명세 §5.2 일정 목록 응답 아이템 — 페이로드 절감용 가벼운 버전.
+ * route_summary_json 등 무거운 필드 제외. 상세는 §5.3에서 조회.
+ */
+public record ScheduleListItem(
+        String scheduleId,
+        String title,
+        OffsetDateTime arrivalTime,
+        OffsetDateTime recommendedDepartureTime,
+        PlaceDto origin,
+        PlaceDto destination,
+        String routeStatus
+) {
+    public static ScheduleListItem from(Schedule s) {
+        return new ScheduleListItem(
+                "sch_" + s.getScheduleUid(),
+                s.getTitle(),
+                s.getArrivalTime(),
+                s.getRecommendedDepartureTime(),
+                PlaceDto.fromOrigin(s),
+                PlaceDto.fromDestination(s),
+                s.hasCalculatedRoute() ? "CALCULATED" : "PENDING_RETRY"
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/dto/ScheduleResponse.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/dto/ScheduleResponse.java
@@ -1,0 +1,48 @@
+package com.todayway.backend.schedule.dto;
+
+import com.todayway.backend.schedule.domain.DepartureAdvice;
+import com.todayway.backend.schedule.domain.Schedule;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 명세 §11.3 Schedule 응답 — 5.1/5.3/5.4 공통 형태.
+ * routeStatus는 도출값 (DB 컬럼 X) — Schedule.hasCalculatedRoute() 기반.
+ */
+public record ScheduleResponse(
+        String scheduleId,
+        String title,
+        PlaceDto origin,
+        PlaceDto destination,
+        OffsetDateTime userDepartureTime,
+        OffsetDateTime arrivalTime,
+        Integer estimatedDurationMinutes,
+        OffsetDateTime recommendedDepartureTime,
+        DepartureAdvice departureAdvice,
+        Integer reminderOffsetMinutes,
+        OffsetDateTime reminderAt,
+        RoutineRuleDto routineRule,
+        String routeStatus,
+        OffsetDateTime routeCalculatedAt,
+        OffsetDateTime createdAt
+) {
+    public static ScheduleResponse from(Schedule s) {
+        return new ScheduleResponse(
+                "sch_" + s.getScheduleUid(),
+                s.getTitle(),
+                PlaceDto.fromOrigin(s),
+                PlaceDto.fromDestination(s),
+                s.getUserDepartureTime(),
+                s.getArrivalTime(),
+                s.getEstimatedDurationMinutes(),
+                s.getRecommendedDepartureTime(),
+                s.getDepartureAdvice(),
+                s.getReminderOffsetMinutes(),
+                s.getReminderAt(),
+                RoutineRuleDto.from(s),
+                s.hasCalculatedRoute() ? "CALCULATED" : "PENDING_RETRY",
+                s.getRouteCalculatedAt(),
+                s.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/dto/UpdateScheduleRequest.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/dto/UpdateScheduleRequest.java
@@ -1,0 +1,23 @@
+package com.todayway.backend.schedule.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+import java.time.OffsetDateTime;
+
+/**
+ * PATCH /schedules/{id} — 명세 §5.4 부분 업데이트. 모든 필드 nullable.
+ */
+public record UpdateScheduleRequest(
+        @Size(min = 1, max = 100) String title,
+
+        @Valid PlaceDto origin,
+        @Valid PlaceDto destination,
+
+        OffsetDateTime userDepartureTime,
+        OffsetDateTime arrivalTime,
+
+        Integer reminderOffsetMinutes,
+
+        @Valid RoutineRuleDto routineRule
+) {}

--- a/backend/src/main/java/com/todayway/backend/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,67 @@
+package com.todayway.backend.schedule.repository;
+
+import com.todayway.backend.schedule.domain.Schedule;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    /**
+     * derived query — @SQLRestriction("deleted_at IS NULL") 자동 적용.
+     */
+    Optional<Schedule> findByScheduleUid(String scheduleUid);
+
+    /**
+     * 명세 §5.2 cursor 페이지네이션. ⚠️ JPQL은 @SQLRestriction 자동 적용 X — `deletedAt IS NULL` 명시 필수.
+     * 정렬: arrival_time ASC, id ASC tie-break.
+     */
+    @Query("""
+            SELECT s FROM Schedule s
+            WHERE s.memberId = :memberId
+              AND s.deletedAt IS NULL
+              AND (:from IS NULL OR s.arrivalTime >= :from)
+              AND (:to IS NULL OR s.arrivalTime <= :to)
+              AND (:cursorId IS NULL OR s.id > :cursorId)
+            ORDER BY s.arrivalTime ASC, s.id ASC
+            """)
+    List<Schedule> findPage(@Param("memberId") Long memberId,
+                            @Param("from") OffsetDateTime from,
+                            @Param("to") OffsetDateTime to,
+                            @Param("cursorId") Long cursorId,
+                            Pageable pageable);
+
+    /**
+     * 명세 §4.1 메인 화면의 nearestSchedule 조회 — 미래 가장 가까운 일정.
+     * derived query — @SQLRestriction 자동 적용.
+     */
+    Optional<Schedule> findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(
+            Long memberId, OffsetDateTime now);
+
+    /**
+     * 이상진 Step 7 PushScheduler용 — 알림 시각 도래한 일정 조회.
+     * ⚠️ JPQL `deletedAt IS NULL` 명시 필수.
+     */
+    @Query("""
+            SELECT s FROM Schedule s
+            WHERE s.reminderAt > :windowStart
+              AND s.reminderAt <= :now
+              AND s.deletedAt IS NULL
+            """)
+    List<Schedule> findDueReminders(@Param("now") OffsetDateTime now,
+                                    @Param("windowStart") OffsetDateTime windowStart);
+
+    /**
+     * 회원 탈퇴 시 cascade — Issue #8.
+     * @Modifying 직접 UPDATE라 영속성 컨텍스트 우회 (clearAutomatically로 1차 캐시 일관성 보장).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Schedule s SET s.deletedAt = :now WHERE s.memberId = :memberId AND s.deletedAt IS NULL")
+    int softDeleteByMemberId(@Param("memberId") Long memberId, @Param("now") OffsetDateTime now);
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
@@ -94,10 +94,16 @@ public class ScheduleService {
         Long memberId = resolveMemberId(memberUid);
         Schedule s = findOwned(memberId, scheduleUid);
 
-        validateTimes(
-                req.userDepartureTime() != null ? req.userDepartureTime() : s.getUserDepartureTime(),
-                req.arrivalTime() != null ? req.arrivalTime() : s.getArrivalTime()
-        );
+        // 명세 §5.4 v1.1.8 — arrivalTime이 PATCH에 포함된 경우만 NOW() 검사 (claude.ai PR #10 P1).
+        // 지난 일정에 title 등 메모 편집 시 NOW() 검사로 fail 방지.
+        if (req.arrivalTime() != null) {
+            OffsetDateTime newDepart = req.userDepartureTime() != null
+                    ? req.userDepartureTime() : s.getUserDepartureTime();
+            validateTimes(newDepart, req.arrivalTime());
+        } else if (req.userDepartureTime() != null) {
+            // userDepartureTime만 변경 — 순서 검증만 (NOW() skip)
+            validateOrderOnly(req.userDepartureTime(), s.getArrivalTime());
+        }
 
         Schedule.PlaceUpdate originUpdate = req.origin() != null
                 ? new Schedule.PlaceUpdate(
@@ -165,6 +171,17 @@ public class ScheduleService {
         }
         if (!arrival.isAfter(OffsetDateTime.now(KST))) {
             // 명세 §5.1 에러: arrivalTime <= NOW()
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+    }
+
+    /**
+     * userDepartureTime만 변경된 PATCH 시 호출 — 순서만 검증 (NOW() skip).
+     * 명세 §5.4 v1.1.8 — 지난 일정 메모 편집 허용 (claude.ai PR #10 P1).
+     */
+    private void validateOrderOnly(OffsetDateTime userDepart, OffsetDateTime arrival) {
+        if (userDepart == null || arrival == null) return;
+        if (!userDepart.isBefore(arrival)) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
     }

--- a/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
@@ -1,0 +1,201 @@
+package com.todayway.backend.schedule.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.common.pagination.CursorRequest;
+import com.todayway.backend.common.pagination.CursorResponse;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.Schedule;
+import com.todayway.backend.schedule.dto.CreateScheduleRequest;
+import com.todayway.backend.schedule.dto.PlaceDto;
+import com.todayway.backend.schedule.dto.RoutineRuleDto;
+import com.todayway.backend.schedule.dto.ScheduleListItem;
+import com.todayway.backend.schedule.dto.ScheduleResponse;
+import com.todayway.backend.schedule.dto.UpdateScheduleRequest;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class ScheduleService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final String CURSOR_PREFIX = "id:";
+
+    private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final RouteService routeService;
+
+    @Transactional
+    public ScheduleResponse create(String memberUid, CreateScheduleRequest req) {
+        Long memberId = resolveMemberId(memberUid);
+        validateTimes(req.userDepartureTime(), req.arrivalTime());
+
+        Schedule s = Schedule.create(
+                memberId, req.title(),
+                req.origin().name(), req.origin().lat(), req.origin().lng(),
+                req.origin().address(), req.origin().placeId(), req.origin().provider(),
+                req.destination().name(), req.destination().lat(), req.destination().lng(),
+                req.destination().address(), req.destination().placeId(), req.destination().provider(),
+                req.userDepartureTime(), req.arrivalTime(),
+                req.reminderOffsetMinutes(),
+                routineType(req.routineRule()),
+                routineDaysCsv(req.routineRule()),
+                routineInterval(req.routineRule())
+        );
+        scheduleRepository.save(s);
+
+        // ODsay 동기 호출 — graceful degradation은 RouteService 내부에서 처리 (false 반환)
+        routeService.refreshRouteSync(s);
+
+        return ScheduleResponse.from(s);
+    }
+
+    public ScheduleResponse get(String memberUid, String scheduleUid) {
+        Long memberId = resolveMemberId(memberUid);
+        Schedule s = findOwned(memberId, scheduleUid);
+        return ScheduleResponse.from(s);
+    }
+
+    public CursorResponse<ScheduleListItem> list(String memberUid,
+                                                 OffsetDateTime from,
+                                                 OffsetDateTime to,
+                                                 CursorRequest cursor) {
+        Long memberId = resolveMemberId(memberUid);
+        Long cursorId = decodeCursor(cursor.cursor());
+
+        // limit + 1 조회 → hasMore 판정 + 마지막 row 제거
+        List<Schedule> rows = scheduleRepository.findPage(memberId, from, to, cursorId,
+                PageRequest.of(0, cursor.limit() + 1));
+        boolean hasMore = rows.size() > cursor.limit();
+        if (hasMore) rows = rows.subList(0, cursor.limit());
+
+        String nextCursor = hasMore ? encodeCursor(rows.get(rows.size() - 1).getId()) : null;
+        List<ScheduleListItem> items = rows.stream().map(ScheduleListItem::from).toList();
+        return CursorResponse.of(items, nextCursor);
+    }
+
+    @Transactional
+    public ScheduleResponse update(String memberUid, String scheduleUid, UpdateScheduleRequest req) {
+        Long memberId = resolveMemberId(memberUid);
+        Schedule s = findOwned(memberId, scheduleUid);
+
+        validateTimes(
+                req.userDepartureTime() != null ? req.userDepartureTime() : s.getUserDepartureTime(),
+                req.arrivalTime() != null ? req.arrivalTime() : s.getArrivalTime()
+        );
+
+        Schedule.PlaceUpdate originUpdate = req.origin() != null
+                ? new Schedule.PlaceUpdate(
+                        req.origin().name(), req.origin().lat(), req.origin().lng(),
+                        req.origin().address(), req.origin().placeId(), req.origin().provider())
+                : null;
+        Schedule.PlaceUpdate destinationUpdate = req.destination() != null
+                ? new Schedule.PlaceUpdate(
+                        req.destination().name(), req.destination().lat(), req.destination().lng(),
+                        req.destination().address(), req.destination().placeId(), req.destination().provider())
+                : null;
+        Schedule.RoutineUpdate routineUpdate = req.routineRule() != null
+                ? new Schedule.RoutineUpdate(
+                        req.routineRule().type(),
+                        routineDaysCsv(req.routineRule()),
+                        req.routineRule().intervalDays())
+                : null;
+
+        boolean placeOrArrivalChanged = s.applyUpdate(
+                req.title(), originUpdate, destinationUpdate,
+                req.userDepartureTime(), req.arrivalTime(),
+                req.reminderOffsetMinutes(), routineUpdate
+        );
+
+        if (placeOrArrivalChanged) {
+            // 명세 §5.4 — 출/도착지 또는 arrivalTime 변경 시 ODsay 재호출
+            routeService.refreshRouteSync(s);
+        } else if (req.userDepartureTime() != null) {
+            // 명세 §5.4 비고 — userDepartureTime만 변경 시 ODsay 재호출 X, advice만 재계산
+            s.recalculateDepartureAdvice();
+        }
+
+        return ScheduleResponse.from(s);
+    }
+
+    @Transactional
+    public void delete(String memberUid, String scheduleUid) {
+        Long memberId = resolveMemberId(memberUid);
+        Schedule s = findOwned(memberId, scheduleUid);
+        s.softDelete();
+    }
+
+    // ───── private helpers ─────
+
+    private Long resolveMemberId(String memberUid) {
+        return memberRepository.findByMemberUid(memberUid)
+                .map(Member::getId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+    }
+
+    private Schedule findOwned(Long memberId, String scheduleUid) {
+        Schedule s = scheduleRepository.findByScheduleUid(scheduleUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND));
+        if (!s.belongsTo(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
+        return s;
+    }
+
+    private void validateTimes(OffsetDateTime userDepart, OffsetDateTime arrival) {
+        if (userDepart == null || arrival == null) return;
+        if (!userDepart.isBefore(arrival)) {
+            // 명세 §5.1 에러: userDepartureTime > arrivalTime 또는 동일 시각
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+        if (!arrival.isAfter(OffsetDateTime.now(KST))) {
+            // 명세 §5.1 에러: arrivalTime <= NOW()
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+    }
+
+    private static String encodeCursor(Long id) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString((CURSOR_PREFIX + id).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Long decodeCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) return null;
+        try {
+            String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            if (!decoded.startsWith(CURSOR_PREFIX)) {
+                throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+            }
+            return Long.parseLong(decoded.substring(CURSOR_PREFIX.length()));
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+    }
+
+    private static com.todayway.backend.schedule.domain.RoutineType routineType(RoutineRuleDto r) {
+        return r != null ? r.type() : null;
+    }
+
+    private static String routineDaysCsv(RoutineRuleDto r) {
+        return r != null ? r.toCsv() : null;
+    }
+
+    private static Integer routineInterval(RoutineRuleDto r) {
+        return r != null ? r.intervalDays() : null;
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/member/MemberControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/member/MemberControllerIntegrationTest.java
@@ -201,6 +201,45 @@ class MemberControllerIntegrationTest {
                 .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
+    @Test
+    void softDelete_cascadesScheduleDeletion() throws Exception {
+        // 회원가입 + 일정 1건 등록 (NoOpRouteService default → routeStatus PENDING_RETRY OK)
+        SignupResult signup = signupNew("cascade01", "캐스케이드");
+        String authHeader = "Bearer " + signup.accessToken();
+
+        java.time.OffsetDateTime arrival = java.time.OffsetDateTime.now(java.time.ZoneOffset.ofHours(9)).plusMinutes(60);
+        java.time.OffsetDateTime depart = arrival.minusMinutes(30);
+        String createBody = """
+                {
+                  "title": "탈퇴테스트",
+                  "origin": {"name":"우이동","lat":37.6612,"lng":127.0124},
+                  "destination": {"name":"국민대","lat":37.6103,"lng":126.9969},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s",
+                  "reminderOffsetMinutes": 5
+                }
+                """.formatted(depart, arrival);
+
+        mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", authHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated());
+
+        // 등록 직후 active schedule 1건 확인 (@SQLRestriction 자동 deleted_at IS NULL 필터)
+        assertThat(scheduleRepository.count()).isEqualTo(1L);
+
+        // 회원 탈퇴 → cascade로 schedule도 soft-delete
+        mockMvc.perform(delete("/api/v1/members/me")
+                        .header("Authorization", authHeader))
+                .andExpect(status().isNoContent());
+
+        // active schedule 0건 — Issue #8 회귀 가드
+        assertThat(scheduleRepository.count()).isEqualTo(0L);
+    }
+
+    @Autowired com.todayway.backend.schedule.repository.ScheduleRepository scheduleRepository;
+
     private record SignupResult(String accessToken, String refreshToken, String memberId) {}
 
     private SignupResult signupNew(String loginId, String nickname) throws Exception {

--- a/backend/src/test/java/com/todayway/backend/schedule/ScheduleControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/schedule/ScheduleControllerIntegrationTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todayway.backend.auth.dto.SignupRequest;
 import com.todayway.backend.route.RouteService;
-import com.todayway.backend.schedule.domain.DepartureAdvice;
 import com.todayway.backend.schedule.domain.Schedule;
 import com.todayway.backend.schedule.repository.ScheduleRepository;
 import org.junit.jupiter.api.Test;
@@ -63,13 +62,13 @@ class ScheduleControllerIntegrationTest {
 
     @Test
     void create_happyPath_whenRouteCalculated_returnsCalculated() throws Exception {
-        // ODsay 호출 성공 시뮬레이션 — refreshRouteSync에서 schedule 필드 갱신 + true 반환
+        // ODsay 호출 성공 시뮬레이션 — refreshRouteSync에서 schedule 필드 갱신 + true 반환.
+        // departureAdvice는 Schedule.updateRouteInfo가 내부에서 자동 계산 (claude.ai PR #10 P2 후).
         when(routeService.refreshRouteSync(any(Schedule.class))).thenAnswer(inv -> {
             Schedule s = inv.getArgument(0);
             s.updateRouteInfo(
                     35,
                     s.getArrivalTime().minusMinutes(35),
-                    DepartureAdvice.LATER,
                     "{\"path\":[]}",
                     OffsetDateTime.now(KST)
             );

--- a/backend/src/test/java/com/todayway/backend/schedule/ScheduleControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/schedule/ScheduleControllerIntegrationTest.java
@@ -1,0 +1,293 @@
+package com.todayway.backend.schedule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.DepartureAdvice;
+import com.todayway.backend.schedule.domain.Schedule;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class ScheduleControllerIntegrationTest {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired ScheduleRepository scheduleRepository;
+
+    @MockitoBean RouteService routeService;
+
+    @Test
+    void create_happyPath_whenRouteCalculated_returnsCalculated() throws Exception {
+        // ODsay 호출 성공 시뮬레이션 — refreshRouteSync에서 schedule 필드 갱신 + true 반환
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            s.updateRouteInfo(
+                    35,
+                    s.getArrivalTime().minusMinutes(35),
+                    DepartureAdvice.LATER,
+                    "{\"path\":[]}",
+                    OffsetDateTime.now(KST)
+            );
+            return true;
+        });
+
+        String accessToken = signupAndGetToken("schhappy01", "스케줄해피");
+        String body = createScheduleBody(arrivalIn(60));
+
+        mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.scheduleId").exists())
+                .andExpect(jsonPath("$.data.routeStatus").value("CALCULATED"))
+                .andExpect(jsonPath("$.data.estimatedDurationMinutes").value(35))
+                .andExpect(jsonPath("$.data.recommendedDepartureTime").exists())
+                .andExpect(jsonPath("$.data.departureAdvice").value("LATER"));
+
+        verify(routeService, times(1)).refreshRouteSync(any(Schedule.class));
+    }
+
+    @Test
+    void create_whenODsayDegradation_returnsPendingRetry() throws Exception {
+        // ODsay 실패 시뮬레이션 — false 반환 + schedule 미수정 (NoOpRouteService 동작과 동일)
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String accessToken = signupAndGetToken("schdegrade01", "그레이스풀");
+        String body = createScheduleBody(arrivalIn(60));
+
+        mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.routeStatus").value("PENDING_RETRY"))
+                .andExpect(jsonPath("$.data.estimatedDurationMinutes").doesNotExist())
+                .andExpect(jsonPath("$.data.routeCalculatedAt").doesNotExist());
+    }
+
+    @Test
+    void list_returnsCursorPaginated() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String accessToken = signupAndGetToken("schlist01", "리스트");
+        // 3건 등록 (서로 다른 도착 시각)
+        for (int i = 1; i <= 3; i++) {
+            mockMvc.perform(post("/api/v1/schedules")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(createScheduleBody(arrivalIn(60 + i * 60))))
+                    .andExpect(status().isCreated());
+        }
+
+        // 첫 페이지 limit=2 → 2개 + nextCursor 존재
+        String firstPage = mockMvc.perform(get("/api/v1/schedules?limit=2")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(2))
+                .andExpect(jsonPath("$.data.nextCursor").exists())
+                .andExpect(jsonPath("$.data.hasMore").value(true))
+                .andReturn().getResponse().getContentAsString();
+        String nextCursor = objectMapper.readTree(firstPage).path("data").path("nextCursor").asText();
+
+        // 다음 페이지 → 1개 + nextCursor null
+        mockMvc.perform(get("/api/v1/schedules?limit=2&cursor=" + nextCursor)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.hasMore").value(false));
+    }
+
+    @Test
+    void get_whenNotOwn_returns403Forbidden() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        // 회원 A가 schedule 생성
+        String tokenA = signupAndGetToken("ownerA01", "주인A");
+        String createResp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createScheduleBody(arrivalIn(60))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        String scheduleId = objectMapper.readTree(createResp).path("data").path("scheduleId").asText();
+
+        // 회원 B가 A의 schedule 조회 시도 → 403
+        String tokenB = signupAndGetToken("strangerB01", "타인B");
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId)
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN_RESOURCE"));
+    }
+
+    @Test
+    void delete_softDeletes_thenGetReturns404() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String accessToken = signupAndGetToken("schdel01", "삭제");
+        String createResp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createScheduleBody(arrivalIn(60))))
+                .andReturn().getResponse().getContentAsString();
+        String scheduleId = objectMapper.readTree(createResp).path("data").path("scheduleId").asText();
+
+        mockMvc.perform(delete("/api/v1/schedules/" + scheduleId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        // 동일 scheduleId 재조회 → 404 (소프트 삭제)
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("SCHEDULE_NOT_FOUND"));
+    }
+
+    @Test
+    void update_whenArrivalChanged_triggersODsayRefresh() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String accessToken = signupAndGetToken("schupd01", "업데이트");
+        String createResp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createScheduleBody(arrivalIn(60))))
+                .andReturn().getResponse().getContentAsString();
+        String scheduleId = objectMapper.readTree(createResp).path("data").path("scheduleId").asText();
+
+        // arrivalTime 변경 → ODsay 재호출 (refreshRouteSync 2번째 호출)
+        OffsetDateTime newArrival = OffsetDateTime.now(KST).plusMinutes(120);
+        mockMvc.perform(patch("/api/v1/schedules/" + scheduleId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"arrivalTime\":\"" + newArrival + "\"}"))
+                .andExpect(status().isOk());
+
+        verify(routeService, times(2)).refreshRouteSync(any(Schedule.class));  // create 1 + update 1
+    }
+
+    @Test
+    void update_whenOnlyUserDepartureTimeChanged_doesNotCallRouteRefresh() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String accessToken = signupAndGetToken("schupd02", "출발만");
+        String createResp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createScheduleBody(arrivalIn(60))))
+                .andReturn().getResponse().getContentAsString();
+        String scheduleId = objectMapper.readTree(createResp).path("data").path("scheduleId").asText();
+
+        // userDepartureTime만 변경 → ODsay 재호출 X (명세 §5.4 비고)
+        OffsetDateTime newDepart = OffsetDateTime.now(KST).plusMinutes(30);
+        mockMvc.perform(patch("/api/v1/schedules/" + scheduleId)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userDepartureTime\":\"" + newDepart + "\"}"))
+                .andExpect(status().isOk());
+
+        verify(routeService, times(1)).refreshRouteSync(any(Schedule.class));  // create 1번만
+    }
+
+    @Test
+    void create_whenArrivalBeforeDeparture_returns400() throws Exception {
+        String accessToken = signupAndGetToken("schval01", "검증");
+
+        OffsetDateTime depart = OffsetDateTime.now(KST).plusMinutes(60);
+        OffsetDateTime arrival = depart.minusMinutes(10);  // arrival < depart → 400
+        String body = """
+                {
+                  "title": "잘못된시간",
+                  "origin": {"name":"출발","lat":37.66,"lng":127.01},
+                  "destination": {"name":"도착","lat":37.61,"lng":126.99},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s"
+                }
+                """.formatted(depart, arrival);
+
+        mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+
+        verify(routeService, never()).refreshRouteSync(any(Schedule.class));
+    }
+
+    // ───── helpers ─────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private static OffsetDateTime arrivalIn(long minutes) {
+        return OffsetDateTime.now(KST).plusMinutes(minutes);
+    }
+
+    private static String createScheduleBody(OffsetDateTime arrival) {
+        OffsetDateTime depart = arrival.minusMinutes(30);
+        return """
+                {
+                  "title": "테스트일정",
+                  "origin": {"name":"우이동","lat":37.6612,"lng":127.0124},
+                  "destination": {"name":"국민대","lat":37.6103,"lng":126.9969},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s",
+                  "reminderOffsetMinutes": 5
+                }
+                """.formatted(depart, arrival);
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/schedule/domain/RoutineCalculatorTest.java
+++ b/backend/src/test/java/com/todayway/backend/schedule/domain/RoutineCalculatorTest.java
@@ -1,0 +1,97 @@
+package com.todayway.backend.schedule.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RoutineCalculator 단위 테스트. BACKEND_CONTEXT §13.4 표 6 케이스.
+ *
+ * | current | type   | daysOfWeek    | intervalDays | expected  |
+ * |---------|--------|---------------|--------------|-----------|
+ * | 화 09:00 | WEEKLY | MON,FRI       | -            | 금 09:00  |
+ * | 금 09:00 | WEEKLY | MON,WED,FRI   | -            | 월 09:00  |
+ * | 일 09:00 | WEEKLY | MON           | -            | 월 09:00  |
+ * | 월 09:00 | DAILY  | -             | -            | 화 09:00  |
+ * | 월 09:00 | CUSTOM | -             | 3            | 목 09:00  |
+ * | 월 09:00 | ONCE   | -             | -            | null      |
+ */
+class RoutineCalculatorTest {
+
+    private final RoutineCalculator calculator = new RoutineCalculator();
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("cases")
+    void calculateNextOccurrence(String name, OffsetDateTime current, RoutineType type,
+                                 String daysOfWeek, Integer intervalDays, OffsetDateTime expected) {
+        Schedule s = newSchedule(current, type, daysOfWeek, intervalDays);
+
+        OffsetDateTime actual = calculator.calculateNextOccurrence(s);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> cases() {
+        // 2026-04-21 (화) 09:00 KST
+        OffsetDateTime tue = OffsetDateTime.of(2026, 4, 21, 9, 0, 0, 0, KST);
+        // 2026-04-24 (금)
+        OffsetDateTime fri = OffsetDateTime.of(2026, 4, 24, 9, 0, 0, 0, KST);
+        // 2026-04-26 (일)
+        OffsetDateTime sun = OffsetDateTime.of(2026, 4, 26, 9, 0, 0, 0, KST);
+        // 2026-04-27 (월)
+        OffsetDateTime mon = OffsetDateTime.of(2026, 4, 27, 9, 0, 0, 0, KST);
+
+        return Stream.of(
+                Arguments.of("화→금 (WEEKLY MON,FRI)", tue, RoutineType.WEEKLY, "MON,FRI", null,
+                        OffsetDateTime.of(2026, 4, 24, 9, 0, 0, 0, KST)),
+                Arguments.of("금→월 (WEEKLY MON,WED,FRI)", fri, RoutineType.WEEKLY, "MON,WED,FRI", null,
+                        OffsetDateTime.of(2026, 4, 27, 9, 0, 0, 0, KST)),
+                Arguments.of("일→월 (WEEKLY MON)", sun, RoutineType.WEEKLY, "MON", null,
+                        OffsetDateTime.of(2026, 4, 27, 9, 0, 0, 0, KST)),
+                Arguments.of("월→화 (DAILY)", mon, RoutineType.DAILY, null, null,
+                        OffsetDateTime.of(2026, 4, 28, 9, 0, 0, 0, KST)),
+                Arguments.of("월→목 (CUSTOM 3일)", mon, RoutineType.CUSTOM, null, 3,
+                        OffsetDateTime.of(2026, 4, 30, 9, 0, 0, 0, KST)),
+                Arguments.of("월→null (ONCE)", mon, RoutineType.ONCE, null, null, null)
+        );
+    }
+
+    @Test
+    void calculateNextOccurrence_whenWeeklyDaysEmpty_returnsNull() {
+        Schedule s = newSchedule(OffsetDateTime.now(KST), RoutineType.WEEKLY, "", null);
+        assertThat(calculator.calculateNextOccurrence(s)).isNull();
+    }
+
+    @Test
+    void calculateNextOccurrence_whenCustomIntervalNull_returnsNull() {
+        Schedule s = newSchedule(OffsetDateTime.now(KST), RoutineType.CUSTOM, null, null);
+        assertThat(calculator.calculateNextOccurrence(s)).isNull();
+    }
+
+    @Test
+    void calculateNextOccurrence_whenTypeNull_returnsNull() {
+        Schedule s = newSchedule(OffsetDateTime.now(KST), null, null, null);
+        assertThat(calculator.calculateNextOccurrence(s)).isNull();
+    }
+
+    private static Schedule newSchedule(OffsetDateTime arrivalTime, RoutineType type,
+                                        String daysOfWeek, Integer intervalDays) {
+        OffsetDateTime depart = arrivalTime.minusMinutes(30);
+        return Schedule.create(
+                1L, "title",
+                "출발", BigDecimal.ZERO, BigDecimal.ZERO, null, null, null,
+                "도착", BigDecimal.ZERO, BigDecimal.ZERO, null, null, null,
+                depart, arrivalTime, 5,
+                type, daysOfWeek, intervalDays
+        );
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/schedule/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/com/todayway/backend/schedule/service/ScheduleServiceTest.java
@@ -1,0 +1,135 @@
+package com.todayway.backend.schedule.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.Schedule;
+import com.todayway.backend.schedule.dto.ScheduleResponse;
+import com.todayway.backend.schedule.dto.UpdateScheduleRequest;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * ScheduleService.update의 PATCH validateTimes 분기 회귀 가드 (claude.ai PR #10 P1).
+ * c9 (854dd8f)에서 도입한 3중 분기:
+ *   - arrivalTime 포함 → validateTimes (NOW 검사 포함)
+ *   - userDepartureTime만 → validateOrderOnly (NOW skip)
+ *   - 둘 다 없음 → 검증 skip
+ *
+ * 누군가 분기를 무심코 합치면 silent regression — 이 테스트 3건이 컴파일/빌드 fail로 차단.
+ */
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+    private static final String MEMBER_UID = "01HMM0123456789ABCDEFGHJK";
+    private static final String SCHEDULE_UID = "01HSS0123456789ABCDEFGHJK";
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock MemberRepository memberRepository;
+    @Mock ScheduleRepository scheduleRepository;
+    @Mock RouteService routeService;
+
+    @InjectMocks ScheduleService scheduleService;
+
+    @Test
+    void update_whenScheduleIsPastAndOnlyTitleChanged_skipsNowValidation() {
+        // 지난 일정 + title만 PATCH → NOW() 검사 skip + 200 (claude.ai P1 핵심 시나리오)
+        Member member = mockMember(MEMBER_ID);
+        Schedule pastSchedule = pastScheduleFixture(MEMBER_ID);
+        when(memberRepository.findByMemberUid(MEMBER_UID)).thenReturn(Optional.of(member));
+        when(scheduleRepository.findByScheduleUid(SCHEDULE_UID)).thenReturn(Optional.of(pastSchedule));
+
+        UpdateScheduleRequest req = new UpdateScheduleRequest(
+                "변경된 메모", null, null, null, null, null, null);
+
+        ScheduleResponse resp = scheduleService.update(MEMBER_UID, SCHEDULE_UID, req);
+
+        assertThat(resp.title()).isEqualTo("변경된 메모");
+        verify(routeService, never()).refreshRouteSync(any(Schedule.class));
+    }
+
+    @Test
+    void update_whenArrivalTimeIsBeforeNow_throwsValidationError() {
+        // PATCH에 NOW() 이전 arrivalTime 명시 → validateTimes 발동 → 400
+        Member member = mockMember(MEMBER_ID);
+        Schedule schedule = futureScheduleFixture(MEMBER_ID);
+        when(memberRepository.findByMemberUid(MEMBER_UID)).thenReturn(Optional.of(member));
+        when(scheduleRepository.findByScheduleUid(SCHEDULE_UID)).thenReturn(Optional.of(schedule));
+
+        OffsetDateTime pastArrival = OffsetDateTime.now(KST).minusHours(1);
+        UpdateScheduleRequest req = new UpdateScheduleRequest(
+                null, null, null, null, pastArrival, null, null);
+
+        assertThatThrownBy(() -> scheduleService.update(MEMBER_UID, SCHEDULE_UID, req))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.VALIDATION_ERROR);
+    }
+
+    @Test
+    void update_whenUserDepartureAfterArrival_throwsValidationError() {
+        // userDepartureTime만 변경 + 순서 위반 (depart > arrival) → validateOrderOnly 발동 → 400
+        Member member = mockMember(MEMBER_ID);
+        Schedule schedule = futureScheduleFixture(MEMBER_ID);
+        when(memberRepository.findByMemberUid(MEMBER_UID)).thenReturn(Optional.of(member));
+        when(scheduleRepository.findByScheduleUid(SCHEDULE_UID)).thenReturn(Optional.of(schedule));
+
+        // schedule.arrivalTime 이후로 userDepart 박음 → 순서 위반
+        OffsetDateTime invalidDepart = schedule.getArrivalTime().plusMinutes(10);
+        UpdateScheduleRequest req = new UpdateScheduleRequest(
+                null, null, null, invalidDepart, null, null, null);
+
+        assertThatThrownBy(() -> scheduleService.update(MEMBER_UID, SCHEDULE_UID, req))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.VALIDATION_ERROR);
+    }
+
+    // ───── helpers ─────
+
+    private static Member mockMember(Long id) {
+        Member m = mock(Member.class);
+        when(m.getId()).thenReturn(id);
+        return m;
+    }
+
+    private static Schedule pastScheduleFixture(Long memberId) {
+        OffsetDateTime pastArrival = OffsetDateTime.now(KST).minusDays(1);
+        return Schedule.create(
+                memberId, "원래 메모",
+                "출발", BigDecimal.ZERO, BigDecimal.ZERO, null, null, null,
+                "도착", BigDecimal.ZERO, BigDecimal.ZERO, null, null, null,
+                pastArrival.minusMinutes(30), pastArrival, 5,
+                null, null, null
+        );
+    }
+
+    private static Schedule futureScheduleFixture(Long memberId) {
+        OffsetDateTime futureArrival = OffsetDateTime.now(KST).plusMinutes(60);
+        return Schedule.create(
+                memberId, "원래 메모",
+                "출발", BigDecimal.ZERO, BigDecimal.ZERO, null, null, null,
+                "도착", BigDecimal.ZERO, BigDecimal.ZERO, null, null, null,
+                futureArrival.minusMinutes(30), futureArrival, 5,
+                null, null, null
+        );
+    }
+}


### PR DESCRIPTION
## 요약

Step 5 schedule 도메인 — **황찬우 백엔드 작업의 마지막 Step**. 일정 CRUD + 루틴 + cursor 페이지네이션 + RouteService 인터페이스(이상진 Step 6 unblock) + cascade Issue #8.

본 PR 머지 후 이상진 Step 6~9 작업 진입 가능 (RouteService 구현체 / OdsayClient / PushScheduler 등).

## 변경 사항 (11 commit)

| Commit | 내용 |
|---|---|
| c1 | `Schedule` 엔티티 + ENUM 3 (`PlaceProvider`/`DepartureAdvice`/`RoutineType`) + `DayOfWeekMapper` |
| c2 | `ScheduleRepository` (cursor + nearest + reminder + cascade) |
| c3 | `RoutineCalculator` + 9 단위 테스트 |
| c4 | `route/` 패키지 (RouteService 인터페이스 + RouteResponse + NoOpRouteService + RouteServiceConfig) |
| c5 | `ScheduleService` + DTO 6 (`PlaceDto`/`RoutineRuleDto`/`CreateScheduleRequest`/`UpdateScheduleRequest`/`ScheduleResponse`/`ScheduleListItem`) |
| c6 | `ScheduleController` 5 엔드포인트 |
| c7 | 통합 테스트 8 시나리오 (`@MockitoBean RouteService`) |
| c8 | `MemberService.softDelete` cascade (closes #8) + 회귀 가드 통합 테스트 |
| **c9** | **fix: PATCH `NOW()` 검사를 `arrivalTime` 포함 시에만 적용 (claude.ai P1, 명세 v1.1.8)** |
| **c10** | **refactor: `Schedule.updateRouteInfo`가 `departureAdvice` 자체 계산 (claude.ai P2 invariant 통합)** |
| **c11** | **test: `ScheduleServiceTest` 단위 테스트 — P1 분기 회귀 가드 3 케이스** |

## 적용된 외부 리뷰/패턴

- **β 패턴 default** — `@CurrentMember String memberUid` + Service 진입부 `findByMemberUid` 1회
- **패턴 3 (인계-2)** — `scheduleUid CHAR(26) columnDefinition` 적용
- **JPQL `deletedAt IS NULL` 명시 (인계-4)** — `findPage` / `findDueReminders` / `softDeleteByMemberId` 모두
- **ENUM 4 컬럼 columnDefinition 명시** — `origin_provider` / `destination_provider` / `departure_advice` / `routine_type`
- **deleted invariant 가드** — `Schedule.applyUpdate` / `updateRouteInfo` 첫 줄 (Member 패턴 정합)
- **Issue #8 회귀 가드 통합 테스트** — 회원 탈퇴 → schedule 일괄 비활성 검증
- **claude.ai PR #10 후속 흡수** — c9 (PATCH UX 버그 fix), c10 (Step 6 silent drift 컴파일 강제 차단), c11 (P1 분기 회귀 가드)

## ODsay 동기 호출 흐름

- 일정 등록/수정 시 `RouteService.refreshRouteSync(schedule)` 호출
- 성공: `routeStatus = "CALCULATED"` + 경로 필드 갱신
- 실패: `routeStatus = "PENDING_RETRY"` (graceful degradation, 명세 §5.1)
- 명세 §5.4 분기: 출/도착지 또는 arrivalTime 변경 → 재호출 / `userDepartureTime`만 변경 → `recalculateDepartureAdvice`만
- 명세 §5.4 v1.1.8 — PATCH `arrivalTime` NOW() 검사는 요청에 `arrivalTime`이 포함된 경우에만 적용 (지난 일정 메모 편집 허용)

## ⚠️ 이상진 Step 6 인계 (D11 — 사전 합의 X, 본 PR 확인 바람)

`route/` 패키지 4 file을 황찬우가 미리 박았습니다. 도메인 경계상 이상진 영역이지만 ScheduleService 컴파일을 위해 필요. **검토 부탁드립니다**:

- **인터페이스 시그니처**: `refreshRouteSync(Schedule) → boolean` / `getRoute(Schedule, boolean) → RouteResponse` — 변경 필요 시 본 PR 후속 별 PR로 처리 가능
- **`RouteResponse` record는 임시** — Step 6에서 명세 §11.4 `Route` 도메인 객체로 좁힘
- **`refreshRouteSync` 구현 시 채울 필드**: `estimatedDurationMinutes` / `recommendedDepartureTime` / `routeSummaryJson`만 채우면 됨. **`departureAdvice` / `reminderAt`은 `Schedule.updateRouteInfo` 내부에서 자동 계산** (c10 invariant 통합 — `ON_TIME_WINDOW_MINUTES` 일관성 컴파일 강제)
- **NoOpRouteService 자동 비활성**: `RouteServiceConfig`의 `@ConditionalOnMissingBean(RouteService.class)`로 OdsayRouteService 등록 시 NoOp 자동 비활성. **다만 NoOpRouteService class 자체는 dead code로 남으므로 Step 6 PR에서 cleanup 권장**
- **ExternalApiException 변환 책임**: `RuntimeException` 상속(`BusinessException` 아님) → OdsayRouteService에서 catch + `BusinessException` 변환 필수 (명세 §1.6 502/503/504 정합)

## 후속 작업 (외부 리뷰 받은 후 결정)

- 명세 §5.4 PATCH 둘 다 null 정책 — Member의 Q1-B 패턴(silent 사고 방지) 적용 여부
- cursor 인코딩 보안성 — opaque hash 강화 여부
- `RoutineRuleDto.daysOfWeek` Bean Validation `@Pattern` (claude.ai PR #10 P5)
- `MemberControllerIntegrationTest.scheduleRepository` autowire 위치 정리 (claude.ai PR #10 P3)

## Break change

0건 — 신규 도메인, 외부 계약 변경 X.

## 검증

- `./gradlew build` BUILD SUCCESSFUL — 단위 + 통합 모두 PASS
- 단위 테스트: `RoutineCalculatorTest` 9건 + `ScheduleServiceTest` 3건 (P1 회귀 가드) + `MemberInvariantTest` 4건 + 기존 모두 PASS
- 통합 테스트: `ScheduleControllerIntegrationTest` 8건 + `MemberControllerIntegrationTest.softDelete_cascadesScheduleDeletion` (cascade 회귀 가드) + 기존 모두 PASS

closes #8