### PR TITLE
feat(backend/route): Step 6 마무리 — RouteController + GET /schedules/{id}/route

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.10-MVP
-> **최종 수정**: 2026-05-04 (이상진 — §6.1 transit path 출처를 ODsay `loadLane` 도로 곡선으로 승격, `route_summary_json` wrapped 형식 도입)
+> **버전**: v1.1.11-MVP
+> **최종 수정**: 2026-05-04 (이상진 — §6.1 응답 예시 WALK `from`/`to` 제거, `RouteSegment` record invariant 정합)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -27,6 +27,7 @@
 | **v1.1.8** | **2026-04-30** | **§5.4 PATCH 검증 정정 — `arrivalTime`의 NOW() 검사는 `arrivalTime`이 요청에 포함된 경우에만 적용. 지난 일정의 `title` 등 메모 편집 허용. (Step 5 PR #10 claude.ai 리뷰 P1 흡수)** |
 | **v1.1.9** | **2026-04-30** | **§6.1 WALK 구간 path 보충 알고리즘 명시 (Step 6 이상진) — ODsay WALK subPath에 좌표 키가 없어 `origin`/`destination`/이전 transit 끝점으로 합성. 매핑표의 `path` 행에 WALK 분기 추가.** |
 | **v1.1.10** | **2026-05-04** | **§6.1 transit path 출처 승격 (이상진) — `passStopList` 정류장 직선 → ODsay `loadLane` 도로 곡선 (`lane[i].section[].graphPos[]`) 정식 사용. `route_summary_json`을 `{"path":..., "lane":...}` wrapped 형식으로 저장 — 캐시 hit 시 재호출 없이 곡선 복원. loadLane 실패는 graceful — `passStopList` 직선 fallback. ODsay 호출 cache miss 1회당 1회 → 2회 (직렬, mapObj 의존).** |
+| **v1.1.11** | **2026-05-04** | **§6.1 응답 예시 WALK `from`/`to` 제거 — `RouteSegment` record invariant + `@JsonInclude(NON_NULL)` 정합 cleanup. 코드 동작 변경 X (record가 WALK에서 reject + Jackson이 null drop).** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -774,8 +775,6 @@ LIMIT ?
           "mode": "WALK",
           "durationMinutes": 5,
           "distanceMeters": 350,
-          "from": "우이동 집",
-          "to": "우이동역",
           "path": [[127.012, 37.661], [127.013, 37.662]]
         },
         {
@@ -795,8 +794,6 @@ LIMIT ?
           "mode": "WALK",
           "durationMinutes": 5,
           "distanceMeters": 350,
-          "from": "성신여대입구역",
-          "to": "국민대학교",
           "path": [[127.015, 37.662], [127.001, 37.610]]
         }
       ]

--- a/backend/src/main/java/com/todayway/backend/route/RouteController.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteController.java
@@ -1,0 +1,45 @@
+package com.todayway.backend.route;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.schedule.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 명세 §6.1 — 일정 경로 조회 (단일).
+ * <p>인증 + 인가 검증은 {@link ScheduleService#getRouteForOwned}가 담당 (단일 트랜잭션 facade).
+ * 본 controller는 HTTP 레이어 변환만 — sch_ prefix strip + ApiResponse 래핑.
+ */
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class RouteController {
+
+    private static final String SCHEDULE_ID_PREFIX = "sch_";
+
+    private final ScheduleService scheduleService;
+
+    @GetMapping("/{scheduleId}/route")
+    public ResponseEntity<ApiResponse<RouteResponse>> getRoute(
+            @CurrentMember String memberUid,
+            @PathVariable String scheduleId,
+            @RequestParam(defaultValue = "false") boolean forceRefresh) {
+        RouteResponse resp = scheduleService.getRouteForOwned(
+                memberUid, stripPrefix(scheduleId), forceRefresh);
+        return ResponseEntity.ok(ApiResponse.of(resp));
+    }
+
+    /** 명세 §1.7 — 외부 노출 ID는 {@code sch_} prefix. 내부 ULID로 변환. */
+    private static String stripPrefix(String scheduleId) {
+        if (scheduleId != null && scheduleId.startsWith(SCHEDULE_ID_PREFIX)) {
+            return scheduleId.substring(SCHEDULE_ID_PREFIX.length());
+        }
+        return scheduleId;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
@@ -6,6 +6,7 @@ import com.todayway.backend.common.pagination.CursorRequest;
 import com.todayway.backend.common.pagination.CursorResponse;
 import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.route.RouteResponse;
 import com.todayway.backend.route.RouteService;
 import com.todayway.backend.schedule.domain.Schedule;
 import com.todayway.backend.schedule.dto.CreateScheduleRequest;
@@ -69,6 +70,23 @@ public class ScheduleService {
         Long memberId = resolveMemberId(memberUid);
         Schedule s = findOwned(memberId, scheduleUid);
         return ScheduleResponse.from(s);
+    }
+
+    /**
+     * 명세 §6.1 — 일정 경로 조회. 소유자 검증 + ODsay 캐시/호출 위임.
+     * <p>{@code @Transactional} (rw) — cache miss 시 {@code RouteService.getRoute}가
+     * {@code Schedule.updateRouteInfo}로 entity 갱신. 같은 트랜잭션 안에서 fetch +
+     * getRoute 호출이라 dirty checking 정상 동작.
+     *
+     * @throws com.todayway.backend.common.exception.BusinessException
+     *         {@code SCHEDULE_NOT_FOUND}(404), {@code FORBIDDEN_RESOURCE}(403),
+     *         {@code EXTERNAL_*}(502/503/504, RouteService에서 매핑)
+     */
+    @Transactional
+    public RouteResponse getRouteForOwned(String memberUid, String scheduleUid, boolean forceRefresh) {
+        Long memberId = resolveMemberId(memberUid);
+        Schedule s = findOwned(memberId, scheduleUid);
+        return routeService.getRoute(s, forceRefresh);
     }
 
     public CursorResponse<ScheduleListItem> list(String memberUid,

--- a/backend/src/test/java/com/todayway/backend/route/RouteControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/RouteControllerIntegrationTest.java
@@ -1,0 +1,261 @@
+package com.todayway.backend.route;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.schedule.domain.Schedule;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §6.1 — {@code GET /schedules/{scheduleId}/route} 통합 테스트.
+ *
+ * <p>{@link RouteService}는 {@code @MockitoBean}으로 대체 — ODsay 실 호출 없이 controller
+ * 계약 분기만 검증 (cache hit/miss 동작 흐름 자체는 {@code OdsayRouteServiceTest} 단위 책임).
+ * 회귀 가드 범위: 인증/인가/sch_ prefix strip / forceRefresh 전파 / 에러 매핑(404/403/401/502/503/504) /
+ * 응답 직렬화(scheduleId·route 6필드·calculatedAt).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class RouteControllerIntegrationTest {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean RouteService routeService;
+
+    @Test
+    void 정상_GET_route_200_응답_RouteResponse_반환() throws Exception {
+        // refresh는 happy path로 stub
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        // getRoute 응답 stub — 실 OdsayRouteService.getRoute의 cache miss + 정상 흐름 시뮬레이션:
+        // applyToSchedule가 schedule.updateRouteInfo로 routeCalculatedAt 갱신해야 RouteResponse.calculatedAt이 non-null.
+        when(routeService.getRoute(any(Schedule.class), eq(false))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            s.updateRouteInfo(34, s.getArrivalTime().minusMinutes(34),
+                    "{\"path\":{},\"lane\":null}", OffsetDateTime.now(KST));
+            return RouteResponse.of(s, fakeRoute(34));
+        });
+
+        String token = signupAndGetToken("routeget01", "조회테스트");
+        String scheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                // 명세 §6.1 응답 예시 — RouteResponse 6필드 + calculatedAt 직렬화 회귀 가드
+                .andExpect(jsonPath("$.data.scheduleId").value(scheduleId))
+                .andExpect(jsonPath("$.data.calculatedAt").exists())
+                .andExpect(jsonPath("$.data.route.totalDurationMinutes").value(34))
+                .andExpect(jsonPath("$.data.route.totalDistanceMeters").value(8704))
+                .andExpect(jsonPath("$.data.route.totalWalkMeters").value(319))
+                .andExpect(jsonPath("$.data.route.transferCount").value(1))
+                .andExpect(jsonPath("$.data.route.payment").value(1500))
+                .andExpect(jsonPath("$.data.route.segments").isArray())
+                .andExpect(jsonPath("$.data.route.segments[0].mode").value("WALK"))
+                .andExpect(jsonPath("$.data.route.segments[0].path").isArray());
+
+        verify(routeService, times(1)).getRoute(any(Schedule.class), eq(false));
+    }
+
+    @Test
+    void forceRefresh_true_쿼리파라미터_RouteService에_전달() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        when(routeService.getRoute(any(Schedule.class), eq(true))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            return RouteResponse.of(s, fakeRoute(34));
+        });
+
+        String token = signupAndGetToken("routeforce01", "강제새로고침");
+        String scheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route?forceRefresh=true")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        verify(routeService, times(1)).getRoute(any(Schedule.class), eq(true));
+    }
+
+    @Test
+    void 존재하지_않는_scheduleId_404_SCHEDULE_NOT_FOUND() throws Exception {
+        String token = signupAndGetToken("routenotfound01", "없는일정");
+
+        mockMvc.perform(get("/api/v1/schedules/sch_01HXXNOEXIST123456789ABCDE/route")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("SCHEDULE_NOT_FOUND"));
+    }
+
+    @Test
+    void 다른_사용자의_일정이면_403_FORBIDDEN_RESOURCE() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        String ownerToken = signupAndGetToken("routeowner01", "소유자");
+        String scheduleId = createSchedule(ownerToken);
+
+        // 다른 사용자가 같은 schedule에 접근
+        String otherToken = signupAndGetToken("routeother01", "다른사용자");
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route")
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN_RESOURCE"));
+    }
+
+    @Test
+    void 인증_없으면_401() throws Exception {
+        mockMvc.perform(get("/api/v1/schedules/sch_01HXX0000000000000000ABCDE/route"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void RouteService가_502_EXTERNAL_ROUTE_API_FAILED_throw하면_502_응답() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        when(routeService.getRoute(any(Schedule.class), any(Boolean.class)))
+                .thenThrow(new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED));
+
+        String token = signupAndGetToken("route502err01", "502테스트");
+        String scheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_ROUTE_API_FAILED"));
+    }
+
+    @Test
+    void RouteService가_504_EXTERNAL_TIMEOUT_throw하면_504_응답() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        when(routeService.getRoute(any(Schedule.class), any(Boolean.class)))
+                .thenThrow(new BusinessException(ErrorCode.EXTERNAL_TIMEOUT));
+
+        String token = signupAndGetToken("route504err01", "504테스트");
+        String scheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isGatewayTimeout())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_TIMEOUT"));
+    }
+
+    @Test
+    void forceRefresh_파라미터_누락시_디폴트_false_RouteService에_전달() throws Exception {
+        // 명세 §6.1 — forceRefresh 미지정 시 디폴트 false. URL에 ?forceRefresh 자체 omit.
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        when(routeService.getRoute(any(Schedule.class), eq(false))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            return RouteResponse.of(s, fakeRoute(34));
+        });
+
+        String token = signupAndGetToken("routedefault01", "디폴트false");
+        String scheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route")  // 쿼리 파라미터 omit
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        verify(routeService, times(1)).getRoute(any(Schedule.class), eq(false));
+    }
+
+    @Test
+    void RouteService가_503_EXTERNAL_AUTH_MISCONFIGURED_throw하면_503_응답() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        when(routeService.getRoute(any(Schedule.class), any(Boolean.class)))
+                .thenThrow(new BusinessException(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED));
+
+        String token = signupAndGetToken("route503err01", "503테스트");
+        String scheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/schedules/" + scheduleId + "/route")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_AUTH_MISCONFIGURED"));
+    }
+
+    // ───── helpers ─────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private String createSchedule(String accessToken) throws Exception {
+        OffsetDateTime arrival = OffsetDateTime.now(KST).plusMinutes(60);
+        OffsetDateTime depart = arrival.minusMinutes(30);
+        String body = """
+                {
+                  "title": "경로조회테스트",
+                  "origin": {"name":"우이동","lat":37.6612,"lng":127.0124},
+                  "destination": {"name":"국민대","lat":37.6103,"lng":126.9969},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s",
+                  "reminderOffsetMinutes": 5
+                }
+                """.formatted(depart, arrival);
+
+        String resp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("scheduleId").asText();
+    }
+
+    private static Route fakeRoute(int totalDurationMinutes) {
+        // RouteSegment record invariant 통과 — WALK 2점 path
+        RouteSegment walk = new RouteSegment(
+                SegmentMode.WALK, totalDurationMinutes, 1000,
+                null, null, null, null, null, null, null,
+                List.of(new double[]{127.0, 37.6}, new double[]{127.1, 37.5})
+        );
+        return new Route(totalDurationMinutes, 8704, 319, 1, 1500, List.of(walk));
+    }
+}


### PR DESCRIPTION
## Summary
- Step 6 §12.4 ODsay 연동 + §6.1 일정 경로 조회 마무리 — `GET /api/v1/schedules/{scheduleId}/route?forceRefresh=` 엔드포인트 추가
- `ScheduleService.getRouteForOwned` facade — `@Transactional(readOnly=false)`로 단일 트랜잭션 안에서 fetch + getRoute 묶어 cache miss 시 dirty checking 보장
- `RouteController` 신규 — `sch_` prefix strip + `@CurrentMember` 인증 + `ApiResponse<RouteResponse>` 래핑 (ScheduleController 패턴 일관)
- 명세 §6.1 응답 예시 WALK `from/to` 제거 — 코드 동작 정합 (RouteSegment invariant가 WALK는 null 강제 + `@JsonInclude(NON_NULL)`이 응답에서 키 제거)

## Test plan
- [x] `RouteControllerIntegrationTest` 9건 — Testcontainers MySQL + MockMvc + `@MockitoBean RouteService`
  - 정상 200 + `scheduleId`/`route` 6필드/`segments`/`calculatedAt` 직렬화 검증
  - `forceRefresh=true` / 디폴트 false 양쪽 `verify(eq(...))`
  - 404 SCHEDULE_NOT_FOUND / 403 FORBIDDEN_RESOURCE / 401 UNAUTHORIZED
  - 502 EXTERNAL_ROUTE_API_FAILED / 503 EXTERNAL_AUTH_MISCONFIGURED / 504 EXTERNAL_TIMEOUT
- [x] 전체 125 tests GREEN, 회귀 0 (Schedule/Member/AuthControllerIntegrationTest 영향 없음)
- [x] Docker daemon 띄워 통합 테스트 로컬 실 검증

## Follow-up (별도 PR)
- T1 트랜잭션 wall-clock 5s→10s 분리 — 데모 후 부하 측정 데이터 확보 후 결정
- `stripPrefix` DRY → `ScheduleIdCodec` value object 추출 (RouteController + ScheduleController 동일 메서드)
- `RouteFacade`/`RouteQueryService` 도메인 경계 회복 (현재 facade가 ScheduleService에 위치)
- `@Version` 낙관적 잠금 — 동시 forceRefresh 가능성 대비
- sch_ prefix 형식 위반 시 400 VALIDATION_ERROR (현재는 404 SCHEDULE_NOT_FOUND로 흡수 — ScheduleController 일관)
- 메모성 javadoc 잔재 정리 (PR 번호 참조 등)