### PR TITLE
feat(backend/route): ODsay loadLane 도로 곡선 통합 + 명세 v1.1.10

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -131,7 +131,7 @@ Authorization: Bearer {accessToken}
 | 404 | `GEOCODE_NO_MATCH` | 지오코딩 결과 없음 |
 | 404 | `SUBSCRIPTION_NOT_FOUND` | 푸시 구독 없음 |
 | 409 | `LOGIN_ID_DUPLICATED` | 로그인 ID 중복 |
-| 502 | `EXTERNAL_ROUTE_API_FAILED` | ODsay 호출 실패 |
+| 502 | `EXTERNAL_ROUTE_API_FAILED` | ODsay 호출 실패 (5xx / 네트워크 장애 / 일반 4xx — 401/403 제외) |
 | **503** | **`EXTERNAL_AUTH_MISCONFIGURED`** | **외부 API 키 미설정 또는 인증 실패. 운영자 조치 필요 (일반 외부장애와 구분) — v1.1.4 추가** |
 | 503 | `MAP_PROVIDER_UNAVAILABLE` | 지도 SDK 설정 조회 불가 |
 | 504 | `EXTERNAL_TIMEOUT` | 외부 API 타임아웃 |
@@ -780,8 +780,10 @@ LIMIT ?
           "mode": "SUBWAY",
           "durationMinutes": 25,
           "distanceMeters": 7500,
+          "from": "우이동역",
+          "to": "성신여대입구역",
           "lineName": "우이신설선",
-          "lineId": "1027",
+          "lineId": "109",
           "stationStart": "우이동역",
           "stationEnd": "성신여대입구역",
           "stationCount": 7,
@@ -826,7 +828,7 @@ LIMIT ?
 | `totalDurationMinutes` | `result.path[0].info.totalTime` | 분 |
 | `totalDistanceMeters` | `result.path[0].info.totalDistance` | m |
 | `totalWalkMeters` | `result.path[0].info.totalWalk` | m |
-| `transferCount` | `result.path[0].info.subwayTransitCount + busTransitCount` | 합산 |
+| `transferCount` | `result.path[0].info.subwayTransitCount + busTransitCount` | 합산. ⚠️ 의미(*환승 횟수* vs *이용 노선 수*) 미확정 — 명세팀 답변 후 v1.1.x 후속 패치 (PR #11 P2 #3) |
 | `payment` | `result.path[0].info.payment` | 원 |
 
 `segments[]` 매핑 (`result.path[0].subPath[]` 순회):
@@ -862,7 +864,15 @@ GET https://api.odsay.com/v1/api/loadLane?mapObject=0:0@{info.mapObj}&apiKey={ke
 - `mapObject` 형식: **`"0:0@" + result.path[0].info.mapObj`** ⚠️ ODsay 공식 문서엔 prefix 명시 안 됨. 검증된 패턴
 - 응답: `result.lane[i].section[j].graphPos[k].{x, y}` — `lane[i]`가 i번째 transit subPath와 1:1 매칭, `section[]`은 평탄화하여 한 transit segment의 path로 합침
 - 호출 흐름: `searchPubTransPathT` → 응답에서 `info.mapObj` 추출 → `loadLane` 호출 (직렬, mapObj 의존)
-- **graceful fallback**: `loadLane` 5xx/timeout/응답 형식 위반 / `info.mapObj` 누락 / `lane[]` 비었을 때 → `passStopList.stations[].x/y` 직선으로 fallback. `searchPubTransPathT`는 정상이라 응답 가능 (cache 갱신도 진행)
+- **graceful fallback** — 다음 케이스에서 `passStopList.stations[].x/y` 직선으로 fallback:
+  - `loadLane` 5xx/timeout/응답 형식 위반
+  - `searchPubTransPathT` 응답에 `info.mapObj` 누락 또는 빈 문자열
+  - `result.lane`이 array 아님 또는 길이가 transit subPath 개수와 불일치 (부분 매핑은 *swap 위험*으로 금지 — 잘못된 노선 곡선이 silent하게 그려지는 시각 버그)
+  - `graphPos[].{x, y}` 좌표 sanity 위반: NaN/Infinity, 한국 좌표 범위 밖(경도 124~132 / 위도 33~39)
+  - lane의 graphPos 점이 2개 미만 (polyline 무의미)
+
+  `searchPubTransPathT`는 정상이라 응답 자체는 가능 (cache 갱신도 진행).
+- **auth 격상 (운영자 alert)**: `loadLane` 401/403은 graceful 흡수하지 않고 propagate → `searchPubTransPathT`와 동일하게 `503 EXTERNAL_AUTH_MISCONFIGURED`로 격상 (API 키 미설정/만료는 운영 조치 필요)
 
 **`route_summary_json` 저장 형식 (wrapped)**:
 ```json
@@ -870,14 +880,17 @@ GET https://api.odsay.com/v1/api/loadLane?mapObject=0:0@{info.mapObj}&apiKey={ke
 ```
 캐시 hit 시 두 raw를 함께 unwrap → mapper에 전달 → 곡선 그대로 복원 (재호출 불필요).
 
+**v1.1.10 운영 노트 — 마이그레이션**:
+v1.1.10 배포 직후엔 v1.1.9 이전 비-wrapped 캐시(`route_summary_json`이 `searchPubTransPathT` raw 그대로 박힘)가 자동으로 invalid 판정됨 → cache miss로 ODsay 재호출 → cache 갱신. 자동 마이그레이션이라 별도 데이터 작업 불필요. 단, 배포 직후 잠깐(TTL 윈도우만큼) ODsay 호출 spike 가능 — 운영 모니터링 권장.
+
 #### 에러
 - `404 SCHEDULE_NOT_FOUND`
 - `403 FORBIDDEN_RESOURCE`
 - `502 EXTERNAL_ROUTE_API_FAILED` — ODsay 호출 실패 + 캐시도 없음
-- `503 EXTERNAL_AUTH_MISCONFIGURED` — ODsay API 키 미설정/만료 (v1.1.4)
+- `503 EXTERNAL_AUTH_MISCONFIGURED` — ODsay API 키 미설정/만료 (v1.1.4). `searchPubTransPathT` / `loadLane` 둘 다 401/403 시 동일 격상 (v1.1.10)
 - `504 EXTERNAL_TIMEOUT` — ODsay 타임아웃 + 캐시도 없음
 
-> 캐시가 있으면 ODsay 실패 시에도 캐시로 응답 (캐시 stale 허용). `calculatedAt`으로 신선도 판단.
+> 캐시가 있으면 ODsay 실패 또는 fresh 응답 매핑 실패 시에도 캐시로 응답 (캐시 stale 허용). `calculatedAt`으로 신선도 판단. v1.1.10부터 매핑 실패도 동일 정책.
 
 #### DB 매핑
 - 캐시 hit: `schedule.route_summary_json` 그대로 사용. 첫 path만 변환해 응답.

--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -461,6 +461,8 @@ ORDER BY arrival_time ASC LIMIT 1
 
 > ⚠️ **중요**: 본 엔드포인트는 내부에서 ODsay API를 **동기 호출**한다. 응답 시간 평균 2~5초.
 > ODsay 호출 실패 시에도 일정은 정상 등록되며, 경로 관련 필드는 `null`로 응답된다 (graceful degradation).
+> 401/403(API 키 미설정/만료)도 등록 흐름에선 graceful 흡수 — 일정 등록 우선. 단 운영자 alert가 필요하므로
+> `log.error` 레벨로 격상해 모니터링 신호는 보존 (조회 흐름 §6.1은 503 격상으로 분리).
 
 #### Request Body
 
@@ -828,7 +830,7 @@ LIMIT ?
 | `totalDurationMinutes` | `result.path[0].info.totalTime` | 분 |
 | `totalDistanceMeters` | `result.path[0].info.totalDistance` | m |
 | `totalWalkMeters` | `result.path[0].info.totalWalk` | m |
-| `transferCount` | `result.path[0].info.subwayTransitCount + busTransitCount` | 합산. ⚠️ 의미(*환승 횟수* vs *이용 노선 수*) 미확정 — 명세팀 답변 후 v1.1.x 후속 패치 (PR #11 P2 #3) |
+| `transferCount` | `result.path[0].info.subwayTransitCount + busTransitCount` | 합산. ⚠️ 의미(*환승 횟수* vs *이용 노선 수*) 미확정 — 명세팀 답변 후 정의/산식 갱신 가능 |
 | `payment` | `result.path[0].info.payment` | 원 |
 
 `segments[]` 매핑 (`result.path[0].subPath[]` 순회):
@@ -868,17 +870,23 @@ GET https://api.odsay.com/v1/api/loadLane?mapObject=0:0@{info.mapObj}&apiKey={ke
   - `loadLane` 5xx/timeout/응답 형식 위반
   - `searchPubTransPathT` 응답에 `info.mapObj` 누락 또는 빈 문자열
   - `result.lane`이 array 아님 또는 길이가 transit subPath 개수와 불일치 (부분 매핑은 *swap 위험*으로 금지 — 잘못된 노선 곡선이 silent하게 그려지는 시각 버그)
-  - `graphPos[].{x, y}` 좌표 sanity 위반: NaN/Infinity, 한국 좌표 범위 밖(경도 124~132 / 위도 33~39)
+  - `graphPos[].{x, y}` 좌표 sanity 위반: NaN/Infinity, 서비스 영역 bbox 밖 (경도 `[124.0, 132.0]` / 위도 `[33.0, 39.0]` — 마라도 33.07°N / 백령도 124.7°E 포함)
   - lane의 graphPos 점이 2개 미만 (polyline 무의미)
 
   `searchPubTransPathT`는 정상이라 응답 자체는 가능 (cache 갱신도 진행).
-- **auth 격상 (운영자 alert)**: `loadLane` 401/403은 graceful 흡수하지 않고 propagate → `searchPubTransPathT`와 동일하게 `503 EXTERNAL_AUTH_MISCONFIGURED`로 격상 (API 키 미설정/만료는 운영 조치 필요)
+  거리 기반 swap 의심 검사(예: lane 시작점-transit 시작점 거리 비교)는 도입 검토했으나 평행 노선/동일 정류장/shift swap에 본질적으로 비효과적이라 채택 안 함 — ODsay 1:1 매칭 가이드 신뢰가 전제. 실 운영에서 이상 곡선 발견 시 lane name 비교 등 별도 검증 로직 추가 검토.
+- **auth 격상 (운영자 alert) — 조회 흐름(`getRoute`) 한정**: `loadLane`/`searchPubTransPathT` 401/403은 graceful 흡수하지 않고 propagate → `503 EXTERNAL_AUTH_MISCONFIGURED`로 격상 (API 키 미설정/만료는 운영 조치 필요).
+  등록/수정 흐름(`refreshRouteSync` — §5.1)은 `routeStatus = PENDING_RETRY` graceful 정책 우선. 401/403도 false 반환하되 `log.error`로 운영자 모니터링 신호는 보존.
 
 **`route_summary_json` 저장 형식 (wrapped)**:
 ```json
 { "path": <searchPubTransPathT raw>, "lane": <loadLane raw or null> }
 ```
 캐시 hit 시 두 raw를 함께 unwrap → mapper에 전달 → 곡선 그대로 복원 (재호출 불필요).
+
+**Wrapped JSON 타입 invariant**:
+- `path` 키: 항상 JSON object (`{...}`). 누락/null/array/primitive면 캐시 손상 판정 → fresh 호출로 자동 복구
+- `lane` 키: JSON object (`{...}`) 또는 `null`만 valid. 텍스트 `"null"` / 빈 문자열 / 숫자 / array는 거부 → 캐시 손상 판정. graceful로 흡수하지 않고 명시 거부해야 silent corruption 방지
 
 **v1.1.10 운영 노트 — 마이그레이션**:
 v1.1.10 배포 직후엔 v1.1.9 이전 비-wrapped 캐시(`route_summary_json`이 `searchPubTransPathT` raw 그대로 박힘)가 자동으로 invalid 판정됨 → cache miss로 ODsay 재호출 → cache 갱신. 자동 마이그레이션이라 별도 데이터 작업 불필요. 단, 배포 직후 잠깐(TTL 윈도우만큼) ODsay 호출 spike 가능 — 운영 모니터링 권장.

--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.9-MVP
-> **최종 수정**: 2026-04-30 (이상진 — Step 6 OdsayRouteService 구현: §6.1 WALK 좌표 보충 알고리즘 명시)
+> **버전**: v1.1.10-MVP
+> **최종 수정**: 2026-05-04 (이상진 — §6.1 transit path 출처를 ODsay `loadLane` 도로 곡선으로 승격, `route_summary_json` wrapped 형식 도입)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -26,6 +26,7 @@
 | **v1.1.7** | **2026-04-30** | **§1.7 Resolver 동작 정정 — `Authentication.getName()`으로 raw `member_uid` 반환만(DB 호출 X), Service가 `findByMemberUid` 1회 조회. §3.3 탈퇴 회원 응답: 404 `MEMBER_NOT_FOUND` → **401 `UNAUTHORIZED`** (Service 부재 시 응답). β PR Resolver 마이그레이션 (이상진 PR #5 I-1 + claude.ai P1).** |
 | **v1.1.8** | **2026-04-30** | **§5.4 PATCH 검증 정정 — `arrivalTime`의 NOW() 검사는 `arrivalTime`이 요청에 포함된 경우에만 적용. 지난 일정의 `title` 등 메모 편집 허용. (Step 5 PR #10 claude.ai 리뷰 P1 흡수)** |
 | **v1.1.9** | **2026-04-30** | **§6.1 WALK 구간 path 보충 알고리즘 명시 (Step 6 이상진) — ODsay WALK subPath에 좌표 키가 없어 `origin`/`destination`/이전 transit 끝점으로 합성. 매핑표의 `path` 행에 WALK 분기 추가.** |
+| **v1.1.10** | **2026-05-04** | **§6.1 transit path 출처 승격 (이상진) — `passStopList` 정류장 직선 → ODsay `loadLane` 도로 곡선 (`lane[i].section[].graphPos[]`) 정식 사용. `route_summary_json`을 `{"path":..., "lane":...}` wrapped 형식으로 저장 — 캐시 hit 시 재호출 없이 곡선 복원. loadLane 실패는 graceful — `passStopList` 직선 fallback. ODsay 호출 cache miss 1회당 1회 → 2회 (직렬, mapObj 의존).** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -842,7 +843,7 @@ LIMIT ?
 | `stationStart` | `subPath.startName` (SUBWAY 한정) | BUS는 from과 중복이라 null |
 | `stationEnd` | `subPath.endName` (SUBWAY 한정) | |
 | `stationCount` | `subPath.stationCount` | |
-| `path` | (transit) `[startX, startY]` + `passStopList.stations[].x/y` + `[endX, endY]` 직선<br>(WALK) 좌표 키 없음 → 합성 (아래 알고리즘) | `[lng, lat]` 배열. transit 정확 곡선은 `loadLane` 추가 호출 (선택) |
+| `path` | (transit) `loadLane.result.lane[i].section[].graphPos[]` 평탄화 (도로 곡선)<br>(WALK) 좌표 키 없음 → 합성 (아래 알고리즘) | `[lng, lat]` 배열. loadLane 실패/누락 시 `passStopList` 직선으로 graceful fallback (v1.1.10) |
 
 🆕 **v1.1.9 — WALK 구간 path 보충 알고리즘** (ODsay WALK subPath는 `startX/Y`/`endX/Y` 키가 없음):
 
@@ -852,15 +853,22 @@ LIMIT ?
 
 여기서 `origin/destination`은 `schedule.origin_lng/lat`, `schedule.destination_lng/lat`. 매핑은 lookahead 1패스로 transit 시작점들을 미리 수집한 뒤 결정적으로 적용 (자의적 보간 금지).
 
-**정확한 `path` 좌표가 필요하면 — ODsay `loadLane` API**:
+🆕 **v1.1.10 — transit `path` 출처 = ODsay `loadLane` 도로 곡선**:
 
 ```
-GET https://api.odsay.com/v1/api/loadLane?mapObject={mapObject}&apiKey={key}
+GET https://api.odsay.com/v1/api/loadLane?mapObject=0:0@{info.mapObj}&apiKey={key}
 ```
 
 - `mapObject` 형식: **`"0:0@" + result.path[0].info.mapObj`** ⚠️ ODsay 공식 문서엔 prefix 명시 안 됨. 검증된 패턴
-- 응답: `result.lane[].section[].graphPos[].{x, y}` — 실제 도로 곡선 좌표
-- 선택: 추가 호출 비용 있음. MVP 단계엔 생략하고 `passStopList` 좌표 직선 허용
+- 응답: `result.lane[i].section[j].graphPos[k].{x, y}` — `lane[i]`가 i번째 transit subPath와 1:1 매칭, `section[]`은 평탄화하여 한 transit segment의 path로 합침
+- 호출 흐름: `searchPubTransPathT` → 응답에서 `info.mapObj` 추출 → `loadLane` 호출 (직렬, mapObj 의존)
+- **graceful fallback**: `loadLane` 5xx/timeout/응답 형식 위반 / `info.mapObj` 누락 / `lane[]` 비었을 때 → `passStopList.stations[].x/y` 직선으로 fallback. `searchPubTransPathT`는 정상이라 응답 가능 (cache 갱신도 진행)
+
+**`route_summary_json` 저장 형식 (wrapped)**:
+```json
+{ "path": <searchPubTransPathT raw>, "lane": <loadLane raw or null> }
+```
+캐시 hit 시 두 raw를 함께 unwrap → mapper에 전달 → 곡선 그대로 복원 (재호출 불필요).
 
 #### 에러
 - `404 SCHEDULE_NOT_FOUND`

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -119,4 +119,53 @@ public class OdsayClient {
                     "ODsay 호출 중 예외 (" + e.getClass().getSimpleName() + ")", null);
         }
     }
+
+    /**
+     * 노선 그래픽 데이터 검색 — 명세 §6.1 비고. {@code searchPubTransPathT} 응답의
+     * {@code result.path[0].info.mapObj} 값을 받아 실제 도로 곡선 좌표 응답을 반환.
+     *
+     * <p>호출 형식: {@code GET /loadLane?mapObject=0:0@{mapObj}&apiKey={key}}.
+     * {@code "0:0@"} prefix는 ODsay 공식 가이드에 명시된 패턴이라 그대로 박는다.
+     *
+     * <p>호출자 정책: graceful — loadLane 실패 시 caller가 catch해서
+     * passStopList 직선 fallback (명세 §6.1 매핑표 비고 v1.1.10).
+     *
+     * @param mapObj {@code searchPubTransPathT} 응답의 {@code info.mapObj} 값 (prefix 없이)
+     * @return ODsay 응답 raw JSON 문자열
+     */
+    public String loadLane(String mapObj) {
+        log.debug("ODsay loadLane 호출: mapObj={}", mapObj);
+        try {
+            String body = restClient.get()
+                    .uri("/loadLane?mapObject=0:0@{mapObj}&apiKey={apiKey}",
+                            mapObj, properties.getApiKey())
+                    .retrieve()
+                    .body(String.class);
+
+            if (body == null || body.isBlank()) {
+                throw new ExternalApiException(SOURCE, ExternalApiException.Type.SERVER_ERROR,
+                        null, "ODsay loadLane 응답 본문이 비어있음", null);
+            }
+            log.debug("ODsay loadLane 응답 수신: {} bytes", body.length());
+            return body;
+        } catch (RestClientResponseException e) {
+            HttpStatusCode status = e.getStatusCode();
+            ExternalApiException.Type type = status.is4xxClientError()
+                    ? ExternalApiException.Type.CLIENT_ERROR
+                    : ExternalApiException.Type.SERVER_ERROR;
+            throw new ExternalApiException(SOURCE, type, status.value(),
+                    "ODsay loadLane 호출 실패: HTTP " + status, null);
+        } catch (ResourceAccessException e) {
+            Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);
+            ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
+                    ? ExternalApiException.Type.TIMEOUT
+                    : ExternalApiException.Type.NETWORK;
+            String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
+            throw new ExternalApiException(SOURCE, type, null,
+                    "ODsay loadLane 통신 실패 (" + causeName + ")", null);
+        } catch (RestClientException e) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
+                    "ODsay loadLane 호출 중 예외 (" + e.getClass().getSimpleName() + ")", null);
+        }
+    }
 }

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayClient.java
@@ -23,8 +23,9 @@ import org.springframework.web.client.RestClientResponseException;
 import java.net.SocketTimeoutException;
 
 /**
- * ODsay 대중교통 길찾기 API 클라이언트.
- * 명세 §5.1: 응답을 raw JSON 그대로 schedule.route_summary_json에 저장한다.
+ * ODsay 대중교통 길찾기 / 노선 그래픽 API 클라이언트. 명세 §5.1 / §6.1 v1.1.10 —
+ * raw JSON을 호출자에게 그대로 반환. wrapped 저장 형식
+ * ({@code {"path":..., "lane":...}})은 {@code OdsayRouteService} 책임.
  */
 @Component
 public class OdsayClient {
@@ -125,10 +126,13 @@ public class OdsayClient {
      * {@code result.path[0].info.mapObj} 값을 받아 실제 도로 곡선 좌표 응답을 반환.
      *
      * <p>호출 형식: {@code GET /loadLane?mapObject=0:0@{mapObj}&apiKey={key}}.
-     * {@code "0:0@"} prefix는 ODsay 공식 가이드에 명시된 패턴이라 그대로 박는다.
+     * {@code "0:0@"} prefix는 ODsay 공식 문서에 명시되지 않은 *검증된 패턴*이다 (명세 §6.1 v1.1.10 비고).
      *
-     * <p>호출자 정책: graceful — loadLane 실패 시 caller가 catch해서
-     * passStopList 직선 fallback (명세 §6.1 매핑표 비고 v1.1.10).
+     * <p>호출자 정책 (명세 §6.1 v1.1.10):
+     * <ul>
+     *   <li>5xx/timeout/응답 형식 위반: graceful — caller가 catch해서 passStopList 직선 fallback</li>
+     *   <li>401/403: 운영자 alert 필요 — caller가 propagate해서 503 EXTERNAL_AUTH_MISCONFIGURED 격상</li>
+     * </ul>
      *
      * @param mapObj {@code searchPubTransPathT} 응답의 {@code info.mapObj} 값 (prefix 없이)
      * @return ODsay 응답 raw JSON 문자열

--- a/backend/src/main/java/com/todayway/backend/external/odsay/OdsayProperties.java
+++ b/backend/src/main/java/com/todayway/backend/external/odsay/OdsayProperties.java
@@ -1,16 +1,38 @@
 package com.todayway.backend.external.odsay;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+/**
+ * ODsay 외부 API 설정. {@code application.yml}의 {@code odsay.*} 키에서 주입.
+ * <p>{@code @Validated} + 필드별 제약으로 시작 시점에 fail-fast — 운영자가 timeoutSeconds=0
+ * 같은 값으로 잘못 설정하면 모든 ODsay 호출이 즉시 timeout으로 떨어져 graceful path만 활성되는
+ * silent 운영 사고 차단.
+ */
 @Getter
 @Setter
+@Validated
 @ConfigurationProperties(prefix = "odsay")
 public class OdsayProperties {
+    /**
+     * ODsay API 키. {@code ${ODSAY_API_KEY:}}로 주입되어 로컬 dev 환경에선 빈 값 가능 —
+     * @NotBlank를 강제하면 다른 도메인 작업자(member/schedule/push)가 ODsay 키 없이
+     * 백엔드 시작 못 함. 빈 값은 ODsay 호출 시점에 401로 떨어져 §5.1/§6.1 graceful 정책으로 흡수.
+     */
     private String apiKey;
+
+    @NotBlank
     private String baseUrl;
+
+    @Min(1)
     private int timeoutSeconds = 5;
+
     /** 명세 §6.1 — schedule.route_summary_json 캐시 TTL (분). 권장 10분. */
+    @Min(1)
     private int cacheTtlMinutes = 10;
 }

--- a/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -36,25 +37,29 @@ import java.util.List;
  * 부분 매핑은 안 함 — 데이터 무결성 우선.
  */
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class OdsayResponseMapper {
 
     private final ObjectMapper objectMapper;
 
     /**
-     * @param rawJson    ODsay raw 응답 (전체 트리)
-     * @param originLng  WALK path 보충용 — schedule.origin_lng
-     * @param originLat  schedule.origin_lat
-     * @param destLng    schedule.destination_lng
-     * @param destLat    schedule.destination_lat
-     * @throws IllegalStateException 응답 형식 위반 ({@code path[0]} 없음, 좌표 파싱 실패 등)
+     * @param pathRawJson  {@code searchPubTransPathT} raw 응답
+     * @param laneRawJson  {@code loadLane} raw 응답 (nullable). null이거나 매핑 실패 시
+     *                     transit segment의 path는 {@code passStopList} 직선으로 fallback —
+     *                     명세 §6.1 v1.1.10 비고
+     * @param originLng    WALK path 보충용 — schedule.origin_lng
+     * @param originLat    schedule.origin_lat
+     * @param destLng      schedule.destination_lng
+     * @param destLat      schedule.destination_lat
+     * @throws IllegalStateException pathRawJson 형식 위반 ({@code path[0]} 없음, 좌표 파싱 실패 등)
      * @throws IllegalArgumentException ODsay 스펙 외 {@code trafficType}
      *         (예: 4=택시 추가 등 — {@link SegmentMode#fromOdsayTrafficType(int)}에서 throw)
      */
-    public Route toRoute(String rawJson,
+    public Route toRoute(String pathRawJson, String laneRawJson,
                          double originLng, double originLat,
                          double destLng, double destLat) {
-        JsonNode root = parse(rawJson);
+        JsonNode root = parse(pathRawJson);
         JsonNode path0 = root.path("result").path("path").path(0);
         if (path0.isMissingNode() || path0.isNull()) {
             throw new IllegalStateException("ODsay 응답에 result.path[0]이 없음");
@@ -75,12 +80,16 @@ public class OdsayResponseMapper {
                           + info.path("busTransitCount").asInt();
         int payment = info.path("payment").asInt();
 
+        // loadLane 곡선 좌표 — transit segment 인덱스 순으로 정렬됨.
+        // null/빈 리스트면 buildTransitSegment 내부에서 passStopList 직선으로 fallback.
+        List<List<double[]>> lanePaths = parseLanePaths(laneRawJson);
+
         // ── segments[] — 두 패스 ──
         // 1) transit start 좌표 미리 수집 (WALK가 다음 transit 시작점을 lookahead 가능)
         JsonNode subPathArr = path0.path("subPath");
         List<double[]> transitStarts = collectTransitStarts(subPathArr);
 
-        // 2) 순회: WALK는 lastPoint→nextTransitStart, transit은 station 좌표
+        // 2) 순회: WALK는 lastPoint→nextTransitStart, transit은 lane[] 곡선 또는 passStopList
         List<RouteSegment> segments = new ArrayList<>();
         double[] lastPoint = {originLng, originLat};
         int transitIdx = 0;
@@ -99,7 +108,10 @@ public class OdsayResponseMapper {
                 segments.add(buildWalkSegment(sectionTime, distance, lastPoint, nextPoint));
                 lastPoint = nextPoint;
             } else {
-                RouteSegment seg = buildTransitSegment(mode, sectionTime, distance, sp);
+                List<double[]> graphPath = transitIdx < lanePaths.size()
+                        ? lanePaths.get(transitIdx)
+                        : null;
+                RouteSegment seg = buildTransitSegment(mode, sectionTime, distance, sp, graphPath);
                 segments.add(seg);
                 // lastPoint 갱신: transit 끝점 — 다음 WALK가 이걸 시작점으로 사용
                 lastPoint = new double[]{
@@ -113,6 +125,43 @@ public class OdsayResponseMapper {
         return new Route(
                 totalDurationMinutes, totalDistanceMeters, totalWalkMeters,
                 transferCount, payment, List.copyOf(segments));
+    }
+
+    /**
+     * loadLane raw 응답을 transit segment 인덱스 순서의 path 좌표 리스트로 변환.
+     * <p>응답 형식: {@code result.lane[i].section[j].graphPos[k].{x, y}} (명세 §6.1 비고).
+     * lane[i]가 i번째 transit subPath와 1:1 매칭된다고 가정 (ODsay 가이드).
+     * <p>null/파싱 실패/구조 위반 시 빈 리스트 반환 — caller(transit segment)는
+     * passStopList 직선으로 fallback. graceful 정책 (명세 §6.1 v1.1.10).
+     */
+    private List<List<double[]>> parseLanePaths(String laneRawJson) {
+        if (laneRawJson == null || laneRawJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            JsonNode root = parse(laneRawJson);
+            JsonNode laneArr = root.path("result").path("lane");
+            if (!laneArr.isArray()) {
+                return List.of();
+            }
+            List<List<double[]>> result = new ArrayList<>();
+            for (JsonNode lane : laneArr) {
+                List<double[]> points = new ArrayList<>();
+                for (JsonNode section : lane.path("section")) {
+                    for (JsonNode pos : section.path("graphPos")) {
+                        points.add(new double[]{
+                                parseCoord(pos.path("x")),
+                                parseCoord(pos.path("y"))
+                        });
+                    }
+                }
+                result.add(List.copyOf(points));
+            }
+            return result;
+        } catch (RuntimeException e) {
+            log.warn("ODsay loadLane 매핑 실패 — passStopList 직선 fallback", e);
+            return List.of();
+        }
     }
 
     // ── private helpers ──
@@ -158,7 +207,8 @@ public class OdsayResponseMapper {
     }
 
     private static RouteSegment buildTransitSegment(SegmentMode mode, int sectionTime,
-                                                    int distance, JsonNode sp) {
+                                                    int distance, JsonNode sp,
+                                                    List<double[]> graphPath) {
         String startName = textOrNull(sp.path("startName"));
         String endName = textOrNull(sp.path("endName"));
         Integer stationCount = sp.has("stationCount") ? sp.path("stationCount").asInt() : null;
@@ -179,7 +229,23 @@ public class OdsayResponseMapper {
         String stationStart = mode == SegmentMode.SUBWAY ? startName : null;
         String stationEnd = mode == SegmentMode.SUBWAY ? endName : null;
 
-        // path: startX/Y + passStopList.stations[].x/y + endX/Y 직선
+        // path 결정 (§6.1 v1.1.10):
+        //   - graphPath(loadLane.lane[i].section[].graphPos[]) 있으면 → 도로 곡선
+        //   - 없거나 비었으면 → passStopList 직선 fallback (startX/Y + stations[].x/y + endX/Y)
+        List<double[]> path = (graphPath != null && !graphPath.isEmpty())
+                ? graphPath
+                : buildPassStopListPath(sp);
+
+        return new RouteSegment(
+                mode, sectionTime, distance,
+                startName, endName,
+                lineName, lineId,
+                stationStart, stationEnd, stationCount,
+                path
+        );
+    }
+
+    private static List<double[]> buildPassStopListPath(JsonNode sp) {
         List<double[]> path = new ArrayList<>();
         path.add(new double[]{requireCoord(sp, "startX"), requireCoord(sp, "startY")});
         for (JsonNode st : sp.path("passStopList").path("stations")) {
@@ -189,14 +255,7 @@ public class OdsayResponseMapper {
             });
         }
         path.add(new double[]{requireCoord(sp, "endX"), requireCoord(sp, "endY")});
-
-        return new RouteSegment(
-                mode, sectionTime, distance,
-                startName, endName,
-                lineName, lineId,
-                stationStart, stationEnd, stationCount,
-                List.copyOf(path)
-        );
+        return List.copyOf(path);
     }
 
     private static String textOrNull(JsonNode node) {

--- a/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
@@ -99,7 +99,7 @@ public class OdsayResponseMapper {
         // loadLane 곡선 좌표 — transit segment 인덱스 순으로 정렬됨.
         // 길이 mismatch / 범위 외 좌표 / 매핑 실패 시 빈 리스트 → 전체 transit이 passStopList 직선으로 fallback.
         // 부분 매핑은 swap 위험(잘못된 노선 곡선이 silent하게 그려짐) 때문에 허용 X.
-        List<List<double[]>> lanePaths = parseLanePaths(laneRawJson, transitStarts);
+        List<List<double[]>> lanePaths = parseLanePaths(laneRawJson, transitStarts.size());
 
         // 2) 순회: WALK는 lastPoint→nextTransitStart, transit은 lane[] 곡선 또는 passStopList
         List<RouteSegment> segments = new ArrayList<>();
@@ -150,20 +150,18 @@ public class OdsayResponseMapper {
      * loadLane raw 응답을 transit segment 인덱스 순서의 path 좌표 리스트로 변환.
      * <p>응답 형식: {@code result.lane[i].section[j].graphPos[k].{x, y}} (명세 §6.1 비고).
      * lane[i]가 i번째 transit subPath와 1:1 매칭된다고 가정 — ODsay 공식 문서엔 명시 X,
-     * fixture로 검증된 패턴. 길이 mismatch 시 swap 위험 차단을 위해 전체 fallback.
+     * fixture로 검증된 패턴. 길이 mismatch 시 부분 매핑(swap 위험)은 허용 X — 전체 fallback.
      *
      * <h3>Fallback 정책 (전부 graceful — 빈 리스트 반환)</h3>
      * <ul>
      *   <li>null/blank/파싱 실패/{@code result.lane}이 array 아님</li>
-     *   <li>lane 길이 ≠ transit subPath 개수 — 부분 매핑은 swap 위험이라 허용 X</li>
+     *   <li>lane 길이 ≠ {@code expectedLaneCount} — 부분 매핑은 swap 위험이라 허용 X</li>
      *   <li>graphPos 좌표 sanity 위반 (NaN/Infinity/한국 좌표 범위 밖/단일 점)</li>
      * </ul>
      *
-     * @param transitStarts transit subPath 시작점 리스트 — 결합 invariant: lane[]과 1:1 매칭 기대.
-     *                      {@code .size()}만 사용하지만 caller 결합을 명시적으로 표현하기 위해 통째로 받음.
+     * @param expectedLaneCount transit subPath 개수와 일치해야 하는 lane[] 길이
      */
-    private List<List<double[]>> parseLanePaths(String laneRawJson, List<double[]> transitStarts) {
-        int expectedLaneCount = transitStarts.size();
+    private List<List<double[]>> parseLanePaths(String laneRawJson, int expectedLaneCount) {
         if (laneRawJson == null || laneRawJson.isBlank()) {
             return List.of();
         }
@@ -180,7 +178,8 @@ public class OdsayResponseMapper {
                 return List.of();
             }
             List<List<double[]>> result = new ArrayList<>();
-            for (JsonNode lane : laneArr) {
+            for (int i = 0; i < laneArr.size(); i++) {
+                JsonNode lane = laneArr.get(i);
                 List<double[]> points = new ArrayList<>();
                 for (JsonNode section : lane.path("section")) {
                     for (JsonNode pos : section.path("graphPos")) {
@@ -188,8 +187,8 @@ public class OdsayResponseMapper {
                     }
                 }
                 if (points.size() < 2) {
-                    log.warn("ODsay loadLane lane의 graphPos 점 {}개 — 단일 점/빈 path는 polyline 무의미, fallback",
-                            points.size());
+                    log.warn("ODsay loadLane lane[{}] graphPos 점 {}개 — 단일 점/빈 path는 polyline 무의미, fallback",
+                            i, points.size());
                     return List.of();
                 }
                 result.add(List.copyOf(points));

--- a/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
@@ -22,15 +22,21 @@ import java.util.List;
  *   <li>첫 WALK: {@code origin} → 다음 transit {@code startX/startY}</li>
  *   <li>중간 WALK: 이전 transit {@code endX/endY} → 다음 transit {@code startX/startY}</li>
  *   <li>마지막 WALK: 이전 transit {@code endX/endY} → {@code destination}</li>
- *   <li>all-WALK (transit 0개): 단일 WALK가 {@code origin} → {@code destination} 직선
- *       (ODsay 700m 이내 응답은 코드 -98로 path 없이 떨어지지만, 그 이상에서 도보만 반환되는
- *        case도 스펙상 가능 — 같은 보충 로직으로 자연스럽게 처리)</li>
+ *   <li>all-WALK (transit 0개): 단일 WALK가 {@code origin} → {@code destination} 직선.
+ *       ODsay 도보-only 응답이 path 형태로 들어오는 가설적 케이스에 대한 보충 — 실제 운영에선
+ *       700m 이내 응답이 에러 코드(코드 -98)로 떨어져 mapper의 {@code path[0] 없음} 분기에서
+ *       graceful catch (구현 메모)</li>
  * </ul>
  *
- * <h3>transit 구간 path</h3>
- * <p>{@code [startX, startY]} + {@code passStopList.stations[].x/y} + {@code [endX, endY]} 직선 연결.
- * 정확한 도로 곡선이 필요하면 ODsay {@code loadLane} 추가 호출이지만 MVP 범위 외 — 명세 §6.1
- * v1.1.4 비고 *"passStopList 좌표 직선 허용"*.
+ * <h3>transit 구간 path (v1.1.10)</h3>
+ * <p>우선순위: {@code loadLane} 도로 곡선 → {@code passStopList} 직선 fallback.
+ * <ul>
+ *   <li>1순위: {@code laneRawJson}의 {@code result.lane[i].section[].graphPos[].{x, y}}
+ *       (i = transit subPath 인덱스 — ODsay 공식 문서엔 명시 X, 검증된 가정. 길이 mismatch 시 전체 fallback)</li>
+ *   <li>2순위 (laneRawJson 누락 / 길이 불일치 / 좌표 sanity 위반 / 파싱 실패):
+ *       {@code [startX, startY]} + {@code passStopList.stations[].x/y} + {@code [endX, endY]} 직선
+ *       — 명세 §6.1 v1.1.10 비고</li>
+ * </ul>
  *
  * <h3>예외 정책</h3>
  * <p>매핑 실패 시 {@link IllegalStateException} (호출자 {@code OdsayRouteService}가 catch).
@@ -52,9 +58,14 @@ public class OdsayResponseMapper {
      * @param originLat    schedule.origin_lat
      * @param destLng      schedule.destination_lng
      * @param destLat      schedule.destination_lat
-     * @throws IllegalStateException pathRawJson 형식 위반 ({@code path[0]} 없음, 좌표 파싱 실패 등)
-     * @throws IllegalArgumentException ODsay 스펙 외 {@code trafficType}
-     *         (예: 4=택시 추가 등 — {@link SegmentMode#fromOdsayTrafficType(int)}에서 throw)
+     * @throws IllegalStateException pathRawJson 형식 위반 — (a) JSON 파싱 실패,
+     *         (b) {@code result.path[0]} 없음, (c) {@code result.path[0].info} 없음,
+     *         (d) transit subPath의 {@code startX/startY/endX/endY} 누락 (transit 자체 좌표 — passStopList 직선 fallback도 이걸 사용),
+     *         (e) {@code passStopList.stations[].x/y}의 숫자 파싱 실패.
+     *         laneRawJson 손상은 throw하지 않음 (passStopList 직선 fallback — 명세 §6.1 v1.1.10 비고).
+     * @throws IllegalArgumentException — (a) ODsay 스펙 외 {@code trafficType}
+     *         ({@link SegmentMode#fromOdsayTrafficType(int)}에서 throw),
+     *         (b) transit segment 최종 path가 2점 미만 ({@link RouteSegment} record invariant)
      */
     public Route toRoute(String pathRawJson, String laneRawJson,
                          double originLng, double originLat,
@@ -80,14 +91,15 @@ public class OdsayResponseMapper {
                           + info.path("busTransitCount").asInt();
         int payment = info.path("payment").asInt();
 
-        // loadLane 곡선 좌표 — transit segment 인덱스 순으로 정렬됨.
-        // null/빈 리스트면 buildTransitSegment 내부에서 passStopList 직선으로 fallback.
-        List<List<double[]>> lanePaths = parseLanePaths(laneRawJson);
-
         // ── segments[] — 두 패스 ──
         // 1) transit start 좌표 미리 수집 (WALK가 다음 transit 시작점을 lookahead 가능)
         JsonNode subPathArr = path0.path("subPath");
         List<double[]> transitStarts = collectTransitStarts(subPathArr);
+
+        // loadLane 곡선 좌표 — transit segment 인덱스 순으로 정렬됨.
+        // 길이 mismatch / 범위 외 좌표 / 매핑 실패 시 빈 리스트 → 전체 transit이 passStopList 직선으로 fallback.
+        // 부분 매핑은 swap 위험(잘못된 노선 곡선이 silent하게 그려짐) 때문에 허용 X.
+        List<List<double[]>> lanePaths = parseLanePaths(laneRawJson, transitStarts);
 
         // 2) 순회: WALK는 lastPoint→nextTransitStart, transit은 lane[] 곡선 또는 passStopList
         List<RouteSegment> segments = new ArrayList<>();
@@ -127,14 +139,31 @@ public class OdsayResponseMapper {
                 transferCount, payment, List.copyOf(segments));
     }
 
+    // 서비스 영역 (한국) bounding box — ODsay가 한국 대중교통 특화 API라 응답 좌표는 이 범위 안.
+    // 마라도(33.07) / 백령도(124.7) 포함 여유. 글로벌 확장 시 정책 재검토 필요.
+    private static final double SERVICE_LNG_MIN = 124.0;
+    private static final double SERVICE_LNG_MAX = 132.0;
+    private static final double SERVICE_LAT_MIN = 33.0;
+    private static final double SERVICE_LAT_MAX = 39.0;
+
     /**
      * loadLane raw 응답을 transit segment 인덱스 순서의 path 좌표 리스트로 변환.
      * <p>응답 형식: {@code result.lane[i].section[j].graphPos[k].{x, y}} (명세 §6.1 비고).
-     * lane[i]가 i번째 transit subPath와 1:1 매칭된다고 가정 (ODsay 가이드).
-     * <p>null/파싱 실패/구조 위반 시 빈 리스트 반환 — caller(transit segment)는
-     * passStopList 직선으로 fallback. graceful 정책 (명세 §6.1 v1.1.10).
+     * lane[i]가 i번째 transit subPath와 1:1 매칭된다고 가정 — ODsay 공식 문서엔 명시 X,
+     * fixture로 검증된 패턴. 길이 mismatch 시 swap 위험 차단을 위해 전체 fallback.
+     *
+     * <h3>Fallback 정책 (전부 graceful — 빈 리스트 반환)</h3>
+     * <ul>
+     *   <li>null/blank/파싱 실패/{@code result.lane}이 array 아님</li>
+     *   <li>lane 길이 ≠ transit subPath 개수 — 부분 매핑은 swap 위험이라 허용 X</li>
+     *   <li>graphPos 좌표 sanity 위반 (NaN/Infinity/한국 좌표 범위 밖/단일 점)</li>
+     * </ul>
+     *
+     * @param transitStarts transit subPath 시작점 리스트 — 결합 invariant: lane[]과 1:1 매칭 기대.
+     *                      {@code .size()}만 사용하지만 caller 결합을 명시적으로 표현하기 위해 통째로 받음.
      */
-    private List<List<double[]>> parseLanePaths(String laneRawJson) {
+    private List<List<double[]>> parseLanePaths(String laneRawJson, List<double[]> transitStarts) {
+        int expectedLaneCount = transitStarts.size();
         if (laneRawJson == null || laneRawJson.isBlank()) {
             return List.of();
         }
@@ -142,6 +171,12 @@ public class OdsayResponseMapper {
             JsonNode root = parse(laneRawJson);
             JsonNode laneArr = root.path("result").path("lane");
             if (!laneArr.isArray()) {
+                log.warn("ODsay loadLane 응답에 result.lane[] 배열 없음 — passStopList 직선 fallback");
+                return List.of();
+            }
+            if (laneArr.size() != expectedLaneCount) {
+                log.warn("ODsay loadLane 길이 불일치 — lane={} transitCount={} (전체 fallback)",
+                        laneArr.size(), expectedLaneCount);
                 return List.of();
             }
             List<List<double[]>> result = new ArrayList<>();
@@ -149,11 +184,13 @@ public class OdsayResponseMapper {
                 List<double[]> points = new ArrayList<>();
                 for (JsonNode section : lane.path("section")) {
                     for (JsonNode pos : section.path("graphPos")) {
-                        points.add(new double[]{
-                                parseCoord(pos.path("x")),
-                                parseCoord(pos.path("y"))
-                        });
+                        points.add(requireKoreaCoord(pos));
                     }
+                }
+                if (points.size() < 2) {
+                    log.warn("ODsay loadLane lane의 graphPos 점 {}개 — 단일 점/빈 path는 polyline 무의미, fallback",
+                            points.size());
+                    return List.of();
                 }
                 result.add(List.copyOf(points));
             }
@@ -161,6 +198,42 @@ public class OdsayResponseMapper {
         } catch (RuntimeException e) {
             log.warn("ODsay loadLane 매핑 실패 — passStopList 직선 fallback", e);
             return List.of();
+        }
+    }
+
+    /**
+     * graphPos 좌표 sanity 검증 (두 invariant 분리):
+     * <ol>
+     *   <li>{@link #requireFiniteCoord} — ODsay 응답 자체의 invariant (NaN/Infinity 거부)</li>
+     *   <li>{@link #requireServiceArea} — 우리 서비스 영역(한국) 비즈니스 invariant</li>
+     * </ol>
+     * silent 통과 시 polyline이 적도/대서양으로 점프하는 시각적 버그.
+     */
+    private static double[] requireKoreaCoord(JsonNode pos) {
+        double[] coord = requireFiniteCoord(pos);
+        requireServiceArea(coord);
+        return coord;
+    }
+
+    /** ODsay 응답 invariant — graphPos는 항상 유한한 숫자. */
+    private static double[] requireFiniteCoord(JsonNode pos) {
+        double lng = parseCoord(pos.path("x"));
+        double lat = parseCoord(pos.path("y"));
+        if (!Double.isFinite(lng) || !Double.isFinite(lat)) {
+            throw new IllegalStateException(
+                    "ODsay graphPos 좌표 NaN/Infinity: lng=" + lng + " lat=" + lat);
+        }
+        return new double[]{lng, lat};
+    }
+
+    /** 비즈니스 invariant — 우리 서비스 영역(한국) 안에 있어야 한다. 글로벌 확장 시 정책 재검토. */
+    private static void requireServiceArea(double[] coord) {
+        double lng = coord[0];
+        double lat = coord[1];
+        if (lng < SERVICE_LNG_MIN || lng > SERVICE_LNG_MAX
+                || lat < SERVICE_LAT_MIN || lat > SERVICE_LAT_MAX) {
+            throw new IllegalStateException(
+                    "graphPos 좌표 서비스 영역 밖: lng=" + lng + " lat=" + lat);
         }
     }
 
@@ -232,6 +305,7 @@ public class OdsayResponseMapper {
         // path 결정 (§6.1 v1.1.10):
         //   - graphPath(loadLane.lane[i].section[].graphPos[]) 있으면 → 도로 곡선
         //   - 없거나 비었으면 → passStopList 직선 fallback (startX/Y + stations[].x/y + endX/Y)
+        // size < 2 검증은 RouteSegment record compact ctor에서 IllegalArgumentException throw.
         List<double[]> path = (graphPath != null && !graphPath.isEmpty())
                 ? graphPath
                 : buildPassStopListPath(sp);

--- a/backend/src/main/java/com/todayway/backend/route/OdsayRouteService.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayRouteService.java
@@ -95,16 +95,18 @@ public class OdsayRouteService implements RouteService {
             applyToSchedule(schedule, route, raw);
             return true;
         } catch (ExternalApiException e) {
-            // 401/403은 운영자 조치 필요 — graceful 흡수 X. caller(ScheduleService)에서
-            // BusinessException으로 격상되어 503 EXTERNAL_AUTH_MISCONFIGURED 응답.
-            // (getRoute의 mapToBusinessException과 동일 정책 — silent false 반환 시
-            //  일정 등록은 성공해도 운영자 alert 누락되어 발견 시점이 늦어짐)
+            // graceful degradation — 명세 §5.1 정책: ODsay 호출 실패 시 일정은 정상 등록되며
+            // 경로 필드 null + routeStatus=PENDING_RETRY로 응답. 401/403도 graceful 흡수
+            // (조회 흐름 §6.1은 503 격상이지만 등록 흐름은 §5.1 우선 — 등록 자체가 실패하면
+            //  사용자 경험 더 나쁨). 단 401/403은 운영자 조치가 필요하므로 log.error로 격상해
+            //  모니터링 신호 보존.
             if (isAuthError(e)) {
-                throw mapToBusinessException(e);
+                log.error("ODsay refresh 401/403 (auth 미설정/만료, 운영자 alert) scheduleUid={} httpStatus={}",
+                        schedule.getScheduleUid(), e.getHttpStatus(), e);
+            } else {
+                log.warn("ODsay refresh 실패 (graceful) scheduleUid={} type={} httpStatus={}",
+                        schedule.getScheduleUid(), e.getType(), e.getHttpStatus(), e);
             }
-            // graceful degradation — ScheduleService.create()/update()는 ODsay 결과 없이 진행.
-            log.warn("ODsay refresh 실패 (graceful) scheduleUid={} type={} httpStatus={}",
-                    schedule.getScheduleUid(), e.getType(), e.getHttpStatus(), e);
             return false;
         } catch (IllegalStateException | IllegalArgumentException e) {
             // 응답 매핑 실패 (path[0] 없음, unknown trafficType, 좌표 파싱 실패) — 동일 graceful 처리.
@@ -210,14 +212,13 @@ public class OdsayRouteService implements RouteService {
         try {
             return odsayClient.loadLane(mapObj);
         } catch (ExternalApiException e) {
-            Integer status = e.getHttpStatus();
-            if (status != null && (status == 401 || status == 403)) {
+            if (isAuthError(e)) {
                 // auth 미설정/만료는 운영자 alert 필요 — graceful 흡수 X.
                 // searchPubTransPathT 흐름과 일관되게 throw → caller가 503 매핑.
                 throw e;
             }
             log.warn("ODsay loadLane 호출 실패 (graceful) type={} httpStatus={}",
-                    e.getType(), status, e);
+                    e.getType(), e.getHttpStatus(), e);
             return null;
         }
     }
@@ -351,16 +352,12 @@ public class OdsayRouteService implements RouteService {
      * </ul>
      */
     private static BusinessException mapToBusinessException(ExternalApiException e) {
+        if (isAuthError(e)) {
+            return new BusinessException(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+        }
         return switch (e.getType()) {
             case TIMEOUT -> new BusinessException(ErrorCode.EXTERNAL_TIMEOUT);
-            case CLIENT_ERROR -> {
-                Integer status = e.getHttpStatus();
-                boolean authIssue = status != null && (status == 401 || status == 403);
-                yield new BusinessException(
-                        authIssue ? ErrorCode.EXTERNAL_AUTH_MISCONFIGURED
-                                  : ErrorCode.EXTERNAL_ROUTE_API_FAILED);
-            }
-            case SERVER_ERROR, NETWORK ->
+            case CLIENT_ERROR, SERVER_ERROR, NETWORK ->
                     new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
         };
     }

--- a/backend/src/main/java/com/todayway/backend/route/OdsayRouteService.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayRouteService.java
@@ -1,5 +1,6 @@
 package com.todayway.backend.route;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -18,11 +19,12 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
- * {@link RouteService} 구현 — ODsay {@code searchPubTransPathT} 호출 + 응답 매핑 + Schedule 갱신
- * + TTL 캐시 fallback. 명세 §5.1 / §6.1 정합.
+ * {@link RouteService} 구현 — ODsay 호출({@code searchPubTransPathT} + {@code loadLane} graceful,
+ * §6.1 v1.1.10) + 응답 매핑 + Schedule 갱신 + TTL 캐시 fallback. 명세 §5.1 / §6.1 정합.
  *
  * <h3>{@code refreshRouteSync} (Schedule 등록/수정 흐름)</h3>
  * <p>실패 시 graceful degradation — {@code ScheduleService.create()}는 ODsay 결과 없이 등록 성공.
@@ -30,13 +32,15 @@ import java.util.Optional;
  * ({@code Schedule.hasCalculatedRoute()}가 false라).
  *
  * <h3>{@code getRoute} (조회 흐름)</h3>
- * <p>4단계 fallback:
+ * <p>fallback 흐름 (§6.1 비고 — "ODsay 실패/매핑 실패 시 캐시 stale 허용"):
  * <ol>
- *   <li>cache hit (TTL 내) → DB raw 그대로 매핑 응답</li>
- *   <li>cache miss / forceRefresh → ODsay 호출 + DB 저장 + 응답</li>
- *   <li>ODsay 실패 + 기존 raw 있음 → stale 응답 (명세 §6.1 비고 — "캐시 stale 허용")</li>
- *   <li>ODsay 실패 + raw 없음 → {@link BusinessException} throw (502/503/504, §1.6)</li>
+ *   <li>cache hit (TTL 내) → wrapped raw({@code {"path":..., "lane":...}}, §6.1 v1.1.10)
+ *       unwrap + 매핑 응답</li>
+ *   <li>cache miss / forceRefresh / 캐시 매핑 실패 → ODsay 2회 호출
+ *       ({@code searchPubTransPathT} + {@code loadLane} graceful) + DB 저장 + 응답</li>
+ *   <li>ODsay 실패 또는 fresh 매핑 실패 + 매핑 가능한 캐시 있음 → stale 응답</li>
  * </ol>
+ * <p>모든 단계 실패(캐시 없음/손상) 시 {@link BusinessException} throw — 502/503/504 (§1.6).
  */
 @Service
 @Slf4j
@@ -71,8 +75,17 @@ public class OdsayRouteService implements RouteService {
         this.clock = clock;
     }
 
-    /** {@code searchPubTransPathT} raw + {@code loadLane} raw 묶음. lane은 graceful 정책으로 nullable. */
-    private record OdsayRaw(String pathRaw, String laneRaw) {}
+    /**
+     * {@code searchPubTransPathT} raw + {@code loadLane} raw 묶음. lane은 graceful 정책으로 nullable.
+     * pathRaw null은 silent corruption 위험이라 명시 거부.
+     * <p>{@code pathRaw}는 ODsay 응답 그대로의 valid JSON 문자열이라 가정 — JSON 유효성 검증은
+     * 호출자(mapper/wrapRaw) 책임. record는 데이터 운반체.
+     */
+    private record OdsayRaw(String pathRaw, String laneRaw) {
+        OdsayRaw {
+            Objects.requireNonNull(pathRaw, "pathRaw");
+        }
+    }
 
     @Override
     public boolean refreshRouteSync(Schedule schedule) {
@@ -82,6 +95,13 @@ public class OdsayRouteService implements RouteService {
             applyToSchedule(schedule, route, raw);
             return true;
         } catch (ExternalApiException e) {
+            // 401/403은 운영자 조치 필요 — graceful 흡수 X. caller(ScheduleService)에서
+            // BusinessException으로 격상되어 503 EXTERNAL_AUTH_MISCONFIGURED 응답.
+            // (getRoute의 mapToBusinessException과 동일 정책 — silent false 반환 시
+            //  일정 등록은 성공해도 운영자 alert 누락되어 발견 시점이 늦어짐)
+            if (isAuthError(e)) {
+                throw mapToBusinessException(e);
+            }
             // graceful degradation — ScheduleService.create()/update()는 ODsay 결과 없이 진행.
             log.warn("ODsay refresh 실패 (graceful) scheduleUid={} type={} httpStatus={}",
                     schedule.getScheduleUid(), e.getType(), e.getHttpStatus(), e);
@@ -92,6 +112,13 @@ public class OdsayRouteService implements RouteService {
                     schedule.getScheduleUid(), e);
             return false;
         }
+    }
+
+    /** 401/403 — API 키 미설정/만료. 운영자 조치 필요. */
+    private static boolean isAuthError(ExternalApiException e) {
+        if (e.getType() != ExternalApiException.Type.CLIENT_ERROR) return false;
+        Integer status = e.getHttpStatus();
+        return status != null && (status == 401 || status == 403);
     }
 
     @Override
@@ -152,25 +179,45 @@ public class OdsayRouteService implements RouteService {
         return new OdsayRaw(pathRaw, laneRaw);
     }
 
-    /** loadLane graceful 호출 — mapObj 추출/호출 실패 시 null. mapper가 passStopList fallback. */
+    /**
+     * loadLane graceful 호출 — mapObj 추출/호출 실패 시 null. mapper가 passStopList fallback.
+     * <p>예외:
+     * <ul>
+     *   <li>auth 에러(401/403)는 운영자 조치가 필요한 신호라 graceful 흡수 X →
+     *       {@code searchPubTransPathT}와 동일하게 propagate (호출자가 503으로 매핑)</li>
+     *   <li>mapObj 추출 단계는 path raw가 ODsay 정상 응답이라 가정 — JSON 파싱 실패만 좁게 catch</li>
+     * </ul>
+     */
     private String tryLoadLane(String pathRaw) {
+        if (pathRaw == null) {
+            // ODsayClient 변경 등으로 null이 들어오면 silent corruption 위험 — 명시 로그 후 fallback
+            log.warn("ODsay loadLane skip — pathRaw가 null. passStopList 직선 fallback");
+            return null;
+        }
         String mapObj;
         try {
             JsonNode root = objectMapper.readTree(pathRaw);
             mapObj = root.path("result").path("path").path(0).path("info").path("mapObj").asText(null);
-        } catch (Exception e) {
-            log.warn("ODsay loadLane mapObj 추출 실패 — passStopList 직선 fallback", e);
+        } catch (JsonProcessingException e) {
+            log.warn("ODsay loadLane mapObj 추출 실패 (path raw JSON 파싱) — passStopList 직선 fallback", e);
             return null;
         }
         if (mapObj == null || mapObj.isBlank()) {
-            log.warn("ODsay 응답에 info.mapObj 없음 — passStopList 직선 fallback");
+            // 정상 케이스도 있음 — ODsay 도보-only(코드 -98 후 캐시) 응답엔 mapObj 자체 없음.
+            log.debug("ODsay 응답에 info.mapObj 없음 — passStopList 직선 fallback");
             return null;
         }
         try {
             return odsayClient.loadLane(mapObj);
         } catch (ExternalApiException e) {
+            Integer status = e.getHttpStatus();
+            if (status != null && (status == 401 || status == 403)) {
+                // auth 미설정/만료는 운영자 alert 필요 — graceful 흡수 X.
+                // searchPubTransPathT 흐름과 일관되게 throw → caller가 503 매핑.
+                throw e;
+            }
             log.warn("ODsay loadLane 호출 실패 (graceful) type={} httpStatus={}",
-                    e.getType(), e.getHttpStatus(), e);
+                    e.getType(), status, e);
             return null;
         }
     }
@@ -228,30 +275,48 @@ public class OdsayRouteService implements RouteService {
                     ? objectMapper.nullNode()
                     : objectMapper.readTree(raw.laneRaw()));
             return objectMapper.writeValueAsString(node);
-        } catch (Exception e) {
-            // pathRaw는 ODsay에서 받은 valid JSON이라 정상적으로는 발생 X. 안전망.
+        } catch (JsonProcessingException e) {
+            // pathRaw/laneRaw는 ODsay에서 받은 valid JSON이라 정상적으로는 발생 X. 안전망.
             throw new IllegalStateException("ODsay raw wrapping 실패", e);
         }
     }
 
-    /** wrapped JSON에서 path/lane raw 분리. 형식 위반은 IllegalStateException으로 throw. */
+    /**
+     * wrapped JSON에서 path/lane raw 분리. 형식 위반은 IllegalStateException으로 throw.
+     * <p>{@code lane}은 {@code null} 또는 object 노드만 valid — 텍스트 "null" / 빈 문자열 /
+     * 잘못된 타입은 명시 거부 (silent fallback이면 곡선 손실을 정상으로 위장).
+     */
     private OdsayRaw unwrapRaw(String wrapped) {
+        JsonNode root;
         try {
-            JsonNode root = objectMapper.readTree(wrapped);
-            JsonNode pathNode = root.path("path");
-            JsonNode laneNode = root.path("lane");
-            if (pathNode.isMissingNode() || pathNode.isNull()) {
-                throw new IllegalStateException("캐시된 routeSummaryJson에 path 없음");
-            }
-            String pathRaw = objectMapper.writeValueAsString(pathNode);
-            String laneRaw = laneNode.isMissingNode() || laneNode.isNull()
-                    ? null
-                    : objectMapper.writeValueAsString(laneNode);
-            return new OdsayRaw(pathRaw, laneRaw);
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
+            root = objectMapper.readTree(wrapped);
+        } catch (JsonProcessingException e) {
             throw new IllegalStateException("캐시된 routeSummaryJson 파싱 실패", e);
+        }
+        JsonNode pathNode = root.path("path");
+        if (pathNode.isMissingNode() || pathNode.isNull() || !pathNode.isObject()) {
+            throw new IllegalStateException("캐시된 routeSummaryJson에 path 객체 없음");
+        }
+        JsonNode laneNode = root.path("lane");
+        String laneRaw;
+        if (laneNode.isMissingNode() || laneNode.isNull()) {
+            laneRaw = null;
+        } else if (laneNode.isObject()) {
+            try {
+                laneRaw = objectMapper.writeValueAsString(laneNode);
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("캐시된 routeSummaryJson lane 직렬화 실패", e);
+            }
+        } else {
+            // string "null" / 빈 문자열 / 숫자 등 잘못된 타입.
+            throw new IllegalStateException(
+                    "캐시된 routeSummaryJson lane 타입 부적합: " + laneNode.getNodeType());
+        }
+        try {
+            String pathRaw = objectMapper.writeValueAsString(pathNode);
+            return new OdsayRaw(pathRaw, laneRaw);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("캐시된 routeSummaryJson path 직렬화 실패", e);
         }
     }
 

--- a/backend/src/main/java/com/todayway/backend/route/OdsayRouteService.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayRouteService.java
@@ -1,5 +1,8 @@
 package com.todayway.backend.route;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import com.todayway.backend.external.ExternalApiException;
@@ -44,30 +47,37 @@ public class OdsayRouteService implements RouteService {
     private final OdsayClient odsayClient;
     private final OdsayResponseMapper mapper;
     private final OdsayProperties properties;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Autowired
     public OdsayRouteService(OdsayClient odsayClient,
                              OdsayResponseMapper mapper,
-                             OdsayProperties properties) {
-        this(odsayClient, mapper, properties, Clock.system(KST));
+                             OdsayProperties properties,
+                             ObjectMapper objectMapper) {
+        this(odsayClient, mapper, properties, objectMapper, Clock.system(KST));
     }
 
     /** 테스트용 — fixed Clock 주입으로 시간 검증 deterministic하게. */
     OdsayRouteService(OdsayClient odsayClient,
                       OdsayResponseMapper mapper,
                       OdsayProperties properties,
+                      ObjectMapper objectMapper,
                       Clock clock) {
         this.odsayClient = odsayClient;
         this.mapper = mapper;
         this.properties = properties;
+        this.objectMapper = objectMapper;
         this.clock = clock;
     }
+
+    /** {@code searchPubTransPathT} raw + {@code loadLane} raw 묶음. lane은 graceful 정책으로 nullable. */
+    private record OdsayRaw(String pathRaw, String laneRaw) {}
 
     @Override
     public boolean refreshRouteSync(Schedule schedule) {
         try {
-            String raw = callOdsay(schedule);
+            OdsayRaw raw = callOdsay(schedule);
             Route route = mapToRoute(schedule, raw);
             applyToSchedule(schedule, route, raw);
             return true;
@@ -97,7 +107,7 @@ public class OdsayRouteService implements RouteService {
 
         // (2) cache miss / expired / forceRefresh / 캐시 손상 — ODsay 호출
         try {
-            String raw = callOdsay(schedule);
+            OdsayRaw raw = callOdsay(schedule);
             Route route = mapToRoute(schedule, raw);
             applyToSchedule(schedule, route, raw);
             return buildResponse(schedule, route);
@@ -126,33 +136,63 @@ public class OdsayRouteService implements RouteService {
 
     // ── helpers ──
 
-    private String callOdsay(Schedule schedule) {
-        return odsayClient.searchPubTransPathT(
+    /**
+     * ODsay 2회 호출 — {@code searchPubTransPathT} 후 응답의 {@code info.mapObj}로 {@code loadLane}.
+     * loadLane은 graceful — 실패 시 {@code laneRaw=null}로 묶어 반환 (mapper가 passStopList 직선 fallback).
+     * <p>{@code searchPubTransPathT} 자체 실패는 throw — 호출자가 graceful catch.
+     */
+    private OdsayRaw callOdsay(Schedule schedule) {
+        String pathRaw = odsayClient.searchPubTransPathT(
                 bd(schedule.getOriginLng()),
                 bd(schedule.getOriginLat()),
                 bd(schedule.getDestinationLng()),
                 bd(schedule.getDestinationLat())
         );
+        String laneRaw = tryLoadLane(pathRaw);
+        return new OdsayRaw(pathRaw, laneRaw);
     }
 
-    private Route mapToRoute(Schedule schedule, String raw) {
-        return mapper.toRoute(raw,
+    /** loadLane graceful 호출 — mapObj 추출/호출 실패 시 null. mapper가 passStopList fallback. */
+    private String tryLoadLane(String pathRaw) {
+        String mapObj;
+        try {
+            JsonNode root = objectMapper.readTree(pathRaw);
+            mapObj = root.path("result").path("path").path(0).path("info").path("mapObj").asText(null);
+        } catch (Exception e) {
+            log.warn("ODsay loadLane mapObj 추출 실패 — passStopList 직선 fallback", e);
+            return null;
+        }
+        if (mapObj == null || mapObj.isBlank()) {
+            log.warn("ODsay 응답에 info.mapObj 없음 — passStopList 직선 fallback");
+            return null;
+        }
+        try {
+            return odsayClient.loadLane(mapObj);
+        } catch (ExternalApiException e) {
+            log.warn("ODsay loadLane 호출 실패 (graceful) type={} httpStatus={}",
+                    e.getType(), e.getHttpStatus(), e);
+            return null;
+        }
+    }
+
+    private Route mapToRoute(Schedule schedule, OdsayRaw raw) {
+        return mapper.toRoute(raw.pathRaw(), raw.laneRaw(),
                 bd(schedule.getOriginLng()), bd(schedule.getOriginLat()),
                 bd(schedule.getDestinationLng()), bd(schedule.getDestinationLat()));
     }
 
     /**
-     * 저장된 raw JSON({@code schedule.routeSummaryJson})을 매핑 시도.
-     * raw 없음/매핑 실패 시 {@link Optional#empty()} — caller가 다음 fallback으로 진행.
+     * 저장된 wrapped raw({@code {"path":..., "lane":...}})를 unwrap → mapper 매핑.
+     * raw 없음/형식 위반/매핑 실패 시 {@link Optional#empty()} — caller가 다음 fallback으로 진행.
      * <p>cache hit 경로(§6.1)와 ODsay 실패 stale fallback 경로 양쪽에서 동일하게 사용.
-     * 매핑 실패가 무시되지 않도록 Optional로 감싸 caller가 명시적으로 검사하게 강제.
      */
     private Optional<Route> tryMapCache(Schedule schedule) {
-        String raw = schedule.getRouteSummaryJson();
-        if (raw == null) {
+        String wrapped = schedule.getRouteSummaryJson();
+        if (wrapped == null) {
             return Optional.empty();
         }
         try {
+            OdsayRaw raw = unwrapRaw(wrapped);
             return Optional.of(mapToRoute(schedule, raw));
         } catch (IllegalStateException | IllegalArgumentException e) {
             log.warn("캐시된 ODsay raw 매핑 실패 scheduleUid={}",
@@ -165,17 +205,54 @@ public class OdsayRouteService implements RouteService {
      * ODsay 응답 + Route 매핑 결과를 Schedule 엔티티에 반영.
      * <p>{@code recommended_departure_time = arrival_time - estimated_duration_minutes}
      * (명세 §5.1 DB 매핑). Schedule.updateRouteInfo가 자동으로 departureAdvice/reminderAt 재계산.
+     * <p>{@code routeSummaryJson}은 wrapped 형식 — {@code {"path":..., "lane":...}} (§6.1 v1.1.10).
      */
-    private void applyToSchedule(Schedule schedule, Route route, String raw) {
+    private void applyToSchedule(Schedule schedule, Route route, OdsayRaw raw) {
         OffsetDateTime now = OffsetDateTime.now(clock);
         OffsetDateTime recommendedDeparture = schedule.getArrivalTime()
                 .minusMinutes(route.totalDurationMinutes());
         schedule.updateRouteInfo(
                 route.totalDurationMinutes(),
                 recommendedDeparture,
-                raw,
+                wrapRaw(raw),
                 now
         );
+    }
+
+    /** {@code {"path": <pathRaw>, "lane": <laneRaw|null>}} — lane은 graceful로 null 가능. */
+    private String wrapRaw(OdsayRaw raw) {
+        try {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.set("path", objectMapper.readTree(raw.pathRaw()));
+            node.set("lane", raw.laneRaw() == null
+                    ? objectMapper.nullNode()
+                    : objectMapper.readTree(raw.laneRaw()));
+            return objectMapper.writeValueAsString(node);
+        } catch (Exception e) {
+            // pathRaw는 ODsay에서 받은 valid JSON이라 정상적으로는 발생 X. 안전망.
+            throw new IllegalStateException("ODsay raw wrapping 실패", e);
+        }
+    }
+
+    /** wrapped JSON에서 path/lane raw 분리. 형식 위반은 IllegalStateException으로 throw. */
+    private OdsayRaw unwrapRaw(String wrapped) {
+        try {
+            JsonNode root = objectMapper.readTree(wrapped);
+            JsonNode pathNode = root.path("path");
+            JsonNode laneNode = root.path("lane");
+            if (pathNode.isMissingNode() || pathNode.isNull()) {
+                throw new IllegalStateException("캐시된 routeSummaryJson에 path 없음");
+            }
+            String pathRaw = objectMapper.writeValueAsString(pathNode);
+            String laneRaw = laneNode.isMissingNode() || laneNode.isNull()
+                    ? null
+                    : objectMapper.writeValueAsString(laneNode);
+            return new OdsayRaw(pathRaw, laneRaw);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("캐시된 routeSummaryJson 파싱 실패", e);
+        }
     }
 
     private boolean isCacheValid(Schedule schedule) {

--- a/backend/src/main/java/com/todayway/backend/route/Route.java
+++ b/backend/src/main/java/com/todayway/backend/route/Route.java
@@ -11,9 +11,9 @@ import java.util.List;
  * <p>모든 필드 {@code int} (not null primitive) — 명세상 number 필수.
  * ODsay 응답에 missing field가 있으면 mapper의 {@code .asInt()}가 0을 반환 (graceful).
  *
- * @param transferCount 잠정 정의: {@code subwayTransitCount + busTransitCount} (명세 §6.1 매핑표).
- *                      합산 의미가 *환승 횟수*인지 *이용 노선 수*인지는 PR #11 P2 #3 (황찬우)
- *                      명세팀 답변 대기 — 답 수령 후 정의 또는 산식 갱신 필요.
+ * @param transferCount {@code subwayTransitCount + busTransitCount} 합산 (명세 §6.1 매핑표).
+ *                      합산 의미(*환승 횟수* vs *이용 노선 수*)는 명세팀 답변 후 정의 또는 산식
+ *                      갱신 가능 — 잠정적으로 두 값이 합쳐서 '총 갈아탄 횟수'를 표현한다고 가정.
  */
 public record Route(
         int totalDurationMinutes,

--- a/backend/src/main/java/com/todayway/backend/route/Route.java
+++ b/backend/src/main/java/com/todayway/backend/route/Route.java
@@ -11,7 +11,9 @@ import java.util.List;
  * <p>모든 필드 {@code int} (not null primitive) — 명세상 number 필수.
  * ODsay 응답에 missing field가 있으면 mapper의 {@code .asInt()}가 0을 반환 (graceful).
  *
- * @param transferCount {@code subwayTransitCount + busTransitCount} 합산 (명세 §6.1 매핑표)
+ * @param transferCount 잠정 정의: {@code subwayTransitCount + busTransitCount} (명세 §6.1 매핑표).
+ *                      합산 의미가 *환승 횟수*인지 *이용 노선 수*인지는 PR #11 P2 #3 (황찬우)
+ *                      명세팀 답변 대기 — 답 수령 후 정의 또는 산식 갱신 필요.
  */
 public record Route(
         int totalDurationMinutes,

--- a/backend/src/main/java/com/todayway/backend/route/RouteSegment.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteSegment.java
@@ -33,4 +33,14 @@ public record RouteSegment(
         String stationEnd,
         Integer stationCount,
         List<double[]> path
-) {}
+) {
+    public RouteSegment {
+        // polyline은 최소 2점 필요 — 단일 점/null/빈 path는 명세 §11.5 위반.
+        // record 자체에 invariant 박아 caller(mapper/외부)와 무관하게 보장.
+        if (path == null || path.size() < 2) {
+            throw new IllegalArgumentException(
+                    "RouteSegment.path는 2점 이상 필요 — mode=" + mode
+                            + " size=" + (path == null ? "null" : path.size()));
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/route/RouteSegment.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteSegment.java
@@ -42,5 +42,38 @@ public record RouteSegment(
                     "RouteSegment.path는 2점 이상 필요 — mode=" + mode
                             + " size=" + (path == null ? "null" : path.size()));
         }
+        if (mode == null) {
+            throw new IllegalArgumentException("RouteSegment.mode는 null 불가");
+        }
+        // mode-specific nullable matrix (명세 §11.5 / §6.1 매핑표):
+        //   WALK   — line*/station* 5필드 모두 null
+        //   SUBWAY — lineName + lineId + stationStart + stationEnd + stationCount 모두 non-null
+        //   BUS    — lineName + lineId만 non-null (station* 필드는 null — from/to와 중복)
+        switch (mode) {
+            case WALK -> {
+                if (from != null || to != null
+                        || lineName != null || lineId != null
+                        || stationStart != null || stationEnd != null || stationCount != null) {
+                    throw new IllegalArgumentException(
+                            "WALK segment는 from/to/line*/station* 필드 모두 null이어야 함");
+                }
+            }
+            case SUBWAY -> {
+                if (lineName == null || lineId == null
+                        || stationStart == null || stationEnd == null || stationCount == null) {
+                    throw new IllegalArgumentException(
+                            "SUBWAY segment는 lineName/lineId/stationStart/stationEnd/stationCount 모두 필수");
+                }
+            }
+            case BUS -> {
+                if (lineName == null || lineId == null) {
+                    throw new IllegalArgumentException("BUS segment는 lineName/lineId 필수");
+                }
+                if (stationStart != null || stationEnd != null) {
+                    throw new IllegalArgumentException(
+                            "BUS segment는 stationStart/stationEnd null 필수 (from/to와 중복 회피)");
+                }
+            }
+        }
     }
 }

--- a/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
@@ -124,4 +124,69 @@ class OdsayClientTest {
         assertThat(ex.getHttpStatus()).isEqualTo(500);
         assertThat(ex.getCause()).isNull();
     }
+
+    // ─── loadLane (§6.1 v1.1.10) ─────────────────────────────────
+
+    @Test
+    void loadLane_정상_200_응답_raw_그대로_반환_mapObject_prefix_포함() {
+        // mapObject prefix "0:0@" 검증 + apiKey 함께 인코딩
+        server.expect(requestTo(Matchers.allOf(
+                        Matchers.containsString("/loadLane"),
+                        Matchers.containsString("mapObject=0:0@908"),
+                        Matchers.containsString("apiKey=test%2Bkey%2Fwith%3Dspecial"))))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("{\"result\":{\"lane\":[]}}", MediaType.APPLICATION_JSON));
+
+        String result = client.loadLane("908:1:1:16");
+
+        assertThat(result).contains("lane");
+        server.verify();
+    }
+
+    @Test
+    void loadLane_빈_응답_body면_SERVER_ERROR_cause_null() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class, () -> client.loadLane("908:1:1:16"));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
+        assertThat(ex.getSource()).isEqualTo(ExternalApiException.Source.ODSAY);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void loadLane_HTTP_401이면_CLIENT_ERROR와_httpStatus_보존_cause_null() {
+        // 운영자 alert: searchPubTransPathT와 동일 정책 — 401/403은 503 EXTERNAL_AUTH_MISCONFIGURED로 격상
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED).body("ApiKeyAuthFailed"));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class, () -> client.loadLane("908:1:1:16"));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.CLIENT_ERROR);
+        assertThat(ex.getHttpStatus()).isEqualTo(401);
+        assertThat(ex.getCause()).isNull();
+        assertThat(ex.getMessage())
+                .doesNotContain("apiKey")
+                .doesNotContain("test+key")
+                .doesNotContain("https://");
+    }
+
+    @Test
+    void loadLane_HTTP_500이면_SERVER_ERROR와_httpStatus_보존() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class, () -> client.loadLane("908:1:1:16"));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
+        assertThat(ex.getHttpStatus()).isEqualTo(500);
+        assertThat(ex.getCause()).isNull();
+    }
 }

--- a/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/odsay/OdsayClientTest.java
@@ -128,11 +128,19 @@ class OdsayClientTest {
     // ─── loadLane (§6.1 v1.1.10) ─────────────────────────────────
 
     @Test
-    void loadLane_정상_200_응답_raw_그대로_반환_mapObject_prefix_포함() {
-        // mapObject prefix "0:0@" 검증 + apiKey 함께 인코딩
+    void loadLane_정상_200_응답_mapObject_prefix는_raw_mapObj변수는_strict_encoding() {
+        // 회귀 가드: 템플릿 "0:0@"는 raw 박혀있어 percent-encoding 안 됨
+        // (Spring RestClient default EncodingMode.TEMPLATE_AND_VALUES).
+        // 변수 {mapObj}만 strict — "908:1:1:16"의 ':' 모두 %3A로 변환.
+        // 누가 .queryParam("mapObject", "0:0@" + mapObj) 패턴으로 바꾸면 prefix까지 인코딩되어
+        // ODsay에 다른 형태로 전달됨 — 그 회귀 차단.
         server.expect(requestTo(Matchers.allOf(
                         Matchers.containsString("/loadLane"),
-                        Matchers.containsString("mapObject=0:0@908"),
+                        // prefix는 raw — '0:0@'가 percent-encoded 안 됨
+                        Matchers.containsString("mapObject=0:0@"),
+                        // mapObj 변수는 strict — '908:1:1:16' → '908%3A1%3A1%3A16'
+                        Matchers.containsString("908%3A1%3A1%3A16"),
+                        // apiKey도 strict
                         Matchers.containsString("apiKey=test%2Bkey%2Fwith%3Dspecial"))))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess("{\"result\":{\"lane\":[]}}", MediaType.APPLICATION_JSON));

--- a/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
@@ -408,6 +408,101 @@ class OdsayResponseMapperTest {
     }
 
     @Test
+    void loadLane_길이_불일치면_swap_위험_방지를_위해_전체_passStopList_fallback() throws IOException {
+        // fixture는 transit 1개(BUS). lane 0개 응답이 와도 부분 매핑 X (잘못된 segment에 매핑되어
+        // silent하게 다른 노선 곡선이 그려지면 visual 버그라 명세 §6.1 v1.1.10에서 전체 fallback 정책).
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        String laneRaw = "{ \"result\": { \"lane\": [] } }";  // size 0
+
+        Route route = mapper.toRoute(pathRaw, laneRaw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // BUS path가 passStopList 18점 그대로 (size mismatch → graphPos 무시)
+        assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    @Test
+    void loadLane_graphPos_한국_좌표_범위_밖이면_passStopList_fallback() throws IOException {
+        // (0, 0) 같은 좌표가 섞이면 polyline 대서양 점프. silent 통과 차단.
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        String laneRaw = """
+                {
+                  "result": {
+                    "lane": [
+                      {
+                        "section": [
+                          {
+                            "graphPos": [
+                              {"x": 126.994769, "y": 37.61072},
+                              {"x": 0, "y": 0},
+                              {"x": 126.976851, "y": 37.565929}
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        Route route = mapper.toRoute(pathRaw, laneRaw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // 한국 범위 밖 좌표 발견 → 전체 lane drop → passStopList 18점
+        assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    @Test
+    void loadLane_graphPos_NaN이면_passStopList_fallback() throws IOException {
+        // ODsay 응답 손상으로 NaN/Infinity가 섞일 가능성 — silent 통과 X
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        // JSON에 NaN은 invalid라 string으로 시뮬레이션 (parseCoord가 NumberFormatException → IllegalStateException)
+        String laneRaw = """
+                {
+                  "result": {
+                    "lane": [
+                      {
+                        "section": [
+                          {
+                            "graphPos": [
+                              {"x": "NaN", "y": "37.61"},
+                              {"x": 126.99, "y": 37.61}
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        Route route = mapper.toRoute(pathRaw, laneRaw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    @Test
+    void loadLane_lane의_graphPos가_2점_미만이면_fallback() throws IOException {
+        // polyline은 최소 2점 필요. lane[0]이 1점만 주면 visual 무의미 → fallback.
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        String laneRaw = """
+                {
+                  "result": {
+                    "lane": [
+                      {
+                        "section": [
+                          {"graphPos": [{"x": 126.994769, "y": 37.61072}]}
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        Route route = mapper.toRoute(pathRaw, laneRaw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    @Test
     void unknown_trafficType이면_IllegalArgumentException() {
         // ODsay가 명세 외 trafficType (예: 4=택시)을 추가했을 때 silent fallback 안 함.
         // OdsayRouteService에서 명시적 catch → graceful degradation.

--- a/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
@@ -38,7 +38,7 @@ class OdsayResponseMapperTest {
     void 실제_ODsay_응답_매핑_명세_6_1_매핑표_전체_검증() throws IOException {
         String raw = Files.readString(Path.of(FIXTURE_PATH));
 
-        Route route = mapper.toRoute(raw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+        Route route = mapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
 
         // ── Route 필드 (§6.1 매핑표) ──
         assertThat(route.totalDurationMinutes()).isEqualTo(34);    // info.totalTime
@@ -53,7 +53,7 @@ class OdsayResponseMapperTest {
     void WALK_구간_매핑_origin과_destination_좌표로_path_보충() throws IOException {
         String raw = Files.readString(Path.of(FIXTURE_PATH));
 
-        Route route = mapper.toRoute(raw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+        Route route = mapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
 
         // [0] 첫 WALK: origin → 다음 transit(BUS) startX/Y
         RouteSegment seg0 = route.segments().get(0);
@@ -105,7 +105,7 @@ class OdsayResponseMapperTest {
                 }
                 """;
 
-        Route route = mapper.toRoute(raw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+        Route route = mapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
 
         assertThat(route.transferCount()).isZero();
         assertThat(route.payment()).isZero();
@@ -143,7 +143,7 @@ class OdsayResponseMapperTest {
                 }
                 """;
 
-        assertThatThrownBy(() -> mapper.toRoute(raw, 0, 0, 0, 0))
+        assertThatThrownBy(() -> mapper.toRoute(raw, null, 0, 0, 0, 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("좌표");
     }
@@ -172,7 +172,7 @@ class OdsayResponseMapperTest {
                 }
                 """;
 
-        assertThatThrownBy(() -> mapper.toRoute(raw, 0, 0, 0, 0))
+        assertThatThrownBy(() -> mapper.toRoute(raw, null, 0, 0, 0, 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("startX");
     }
@@ -181,7 +181,7 @@ class OdsayResponseMapperTest {
     void BUS_구간_매핑_busNo_busID_string_변환_passStopList_path() throws IOException {
         String raw = Files.readString(Path.of(FIXTURE_PATH));
 
-        Route route = mapper.toRoute(raw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+        Route route = mapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
 
         // [1] BUS 1711번
         RouteSegment seg = route.segments().get(1);
@@ -213,7 +213,7 @@ class OdsayResponseMapperTest {
     void path_배열이_비어있으면_IllegalStateException() {
         String raw = "{ \"result\": { \"path\": [] } }";
 
-        assertThatThrownBy(() -> mapper.toRoute(raw, 0, 0, 0, 0))
+        assertThatThrownBy(() -> mapper.toRoute(raw, null, 0, 0, 0, 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("path[0]");
     }
@@ -222,7 +222,7 @@ class OdsayResponseMapperTest {
     void 잘못된_JSON이면_IllegalStateException() {
         String raw = "this-is-not-json";
 
-        assertThatThrownBy(() -> mapper.toRoute(raw, 0, 0, 0, 0))
+        assertThatThrownBy(() -> mapper.toRoute(raw, null, 0, 0, 0, 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("파싱 실패");
     }
@@ -264,7 +264,7 @@ class OdsayResponseMapperTest {
                 }
                 """;
 
-        Route route = mapper.toRoute(raw, 127.014, 37.610, 126.977, 37.564);
+        Route route = mapper.toRoute(raw, null, 127.014, 37.610, 126.977, 37.564);
 
         assertThat(route.segments()).hasSize(1);
         RouteSegment seg = route.segments().get(0);
@@ -307,9 +307,104 @@ class OdsayResponseMapperTest {
                 }
                 """;
 
-        assertThatThrownBy(() -> mapper.toRoute(raw, 0, 0, 0, 0))
+        assertThatThrownBy(() -> mapper.toRoute(raw, null, 0, 0, 0, 0))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("info");
+    }
+
+    @Test
+    void loadLane_raw_제공시_transit_path가_graphPos로_교체() throws IOException {
+        // §6.1 v1.1.10 — loadLane.lane[i].section[].graphPos[] → transit segment i의 path
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        // fixture는 transit subPath 1개(BUS) → lane[0].section[]만 사용
+        String laneRaw = """
+                {
+                  "result": {
+                    "lane": [
+                      {
+                        "section": [
+                          {
+                            "graphPos": [
+                              {"x": 126.994769, "y": 37.61072},
+                              {"x": 126.992, "y": 37.605},
+                              {"x": 126.985, "y": 37.580},
+                              {"x": 126.980, "y": 37.572},
+                              {"x": 126.976851, "y": 37.565929}
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        Route route = mapper.toRoute(pathRaw, laneRaw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // BUS segment(index 1)의 path가 graphPos 5점으로 교체 — passStopList(18점) 아님
+        RouteSegment busSeg = route.segments().get(1);
+        assertThat(busSeg.mode()).isEqualTo(SegmentMode.BUS);
+        assertThat(busSeg.path()).hasSize(5);
+        assertThat(busSeg.path().get(0)).containsExactly(126.994769, 37.61072);
+        assertThat(busSeg.path().get(4)).containsExactly(126.976851, 37.565929);
+    }
+
+    @Test
+    void loadLane_raw_깨졌을때_passStopList_fallback() throws IOException {
+        // graceful — lane raw 형식 위반 시 transit path는 기존 passStopList 직선으로 fallback
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = mapper.toRoute(pathRaw, "this-is-not-json", ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+        assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    @Test
+    void loadLane_lane_배열_비었을때_passStopList_fallback() throws IOException {
+        String pathRaw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = mapper.toRoute(pathRaw, "{ \"result\": { \"lane\": [] } }",
+                ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+        assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    @Test
+    void loadLane_section_여러개면_graphPos_평탄화() {
+        // lane[0].section[0,1] 두 section의 graphPos를 합쳐 한 transit segment의 path로
+        String pathRaw = """
+                {
+                  "result": {
+                    "path": [{
+                      "info": {
+                        "totalTime": 30, "totalDistance": 5000, "totalWalk": 0,
+                        "subwayTransitCount": 0, "busTransitCount": 1, "payment": 1500
+                      },
+                      "subPath": [{
+                        "trafficType": 2,
+                        "sectionTime": 30, "distance": 5000,
+                        "startName": "A", "endName": "B", "stationCount": 0,
+                        "startX": 127.0, "startY": 37.6,
+                        "endX": 127.1, "endY": 37.5,
+                        "lane": [{"busNo": "100", "busID": 1}],
+                        "passStopList": {"stations": []}
+                      }]
+                    }]
+                  }
+                }
+                """;
+        String laneRaw = """
+                {
+                  "result": {
+                    "lane": [{
+                      "section": [
+                        {"graphPos": [{"x": 127.0, "y": 37.6}, {"x": 127.05, "y": 37.55}]},
+                        {"graphPos": [{"x": 127.05, "y": 37.55}, {"x": 127.1, "y": 37.5}]}
+                      ]
+                    }]
+                  }
+                }
+                """;
+
+        Route route = mapper.toRoute(pathRaw, laneRaw, 0, 0, 0, 0);
+
+        assertThat(route.segments().get(0).path()).hasSize(4);  // 2 + 2 평탄화
     }
 
     @Test
@@ -330,7 +425,7 @@ class OdsayResponseMapperTest {
                 }
                 """;
 
-        assertThatThrownBy(() -> mapper.toRoute(raw, 0, 0, 0, 0))
+        assertThatThrownBy(() -> mapper.toRoute(raw, null, 0, 0, 0, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("99");
     }

--- a/backend/src/test/java/com/todayway/backend/route/OdsayRouteServiceTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayRouteServiceTest.java
@@ -10,6 +10,8 @@ import com.todayway.backend.schedule.domain.Schedule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -83,34 +85,23 @@ class OdsayRouteServiceTest {
                 .isEqualTo(s.getArrivalTime().minusMinutes(34));
     }
 
-    @Test
-    void refreshRouteSync_401이면_BusinessException_503_AUTH_MISCONFIGURED_propagate() {
-        // 401/403은 운영자 조치 필요 — silent false 반환 X. 일정 등록 시점에도 동일 정책.
+    @ParameterizedTest
+    @ValueSource(ints = {401, 403})
+    void refreshRouteSync_401_403도_graceful_false반환_명세_5_1_정책(int status) {
+        // 명세 §5.1 — ODsay 호출 실패 시 일정은 정상 등록 + PENDING_RETRY (graceful degradation).
+        // 401/403도 등록 흐름에선 §5.1 우선이라 BusinessException throw X (조회 §6.1만 503 격상).
+        // 운영자 alert는 log.error 레벨 격상으로 보존. isAuthError의 || 양쪽 분기 회귀 가드.
         Schedule s = newSchedule();
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenThrow(new ExternalApiException(
                         ExternalApiException.Source.ODSAY,
-                        ExternalApiException.Type.CLIENT_ERROR, 401, "auth", null));
+                        ExternalApiException.Type.CLIENT_ERROR, status, "auth", null));
 
-        BusinessException ex = catchThrowableOfType(
-                BusinessException.class, () -> service.refreshRouteSync(s));
+        boolean result = service.refreshRouteSync(s);
 
-        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+        assertThat(result).isFalse();
         assertThat(s.getRouteSummaryJson()).isNull();
-    }
-
-    @Test
-    void refreshRouteSync_403이면_BusinessException_503_AUTH_MISCONFIGURED_propagate() {
-        Schedule s = newSchedule();
-        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
-                .thenThrow(new ExternalApiException(
-                        ExternalApiException.Source.ODSAY,
-                        ExternalApiException.Type.CLIENT_ERROR, 403, "forbidden", null));
-
-        BusinessException ex = catchThrowableOfType(
-                BusinessException.class, () -> service.refreshRouteSync(s));
-
-        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+        assertThat(s.getEstimatedDurationMinutes()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/todayway/backend/route/OdsayRouteServiceTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayRouteServiceTest.java
@@ -84,6 +84,36 @@ class OdsayRouteServiceTest {
     }
 
     @Test
+    void refreshRouteSync_401이면_BusinessException_503_AUTH_MISCONFIGURED_propagate() {
+        // 401/403은 운영자 조치 필요 — silent false 반환 X. 일정 등록 시점에도 동일 정책.
+        Schedule s = newSchedule();
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenThrow(new ExternalApiException(
+                        ExternalApiException.Source.ODSAY,
+                        ExternalApiException.Type.CLIENT_ERROR, 401, "auth", null));
+
+        BusinessException ex = catchThrowableOfType(
+                BusinessException.class, () -> service.refreshRouteSync(s));
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+        assertThat(s.getRouteSummaryJson()).isNull();
+    }
+
+    @Test
+    void refreshRouteSync_403이면_BusinessException_503_AUTH_MISCONFIGURED_propagate() {
+        Schedule s = newSchedule();
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenThrow(new ExternalApiException(
+                        ExternalApiException.Source.ODSAY,
+                        ExternalApiException.Type.CLIENT_ERROR, 403, "forbidden", null));
+
+        BusinessException ex = catchThrowableOfType(
+                BusinessException.class, () -> service.refreshRouteSync(s));
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+    }
+
+    @Test
     void refreshRouteSync_ExternalApiException은_graceful_false반환_schedule변경없음() {
         Schedule s = newSchedule();
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
@@ -330,6 +360,78 @@ class OdsayRouteServiceTest {
         // stale — calculatedAt은 갱신되지 않음 (15분 전 그대로), routeSummaryJson도 보존
         assertThat(res.calculatedAt()).isEqualTo(FIXED_NOW.minusMinutes(15));
         assertThat(s.getRouteSummaryJson()).isEqualTo("{\"path\":{\"cached\":true},\"lane\":null}");
+    }
+
+    // ─── unwrapRaw / wrapRaw 분기 (§6.1 v1.1.10) ────────────────
+
+    @Test
+    void getRoute_캐시_wrapped_path_없으면_unwrap_실패_fresh_복구() {
+        // 잘못 저장된 캐시 (path 키 없음) → unwrapRaw IllegalStateException → tryMapCache empty → fresh.
+        // v1.1.10 이전 raw가 그대로 남아있는 경우 자동 마이그레이션 (운영 spike 가능성 P1 T2).
+        Schedule s = newSchedule();
+        s.updateRouteInfo(34, s.getArrivalTime().minusMinutes(34),
+                "{\"result\":{\"path\":[]}}",  // v1.1.10 이전 형식: path 키 없이 ODsay raw 그대로
+                FIXED_NOW.minusMinutes(5));   // TTL 내
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn("{\"result\":{\"path\":[{\"info\":{}}]}}");
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(fakeRoute(34));
+
+        service.getRoute(s, false);
+
+        verify(odsayClient, times(1))
+                .searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void getRoute_캐시_wrapped_lane이_텍스트_null이면_unwrap_거부_fresh_복구() {
+        // lane 노드가 text "null" 또는 비-object 형태면 명시 거부 (M1 안전망)
+        Schedule s = newSchedule();
+        s.updateRouteInfo(34, s.getArrivalTime().minusMinutes(34),
+                "{\"path\":{\"a\":1},\"lane\":\"null\"}",  // lane이 string "null"
+                FIXED_NOW.minusMinutes(5));
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn("{\"result\":{\"path\":[{\"info\":{}}]}}");
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(fakeRoute(34));
+
+        service.getRoute(s, false);
+
+        verify(odsayClient, times(1))
+                .searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    void getRoute_loadLane_401이면_503_AUTH_MISCONFIGURED_propagate() {
+        // M3: loadLane이 401/403이면 운영자 alert 필요 → graceful 흡수 X, BusinessException으로 격상
+        Schedule s = newSchedule();
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn("{\"result\":{\"path\":[{\"info\":{\"mapObj\":\"x:y\"}}]}}");
+        when(odsayClient.loadLane(anyString()))
+                .thenThrow(new ExternalApiException(
+                        ExternalApiException.Source.ODSAY,
+                        ExternalApiException.Type.CLIENT_ERROR, 401, "auth", null));
+
+        BusinessException ex = catchThrowableOfType(
+                BusinessException.class, () -> service.getRoute(s, false));
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+    }
+
+    @Test
+    void getRoute_loadLane_403이면_503_AUTH_MISCONFIGURED_propagate() {
+        Schedule s = newSchedule();
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn("{\"result\":{\"path\":[{\"info\":{\"mapObj\":\"x:y\"}}]}}");
+        when(odsayClient.loadLane(anyString()))
+                .thenThrow(new ExternalApiException(
+                        ExternalApiException.Source.ODSAY,
+                        ExternalApiException.Type.CLIENT_ERROR, 403, "forbidden", null));
+
+        BusinessException ex = catchThrowableOfType(
+                BusinessException.class, () -> service.getRoute(s, false));
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
     }
 
     // ─── helpers ──────────────────────────────────────────────────

--- a/backend/src/test/java/com/todayway/backend/route/OdsayRouteServiceTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayRouteServiceTest.java
@@ -1,5 +1,6 @@
 package com.todayway.backend.route;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import com.todayway.backend.external.ExternalApiException;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,6 +45,7 @@ class OdsayRouteServiceTest {
     @Mock OdsayResponseMapper mapper;
 
     OdsayProperties properties;
+    ObjectMapper objectMapper;
     Clock fixedClock;
     OdsayRouteService service;
 
@@ -53,8 +56,9 @@ class OdsayRouteServiceTest {
         properties.setBaseUrl("https://api.odsay.com/v1/api");
         properties.setTimeoutSeconds(5);
         properties.setCacheTtlMinutes(10);
+        objectMapper = new ObjectMapper();
         fixedClock = Clock.fixed(FIXED_NOW.toInstant(), KST);
-        service = new OdsayRouteService(odsayClient, mapper, properties, fixedClock);
+        service = new OdsayRouteService(odsayClient, mapper, properties, objectMapper, fixedClock);
     }
 
     // ─── refreshRouteSync ─────────────────────────────────────────
@@ -64,14 +68,15 @@ class OdsayRouteServiceTest {
         Schedule s = newSchedule();
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn("{\"raw\":\"json\"}");
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(fakeRoute(34));
 
         boolean result = service.refreshRouteSync(s);
 
         assertThat(result).isTrue();
         assertThat(s.getEstimatedDurationMinutes()).isEqualTo(34);
-        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"raw\":\"json\"}");
+        // wrapped 형식 — {"path": <pathRaw>, "lane": null} (mapObj 없는 stub이라 lane null fallback)
+        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"path\":{\"raw\":\"json\"},\"lane\":null}");
         assertThat(s.getRouteCalculatedAt()).isEqualTo(FIXED_NOW);
         // 명세 §5.1 — recommended_departure_time = arrival_time - estimated_duration_minutes
         assertThat(s.getRecommendedDepartureTime())
@@ -100,7 +105,7 @@ class OdsayRouteServiceTest {
         Schedule s = newSchedule();
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn("{}");
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenThrow(new IllegalStateException("path[0] 없음"));
 
         boolean result = service.refreshRouteSync(s);
@@ -114,7 +119,7 @@ class OdsayRouteServiceTest {
     @Test
     void getRoute_cache_hit_TTL_내면_ODsay_호출안함() {
         Schedule s = newScheduleWithCache(FIXED_NOW.minusMinutes(5));   // TTL=10, 5분 전 → hit
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(fakeRoute(34));
 
         RouteResponse res = service.getRoute(s, false);
@@ -131,7 +136,7 @@ class OdsayRouteServiceTest {
         Schedule s = newScheduleWithCache(FIXED_NOW.minusMinutes(10));
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn("{\"fresh\":true}");
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(fakeRoute(34));
 
         service.getRoute(s, false);
@@ -145,7 +150,7 @@ class OdsayRouteServiceTest {
         Schedule s = newScheduleWithCache(FIXED_NOW.minusMinutes(15));  // TTL=10, 15분 전 → expired
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn("{\"fresh\":true}");
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(fakeRoute(34));
 
         service.getRoute(s, false);
@@ -154,7 +159,7 @@ class OdsayRouteServiceTest {
                 .searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble());
         // cache 갱신 검증
         assertThat(s.getRouteCalculatedAt()).isEqualTo(FIXED_NOW);
-        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"fresh\":true}");
+        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"path\":{\"fresh\":true},\"lane\":null}");
     }
 
     @Test
@@ -162,7 +167,7 @@ class OdsayRouteServiceTest {
         Schedule s = newScheduleWithCache(FIXED_NOW.minusMinutes(1));   // 1분 전 — TTL 내
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn("{\"forced\":true}");
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(fakeRoute(34));
 
         service.getRoute(s, true);
@@ -179,7 +184,7 @@ class OdsayRouteServiceTest {
                 .thenThrow(new ExternalApiException(
                         ExternalApiException.Source.ODSAY,
                         ExternalApiException.Type.SERVER_ERROR, 500, "5xx", null));
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn(fakeRoute(34));
 
         RouteResponse res = service.getRoute(s, false);
@@ -219,6 +224,61 @@ class OdsayRouteServiceTest {
     }
 
     @Test
+    void getRoute_loadLane_정상호출_wrapped_저장() {
+        // §6.1 v1.1.10 — searchPubTransPathT 응답에 mapObj 있으면 loadLane 호출 + wrapped 저장
+        Schedule s = newSchedule();
+        String pathRaw = "{\"result\":{\"path\":[{\"info\":{\"mapObj\":\"908:1:1:16\"}}]}}";
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(pathRaw);
+        when(odsayClient.loadLane("908:1:1:16")).thenReturn("{\"lane_data\":true}");
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(fakeRoute(34));
+
+        service.getRoute(s, false);
+
+        verify(odsayClient, times(1)).loadLane("908:1:1:16");
+        // wrapped 형식 — path + lane 둘 다 보존
+        assertThat(s.getRouteSummaryJson())
+                .contains("\"path\":")
+                .contains("\"mapObj\":\"908:1:1:16\"")
+                .contains("\"lane\":{\"lane_data\":true}");
+    }
+
+    @Test
+    void getRoute_loadLane_실패시_graceful_lane_null_저장() {
+        // loadLane이 5xx여도 path 매핑은 정상 진행 + lane=null로 저장 (passStopList fallback)
+        Schedule s = newSchedule();
+        String pathRaw = "{\"result\":{\"path\":[{\"info\":{\"mapObj\":\"x:y\"}}]}}";
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(pathRaw);
+        when(odsayClient.loadLane(anyString()))
+                .thenThrow(new ExternalApiException(
+                        ExternalApiException.Source.ODSAY,
+                        ExternalApiException.Type.SERVER_ERROR, 500, "5xx", null));
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(fakeRoute(34));
+
+        service.getRoute(s, false);
+
+        assertThat(s.getRouteSummaryJson()).contains("\"lane\":null");
+    }
+
+    @Test
+    void getRoute_mapObj_없으면_loadLane_호출_안됨() {
+        // ODsay 응답에 info.mapObj 없으면 loadLane 호출 자체 skip — 불필요 호출 방지
+        Schedule s = newSchedule();
+        when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn("{\"result\":{\"path\":[{\"info\":{}}]}}");
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(fakeRoute(34));
+
+        service.getRoute(s, false);
+
+        verify(odsayClient, never()).loadLane(anyString());
+        assertThat(s.getRouteSummaryJson()).contains("\"lane\":null");
+    }
+
+    @Test
     void getRoute_ODsay_5xx_캐시없으면_BusinessException_502() {
         Schedule s = newSchedule();
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
@@ -237,7 +297,7 @@ class OdsayRouteServiceTest {
         // 캐시 TTL 내(5분 전)이지만 저장된 raw가 손상됐다고 가정 → mapper 첫 호출은 실패.
         // fresh ODsay 호출 + 두 번째 매핑은 성공해야 200 응답.
         Schedule s = newScheduleWithCache(FIXED_NOW.minusMinutes(5));
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenThrow(new IllegalStateException("path[0] 없음"))   // (1) tryMapCache 실패
                 .thenReturn(fakeRoute(34));                             // (2) fresh 매핑 성공
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
@@ -250,7 +310,7 @@ class OdsayRouteServiceTest {
         verify(odsayClient, times(1))
                 .searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble());
         assertThat(s.getRouteCalculatedAt()).isEqualTo(FIXED_NOW);
-        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"recovered\":true}");
+        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"path\":{\"recovered\":true},\"lane\":null}");
     }
 
     @Test
@@ -260,7 +320,7 @@ class OdsayRouteServiceTest {
         Schedule s = newScheduleWithCache(FIXED_NOW.minusMinutes(15));   // expired
         when(odsayClient.searchPubTransPathT(anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenReturn("{\"corrupt\":true}");
-        when(mapper.toRoute(anyString(), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
+        when(mapper.toRoute(anyString(), nullable(String.class), anyDouble(), anyDouble(), anyDouble(), anyDouble()))
                 .thenThrow(new IllegalStateException("path[0] 없음"))   // (1) fresh 매핑 실패
                 .thenReturn(fakeRoute(34));                             // (2) stale 매핑 성공
 
@@ -269,7 +329,7 @@ class OdsayRouteServiceTest {
         assertThat(res).isNotNull();
         // stale — calculatedAt은 갱신되지 않음 (15분 전 그대로), routeSummaryJson도 보존
         assertThat(res.calculatedAt()).isEqualTo(FIXED_NOW.minusMinutes(15));
-        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"cached\":true}");
+        assertThat(s.getRouteSummaryJson()).isEqualTo("{\"path\":{\"cached\":true},\"lane\":null}");
     }
 
     // ─── helpers ──────────────────────────────────────────────────
@@ -290,13 +350,16 @@ class OdsayRouteServiceTest {
         );
     }
 
-    /** 캐시 보유 Schedule — calculatedAt만 입력. updateRouteInfo로 routeSummaryJson 채움. */
+    /**
+     * 캐시 보유 Schedule. routeSummaryJson은 wrapped 형식 (§6.1 v1.1.10) —
+     * {@code {"path":..., "lane":null}}. lane=null로 두면 mapper가 passStopList fallback.
+     */
     private static Schedule newScheduleWithCache(OffsetDateTime calculatedAt) {
         Schedule s = newSchedule();
         s.updateRouteInfo(
                 34,
                 s.getArrivalTime().minusMinutes(34),
-                "{\"cached\":true}",
+                "{\"path\":{\"cached\":true},\"lane\":null}",
                 calculatedAt
         );
         return s;

--- a/backend/src/test/java/com/todayway/backend/route/RouteSegmentTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/RouteSegmentTest.java
@@ -4,19 +4,28 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * {@link RouteSegment} record invariant — path는 polyline 의미상 2점 이상 필수 (명세 §11.5).
- * <p>v1.1.10에서 mapper에 박혀있던 검증을 record compact ctor로 이동 — caller(mapper/외부)
- * 무관하게 invariant 보장. WALK/SUBWAY/BUS 모두 동일 적용.
+ * {@link RouteSegment} record invariant — 명세 §11.5 / §6.1 매핑표 정합:
+ * <ul>
+ *   <li>{@code path}: 2점 이상 (polyline 의미)</li>
+ *   <li>{@code mode}: non-null</li>
+ *   <li>mode-specific nullable 매트릭스 — caller(mapper/외부) 무관하게 record가 강제</li>
+ * </ul>
  */
 class RouteSegmentTest {
+
+    private static final List<double[]> VALID_PATH =
+            List.of(new double[]{127.0, 37.6}, new double[]{127.1, 37.5});
+
+    // ─── path size invariant ─────────────────────────────────────
 
     @Test
     void path_null이면_IllegalArgumentException() {
         assertThatThrownBy(() -> new RouteSegment(
-                SegmentMode.WALK, 5, 350, "A", "B",
+                SegmentMode.WALK, 5, 350, null, null,
                 null, null, null, null, null,
                 null))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -33,13 +42,105 @@ class RouteSegmentTest {
                 .hasMessageContaining("2점 이상");
     }
 
+    // ─── mode-specific nullable 매트릭스 ──────────────────────────
+
     @Test
-    void path가_2점이면_정상_생성() {
+    void WALK_정상() {
+        // WALK는 from/to/line*/station* 5+2 = 7필드 모두 null
         RouteSegment seg = new RouteSegment(
-                SegmentMode.WALK, 5, 350, "A", "B",
+                SegmentMode.WALK, 5, 350, null, null,
                 null, null, null, null, null,
-                List.of(new double[]{127.0, 37.6}, new double[]{127.1, 37.5}));
-        // 정상 — 2점이라 invariant 통과
-        org.assertj.core.api.Assertions.assertThat(seg.path()).hasSize(2);
+                VALID_PATH);
+        assertThat(seg.mode()).isEqualTo(SegmentMode.WALK);
+    }
+
+    @Test
+    void WALK에_lineName_있으면_IAE() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.WALK, 5, 350, null, null,
+                "잘못", null, null, null, null,
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("WALK");
+    }
+
+    @Test
+    void WALK에_from_있으면_IAE() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.WALK, 5, 350, "잘못", null,
+                null, null, null, null, null,
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("WALK");
+    }
+
+    @Test
+    void SUBWAY_정상() {
+        // SUBWAY는 lineName/lineId/stationStart/stationEnd/stationCount 모두 채움
+        RouteSegment seg = new RouteSegment(
+                SegmentMode.SUBWAY, 25, 7500, "우이동역", "성신여대입구역",
+                "우이신설선", "109", "우이동역", "성신여대입구역", 7,
+                VALID_PATH);
+        assertThat(seg.mode()).isEqualTo(SegmentMode.SUBWAY);
+    }
+
+    @Test
+    void SUBWAY에_stationCount_누락이면_IAE() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.SUBWAY, 25, 7500, "A", "B",
+                "1호선", "1", "A", "B", null,  // stationCount null
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("SUBWAY");
+    }
+
+    @Test
+    void SUBWAY에_lineName_누락이면_IAE() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.SUBWAY, 25, 7500, "A", "B",
+                null, "1", "A", "B", 5,  // lineName null
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("SUBWAY");
+    }
+
+    @Test
+    void BUS_정상() {
+        // BUS는 lineName/lineId 채움, stationStart/stationEnd null (from/to와 중복 회피)
+        RouteSegment seg = new RouteSegment(
+                SegmentMode.BUS, 29, 8385, "국민대학교앞", "시청앞.덕수궁",
+                "1711", "908", null, null, 15,
+                VALID_PATH);
+        assertThat(seg.mode()).isEqualTo(SegmentMode.BUS);
+    }
+
+    @Test
+    void BUS에_stationStart_있으면_IAE() {
+        // BUS는 stationStart null이어야 함 (from과 중복 회피, §6.1 매핑표)
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.BUS, 29, 8385, "A", "B",
+                "100", "1", "A", null, 15,  // stationStart 잘못 채움
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("BUS");
+    }
+
+    @Test
+    void BUS에_lineName_누락이면_IAE() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.BUS, 29, 8385, "A", "B",
+                null, "1", null, null, 15,  // lineName null
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("BUS");
+    }
+
+    @Test
+    void mode_null이면_IAE() {
+        assertThatThrownBy(() -> new RouteSegment(
+                null, 5, 350, null, null, null, null, null, null, null,
+                VALID_PATH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mode");
     }
 }

--- a/backend/src/test/java/com/todayway/backend/route/RouteSegmentTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/RouteSegmentTest.java
@@ -1,0 +1,45 @@
+package com.todayway.backend.route;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link RouteSegment} record invariant — path는 polyline 의미상 2점 이상 필수 (명세 §11.5).
+ * <p>v1.1.10에서 mapper에 박혀있던 검증을 record compact ctor로 이동 — caller(mapper/외부)
+ * 무관하게 invariant 보장. WALK/SUBWAY/BUS 모두 동일 적용.
+ */
+class RouteSegmentTest {
+
+    @Test
+    void path_null이면_IllegalArgumentException() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.WALK, 5, 350, "A", "B",
+                null, null, null, null, null,
+                null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("2점 이상");
+    }
+
+    @Test
+    void path가_단일_점이면_IllegalArgumentException() {
+        assertThatThrownBy(() -> new RouteSegment(
+                SegmentMode.BUS, 10, 1000, "A", "B",
+                "100", "1", null, null, 5,
+                List.of(new double[]{127.0, 37.6})))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("2점 이상");
+    }
+
+    @Test
+    void path가_2점이면_정상_생성() {
+        RouteSegment seg = new RouteSegment(
+                SegmentMode.WALK, 5, 350, "A", "B",
+                null, null, null, null, null,
+                List.of(new double[]{127.0, 37.6}, new double[]{127.1, 37.5}));
+        // 정상 — 2점이라 invariant 통과
+        org.assertj.core.api.Assertions.assertThat(seg.path()).hasSize(2);
+    }
+}


### PR DESCRIPTION
## Summary
- transit segment `path` 출처를 `passStopList` 직선 → ODsay `loadLane.lane[i].section[].graphPos[]` 도로 곡선으로 승격 (명세 §6.1 v1.1.10)
- `route_summary_json`을 `{"path": ..., "lane": ...}` wrapped 형식으로 저장 — 캐시 hit 시 두 raw 함께 unwrap → 곡선 그대로 복원 (재호출 불필요)
- ODsay 호출 cache miss 1회당 1회 → 2회 (직렬, mapObj 의존). loadLane 5xx/timeout/형식 위반 / mapObj 누락 / lane size mismatch / 좌표 sanity 위반 / 단일 점은 모두 `passStopList` 직선으로 graceful fallback. 401/403만 운영자 alert로 격상 (`searchPubTransPathT`와 동일)
- `refreshRouteSync`도 401/403 propagate — 일정 등록 시점에 silent false 반환하지 않음 (이전 PR 회귀 보강)
- `RouteSegment` record compact constructor에 `path.size() >= 2` invariant — caller 무관하게 polyline 의미 보장
- 좌표 sanity 분리: `requireFiniteCoord`(ODsay 스펙 invariant) + `requireServiceArea`(한국 bbox 비즈니스 invariant)
- 명세 §6.1 SUBWAY 응답 예시 정합성 정정 (`from`/`to` 추가, `lineId` 형식)

## Test plan
- [x] `OdsayResponseMapperTest` 19건 — loadLane 매핑·fallback 5케이스 + 좌표 sanity + 단일 점 + size mismatch
- [x] `OdsayRouteServiceTest` 22건 — 2회 호출 흐름·wrap/unwrap·401/403 propagate (refresh + getRoute)
- [x] `OdsayClientTest` 9건 — `loadLane` 4분기(정상/empty/401/500)
- [x] `RouteSegmentTest` 3건 — record invariant (null/단일 점 IAE)

## Follow-up (별도 PR)
- 트랜잭�션 wall-clock 5s→10s 영향 — Step 7 \`RouteController\` 시점에 결정 (\`@Transactional\` propagation / loadLane 별도 timeout 등)
- v1.1.10 이전 캐시 자동 마이그레이션 spike — 운영 모니터링 metric/error 로그 격상 (운영 단계 진입 전)
- \`RouteSegment\` mode-specific nullable matrix invariant
- \`Route.transferCount\` 의미 확정 후 매핑 공식 갱신 (PR #11 P2 #3 — 명세팀 답변 대기)