### PR TITLE
chore(backend): EC2/RDS 배포 환경변수 분리 + Dockerfile

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,25 @@
+# Gradle 빌드 산출물 — 컨테이너 안에서 재빌드
+build/
+.gradle/
+out/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# 시크릿 (실수로 이미지에 박히는 사고 방지)
+.env
+.env.*
+!.env.example
+
+# 로컬 OS
+.DS_Store
+Thumbs.db
+
+# 외부 JAR / 로그 / 임시 파일
+*.jar
+*.log
+*.tmp
+
+# Dockerfile 자체는 build context에 필요하므로 제외 X

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,18 +1,31 @@
-# DB 접속 정보 (로컬 개발용)
+# =============================================================================
+# 로컬 개발용 .env 템플릿 — `cp .env.example .env` 후 값 채우기
+# 운영 EC2는 이 파일이 아닌 /etc/todayway/app.env 에 같은 키 구조로 채움
+# =============================================================================
+
+# --- DB 접속 ---
+# 로컬: 도커 mysql:8.0 컨테이너 가정 (host=localhost, port=3306)
+# 운영: RDS endpoint를 DB_HOST에 박음
+# DB_SSL_MODE 값: DISABLED / PREFERRED (default, server 지원 시 SSL) / REQUIRED (SSL 강제) / VERIFY_CA / VERIFY_IDENTITY
+#   - 운영 RDS 권장: REQUIRED (require_secure_transport=ON일 시 필수)
+#   - 로컬 dev: PREFERRED 그대로
+DB_HOST=localhost
+DB_PORT=3306
 DB_NAME=routine_commute
 DB_USER=root
 DB_PASSWORD=
+DB_SSL_MODE=PREFERRED
 
-# 서버 포트 (기본 8080)
+# --- 서버 ---
 SERVER_PORT=8080
 
-# JWT (256-bit Base64-encoded — openssl rand -base64 32 로 생성)
+# --- JWT (256-bit Base64-encoded — `openssl rand -base64 32` 로 생성) ---
 JWT_SECRET=changeme-base64-encoded-256bit-secret
 
-# 외부 API 키 (도메인 담당자가 본인 작업 시 채움)
+# --- 외부 API 키 (도메인 담당자가 본인 작업 시 채움) ---
 ODSAY_API_KEY=
 KAKAO_LOCAL_API_KEY=
 
-# Web Push (VAPID 키페어 — web-push generate-vapid-keys 로 생성)
+# --- Web Push (VAPID 키페어 — `web-push generate-vapid-keys` 로 생성) ---
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# =============================================================================
+# Build stage — Gradle wrapper로 bootJar 생성 (테스트 skip)
+# =============================================================================
+FROM eclipse-temurin:21-jdk-jammy AS build
+WORKDIR /workspace
+
+# 의존성 레이어 캐시 활용: build 파일 먼저 복사
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon --no-watch-fs || true
+
+# 소스 복사 후 빌드
+COPY src src
+RUN ./gradlew bootJar -x test --no-daemon --no-watch-fs
+
+# =============================================================================
+# Runtime stage — JRE slim + non-root + KST 시간대
+# =============================================================================
+FROM eclipse-temurin:21-jre-jammy
+
+ENV TZ=Asia/Seoul
+
+RUN useradd --create-home --shell /bin/bash spring
+USER spring
+WORKDIR /home/spring
+
+COPY --from=build /workspace/build/libs/*.jar /home/spring/app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/home/spring/app.jar"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -42,6 +42,49 @@ export $(cat .env | xargs)
 
 → http://localhost:8080/actuator/health 로 헬스 체크
 
+## EC2 운영 (Docker)
+
+EC2에서 RDS에 붙어 동작시킬 때:
+
+### 1. `/etc/todayway/app.env` 작성 (root, `chmod 600`)
+
+`.env.example`과 동일 키 구조. 운영 값:
+
+| 키 | 값 |
+|---|---|
+| `DB_HOST` | RDS endpoint |
+| `DB_PORT` | RDS 포트 (보통 `3306`) |
+| `DB_NAME` | `routine_commute` |
+| `DB_USER` / `DB_PASSWORD` | RDS master credential |
+| `DB_SSL_MODE` | `REQUIRED` (RDS 운영 권장) / `PREFERRED` (default, server 지원 시 SSL) / `VERIFY_CA` (RDS CA bundle로 cert 검증) |
+| `JWT_SECRET` | `openssl rand -base64 32` 결과 |
+| `ODSAY_API_KEY` / `KAKAO_LOCAL_API_KEY` / `VAPID_*` | 외부 키 (도메인 담당자) |
+
+### 2. 이미지 빌드 + 실행
+
+```bash
+# EC2에서 직접 빌드 시
+docker build -t todayway-backend backend/
+
+# 실행
+docker run -d --name todayway \
+  --restart=unless-stopped \
+  --env-file /etc/todayway/app.env \
+  -p 8080:8080 \
+  todayway-backend
+```
+
+GHCR 이미지를 쓸 경우 `todayway-backend` 자리에 `ghcr.io/kookmin-sw/2026-capstone-53/backend:latest`.
+
+### 3. 검증
+
+```bash
+docker logs -f todayway          # Flyway 로그 + Started BackendApplication
+curl localhost:8080/actuator/health   # {"status":"UP"}
+```
+
+Flyway 로그에 `Successfully applied 1 migration` 또는 `Schema is up to date` 중 하나가 보이면 정상.
+
 ## 도메인 패키지
 
 본인 도메인 패키지를 직접 추가해서 작업합니다 (예: `com.todayway.backend.{도메인}`).
@@ -59,3 +102,4 @@ export $(cat .env | xargs)
 
 - `.env` 는 절대 커밋 금지 (`.gitignore` 등록됨)
 - 외부 API 키 / DB 패스워드는 환경변수로만 주입
+- **RDS endpoint, master credential 등 운영 시크릿은 README/코드에 박지 않음** — EC2의 `/etc/todayway/app.env`에만 존재

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -64,6 +64,11 @@ dependencies {
 	testImplementation("org.springframework.security:spring-security-test")
 }
 
+// 운영 이미지 빌드 시 plain JAR 불필요 — bootJar만 산출 (Dockerfile wildcard 충돌 방지)
+tasks.named<Jar>("jar") {
+	enabled = false
+}
+
 tasks.withType<Test> {
 	useJUnitPlatform()
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 30s
   datasource:
-    url: jdbc:mysql://localhost:3306/${DB_NAME:routine_commute}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:routine_commute}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&sslMode=${DB_SSL_MODE:PREFERRED}
     username: ${DB_USER:root}
     password: ${DB_PASSWORD:}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 변경 사항

EC2에서 RDS에 붙어 백엔드 컨테이너로 띄울 수 있게 인프라 설정 분리 + Dockerfile 추가.

- `application.yml`: DB URL의 host/port를 환경변수로 분리 (`DB_HOST`/`DB_PORT`). 기존 default `localhost:3306` 유지 → 로컬 dev 흐름 영향 0.
- `application.yml`: SSL 옵션 — `sslMode=${DB_SSL_MODE:PREFERRED}` 추가. PREFERRED default라 로컬 mysql:8.0 (SSL 자동 활성)에서 자동 SSL handshake. caching_sha2_password 인증이 channel 암호화 위에서 통과.
- `.env.example`: `DB_HOST`/`DB_PORT`/`DB_SSL_MODE` 키 추가, 운영/로컬 가이드 주석.
- `build.gradle.kts`: `tasks.named<Jar>("jar") { enabled = false }` 추가. Spring Boot 3 default가 bootJar + plainJar 둘 다 산출 → Dockerfile의 wildcard COPY 충돌 방지.
- `Dockerfile`: multi-stage. build (`eclipse-temurin:21-jdk-jammy`) + runtime (`-jre-jammy`). non-root user, `TZ=Asia/Seoul`, gradle wrapper로 의존성 캐시 레이어 활용.
- `.dockerignore`: `build/`, `.gradle/`, `.env`, `.idea/`, `*.jar` 등 빌드 컨텍스트 제외 + 시크릿 사고 방지.
- `README`: "EC2 운영 (Docker)" 섹션 추가 — `/etc/todayway/app.env` 키 표 + `docker run --env-file` 표준 명령. 시크릿이 코드/README에 박히지 않게 보안 주의사항 명시.

## 테스트

- [x] `./gradlew build` (통합 테스트 포함 전체 통과, 3m 26s)
- [x] `Task :jar SKIPPED` 확인 (plainJar disable 정상 작동)
- [x] `docker build -t todayway-backend .` 이미지 생성 성공
- [x] `docker run --env-file .env -e DB_HOST=host.docker.internal -p 8080:8080 todayway-backend` 정상 시작
- [x] Flyway 마이그레이션: `Successfully validated 1 migration` + `Schema is up to date`
- [x] Tomcat startup: `Started BackendApplication in 11.998 seconds`
- [x] `/actuator/health` → `{"status":"UP"}`

## EC2 운영자 인계 사항

EC2에서 띄울 때 `/etc/todayway/app.env` 작성 필요 (root, chmod 600). 키 구조는 `backend/.env.example`과 동일하되 운영 값으로:

| 키 | 운영 값 |
|---|---|
| `DB_HOST` | RDS endpoint |
| `DB_PORT` | `3306` |
| `DB_NAME` | `routine_commute` |
| `DB_USER` / `DB_PASSWORD` | RDS master credential |
| `DB_SSL_MODE` | `REQUIRED` 권장 (RDS 파라미터 그룹 `require_secure_transport`가 ON일 시 필수) |
| `JWT_SECRET` | `openssl rand -base64 32` 결과 |
| 외부 API 키 | 도메인 담당자 채움 |

빌드+실행:
```docker build -t todayway-backend backend/
docker run -d --name todayway \
  --restart=unless-stopped \
  --env-file /etc/todayway/app.env \
  -p 8080:8080 todayway-backend```

검증:
```docker logs -f todayway          # Flyway 로그 + Started BackendApplication
curl localhost:8080/actuator/health   # {"status":"UP"}```

## 명세 참조

- `BACKEND_CONTEXT.md` §2 — 기존 `backend/` 폴더에 추가만, 새 init X
- 팀장 인프라 문서 — `/etc/todayway/app.env` 표준 + GHCR 이미지 패턴

## 후속 작업 (별건)

- `Using generated security password` WARN — Spring Security default UserDetailsService cleanup. 우리 JWT 흐름과 무관 (generated password 사용 0). 우선순위 P3.
- GHCR 이미지 push workflow — 팀장 deploy.yml 작성 시점에 매칭.
- RDS `require_secure_transport` 확인 후 README의 `DB_SSL_MODE` 권장값 갱신.
- HikariCP 풀 튜닝 — RDS 인스턴스 크기 + 동시 사용자 패턴 확정 후.