### PR TITLE
feat(backend/map,geocode): Step 8 — 메인/지도 (§4) + 지오코딩 (§8) + 셀프리뷰 16건 fix

### DIFF
--- a/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,19 @@
 package com.todayway.backend.common.exception;
 
 import com.todayway.backend.common.response.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -29,6 +35,39 @@ public class GlobalExceptionHandler {
         ErrorCode code = ErrorCode.VALIDATION_ERROR;
         return ResponseEntity.status(code.getStatus())
                 .body(ErrorResponse.of(code.name(), detail));
+    }
+
+    /**
+     * 다양한 입력 검증 실패를 일괄 400 VALIDATION_ERROR 로 매핑 (명세 §1.6 정합).
+     * <ul>
+     *   <li>{@link HandlerMethodValidationException} — Spring 6.1+ {@code @RequestParam @Min/@Max} 위반.</li>
+     *   <li>{@link ConstraintViolationException} — 레거시 path. {@code Coordinate} compact constructor 의 invalid 좌표 등 도메인 invariant 위반도 흡수.</li>
+     *   <li>{@link IllegalArgumentException} — record/entity 의 invariant 위반 (사용자 입력 가정).</li>
+     *   <li>{@link HttpMessageNotReadableException} — malformed JSON / Content-Type 누락 (issue #16).</li>
+     *   <li>{@link MissingServletRequestParameterException} — 필수 query 누락.</li>
+     *   <li>{@link MethodArgumentTypeMismatchException} — query 타입 불일치 (예: {@code lat=foo}).</li>
+     * </ul>
+     * 이전엔 catch-all 의 500 INTERNAL_SERVER_ERROR 로 떨어져 명세 §1.6 위반 + 운영 모니터링 오염 (가짜 500).
+     */
+    @ExceptionHandler({
+            HandlerMethodValidationException.class,
+            ConstraintViolationException.class,
+            IllegalArgumentException.class,
+            HttpMessageNotReadableException.class,
+            MissingServletRequestParameterException.class,
+            MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception e) {
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/backend/src/main/java/com/todayway/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/todayway/backend/common/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.todayway.backend.common.jwt;
 
+import com.todayway.backend.common.security.PermitAllPaths;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -44,6 +45,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(auth);
         } catch (ExpiredJwtException e) {
             SecurityContextHolder.clearContext();
+            // permitAll endpoint (예: 명세 §4.1 GET /main 게스트 허용) 호출자가 만료 토큰을 보내도
+            // 401 차단하지 않고 게스트 흐름으로 진행 — 명세 §4.1 "게스트 허용 (인증 시 추가 정보)" 정합.
+            // 인증 필요 endpoint 는 종전대로 401 TOKEN_EXPIRED 명시 응답.
+            if (PermitAllPaths.matches(request)) {
+                chain.doFilter(request, response);
+                return;
+            }
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");

--- a/backend/src/main/java/com/todayway/backend/common/security/PermitAllPaths.java
+++ b/backend/src/main/java/com/todayway/backend/common/security/PermitAllPaths.java
@@ -1,0 +1,35 @@
+package com.todayway.backend.common.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Set;
+
+/**
+ * 인증 없이 접근 가능한 endpoint 목록의 단일 source. {@link SecurityConfig} 의 {@code permitAll()}
+ * 등록과 {@link com.todayway.backend.common.jwt.JwtAuthenticationFilter} 의 만료 토큰 graceful 처리
+ * 모두 본 상수를 참조해 drift 차단.
+ *
+ * <p>{@link #PATHS} 는 Spring Security 의 {@code requestMatchers(String...)} 에 그대로 전달.
+ * {@link #matches} 는 filter 가 servlet path 비교용으로 사용. context-path 가 비어있는 가정 하에
+ * {@code getRequestURI()} 로 충분.
+ */
+public final class PermitAllPaths {
+
+    public static final String[] PATHS = {
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/api/v1/auth/logout",
+            "/api/v1/main",
+            "/api/v1/map/config",
+            "/actuator/health"
+    };
+
+    private static final Set<String> PATH_SET = Set.of(PATHS);
+
+    public static boolean matches(HttpServletRequest request) {
+        return PATH_SET.contains(request.getRequestURI());
+    }
+
+    private PermitAllPaths() {
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
@@ -40,14 +40,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/v1/auth/signup",
-                                "/api/v1/auth/login",
-                                "/api/v1/auth/logout",
-                                "/api/v1/main",
-                                "/api/v1/map/config",
-                                "/actuator/health"
-                        ).permitAll()
+                        .requestMatchers(PermitAllPaths.PATHS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMember.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMember.java
@@ -8,4 +8,11 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CurrentMember {
+
+    /**
+     * {@code true} (기본): 미인증 시 {@code UNAUTHORIZED} 401 — 모든 인증 필요 endpoint 의 디폴트.
+     * {@code false}: 미인증 시 {@code null} 주입 — 명세 §4.1 {@code GET /main} 같은
+     * "게스트 허용 (인증 시 추가 정보)" endpoint 전용.
+     */
+    boolean required() default true;
 }

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -12,9 +12,12 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
- * @CurrentMember 가 붙은 String 파라미터에 SecurityContext의 raw memberUid 주입.
- * DB 호출 0회 — Authentication.getName() 만 호출. 멤버 존재 검증은 Service의 findByMemberUid 책임.
+ * {@link CurrentMember} 가 붙은 String 파라미터에 SecurityContext 의 raw memberUid 주입.
+ * DB 호출 0회 — Authentication.getPrincipal() 만 사용. 멤버 존재 검증은 Service 의 findByMemberUid 책임.
  * 명세 §1.7: JWT sub claim = prefix 없는 raw ULID 26자.
+ *
+ * <p>{@code @CurrentMember(required = false)} 인 경우 미인증 시 {@code null} 주입 — 명세 §4.1
+ * {@code GET /main} 게스트 허용 endpoint 전용. 디폴트 ({@code required = true}) 는 미인증 시 401.
  */
 @Component
 public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -31,9 +34,13 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !(auth.getPrincipal() instanceof String memberUid) || memberUid.isBlank()) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        if (auth != null && auth.getPrincipal() instanceof String memberUid && !memberUid.isBlank()) {
+            return memberUid;
         }
-        return memberUid;
+        CurrentMember annotation = parameter.getParameterAnnotation(CurrentMember.class);
+        if (annotation != null && !annotation.required()) {
+            return null;
+        }
+        throw new BusinessException(ErrorCode.UNAUTHORIZED);
     }
 }

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -3,6 +3,7 @@ package com.todayway.backend.common.web;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -34,8 +35,15 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.getPrincipal() instanceof String memberUid && !memberUid.isBlank()) {
-            return memberUid;
+        // Spring Security 의 AnonymousAuthenticationFilter 가 미인증 요청에 principal="anonymousUser"
+        // String 토큰을 박는다. 단순 `instanceof String` 검사만으로는 그 문자열이 valid memberUid
+        // 처럼 통과하므로 AnonymousAuthenticationToken 을 명시적으로 제외해야 게스트 흐름이 발화한다.
+        boolean authenticated = auth != null
+                && !(auth instanceof AnonymousAuthenticationToken)
+                && auth.getPrincipal() instanceof String memberUid
+                && !memberUid.isBlank();
+        if (authenticated) {
+            return ((String) auth.getPrincipal());
         }
         CurrentMember annotation = parameter.getParameterAnnotation(CurrentMember.class);
         if (annotation != null && !annotation.required()) {

--- a/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
@@ -14,9 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 명세 §8.1 — {@code POST /geocode}.
- * <p>인증은 SecurityConfig {@code anyRequest().authenticated()} 로 강제 — endpoint 가 permitAll 에
- * 등록되지 않았으므로 토큰 없으면 자동 401. {@link GeocodeService#geocode} 자체는 회원 데이터를 다루지
- * 않아 {@code @CurrentMember} 주입은 불필요 (인증 게이트만 통과하면 cache + 외부 호출만 수행).
+ * <p>{@link GeocodeService#geocode} 가 회원 데이터를 다루지 않아 {@code @CurrentMember} 주입 불필요 —
+ * 인증 게이트만 통과하면 cache + 외부 호출만 수행. 인증 미통과 401 회귀 가드는 통합 테스트가 담당.
  */
 @RestController
 @RequestMapping("/api/v1/geocode")

--- a/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
@@ -1,0 +1,33 @@
+package com.todayway.backend.geocode.controller;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.geocode.dto.GeocodeRequest;
+import com.todayway.backend.geocode.dto.GeocodeResponse;
+import com.todayway.backend.geocode.service.GeocodeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 명세 §8.1 — {@code POST /geocode}.
+ * <p>인증은 SecurityConfig {@code anyRequest().authenticated()} 로 강제 — endpoint 가 permitAll 에
+ * 등록되지 않았으므로 토큰 없으면 자동 401. {@link GeocodeService#geocode} 자체는 회원 데이터를 다루지
+ * 않아 {@code @CurrentMember} 주입은 불필요 (인증 게이트만 통과하면 cache + 외부 호출만 수행).
+ */
+@RestController
+@RequestMapping("/api/v1/geocode")
+@RequiredArgsConstructor
+public class GeocodeController {
+
+    private final GeocodeService geocodeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<GeocodeResponse>> geocode(
+            @Valid @RequestBody GeocodeRequest request) {
+        return ResponseEntity.ok(ApiResponse.of(geocodeService.geocode(request)));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
@@ -87,11 +87,11 @@ public class GeocodeCache {
         this.placeId = placeId;
     }
 
-    /** 매칭된 결과 캐시 신규 생성. */
+    /** 매칭된 결과 캐시 신규 생성. {@link MatchedFields} 로 9-positional-arg 의 swap 위험 차단. */
     public static GeocodeCache match(String queryHash, String queryText, GeocodeCacheProvider provider,
-                                     String name, String address,
-                                     BigDecimal lat, BigDecimal lng, String placeId) {
-        return new GeocodeCache(queryHash, queryText, provider, true, name, address, lat, lng, placeId);
+                                     MatchedFields fields) {
+        return new GeocodeCache(queryHash, queryText, provider, true,
+                fields.name(), fields.address(), fields.lat(), fields.lng(), fields.placeId());
     }
 
     /** Kakao documents 빈 배열 응답을 캐시 (반복 미스 query 의 외부 API 호출 차단). */
@@ -107,15 +107,14 @@ public class GeocodeCache {
     }
 
     /** TTL 만료 후 재조회 결과로 row 갱신. {@code cachedAt} 도 NOW 로 reset. */
-    public void refreshAsMatch(String queryText, String name, String address,
-                               BigDecimal lat, BigDecimal lng, String placeId) {
+    public void refreshAsMatch(String queryText, MatchedFields fields) {
         this.queryText = queryText;
         this.matched = true;
-        this.name = name;
-        this.address = address;
-        this.lat = lat;
-        this.lng = lng;
-        this.placeId = placeId;
+        this.name = fields.name();
+        this.address = fields.address();
+        this.lat = fields.lat();
+        this.lng = fields.lng();
+        this.placeId = fields.placeId();
         this.cachedAt = OffsetDateTime.now(KST);
     }
 

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
@@ -1,0 +1,132 @@
+package com.todayway.backend.geocode.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+/**
+ * 명세 §8.1 — Kakao/NAVER Geocoding 결과 캐시 (TTL 30일). V1__init.sql {@code geocode_cache} 정합.
+ *
+ * <p>row identity = {@code (query_hash, provider)} UNIQUE. 동일 쿼리·동일 provider 결과는 단일 row 로
+ * 보존되며, TTL 만료 후 재호출 시 {@link #refresh} 로 갱신 (UPSERT 시 unique 위반 catch + retry 로
+ * race-safe).
+ *
+ * <p>matched=false (Kakao documents 빈 배열) 도 캐시 — 같은 미스 query 의 반복 호출이 외부 API
+ * quota 를 소모하지 않게 한다. 서비스 흐름은 {@link #isMatched} 가 false 면 404 GEOCODE_NO_MATCH.
+ *
+ * <p>BaseEntity 미상속 ({@code updated_at} 컬럼 없음) — append + refresh 외 상태 없음.
+ */
+@Getter
+@Entity
+@Table(name = "geocode_cache")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GeocodeCache {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "query_hash", nullable = false, updatable = false, columnDefinition = "CHAR(64)")
+    private String queryHash;
+
+    @Column(name = "query_text", nullable = false, length = 255)
+    private String queryText;
+
+    @Column(name = "matched", nullable = false)
+    private boolean matched;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "address", length = 255)
+    private String address;
+
+    @Column(name = "lat", precision = 10, scale = 7)
+    private BigDecimal lat;
+
+    @Column(name = "lng", precision = 10, scale = 7)
+    private BigDecimal lng;
+
+    @Column(name = "place_id", length = 100)
+    private String placeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, updatable = false,
+            columnDefinition = "ENUM('NAVER','KAKAO_LOCAL')")
+    private GeocodeCacheProvider provider;
+
+    @Column(name = "cached_at", nullable = false)
+    private OffsetDateTime cachedAt;
+
+    private GeocodeCache(String queryHash, String queryText, GeocodeCacheProvider provider,
+                         boolean matched, String name, String address,
+                         BigDecimal lat, BigDecimal lng, String placeId) {
+        this.queryHash = queryHash;
+        this.queryText = queryText;
+        this.provider = provider;
+        this.matched = matched;
+        this.name = name;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.placeId = placeId;
+    }
+
+    /** 매칭된 결과 캐시 신규 생성. */
+    public static GeocodeCache match(String queryHash, String queryText, GeocodeCacheProvider provider,
+                                     String name, String address,
+                                     BigDecimal lat, BigDecimal lng, String placeId) {
+        return new GeocodeCache(queryHash, queryText, provider, true, name, address, lat, lng, placeId);
+    }
+
+    /** Kakao documents 빈 배열 응답을 캐시 (반복 미스 query 의 외부 API 호출 차단). */
+    public static GeocodeCache miss(String queryHash, String queryText, GeocodeCacheProvider provider) {
+        return new GeocodeCache(queryHash, queryText, provider, false, null, null, null, null, null);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (cachedAt == null) {
+            cachedAt = OffsetDateTime.now(KST);
+        }
+    }
+
+    /** TTL 만료 후 재조회 결과로 row 갱신. {@code cachedAt} 도 NOW 로 reset. */
+    public void refreshAsMatch(String queryText, String name, String address,
+                               BigDecimal lat, BigDecimal lng, String placeId) {
+        this.queryText = queryText;
+        this.matched = true;
+        this.name = name;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.placeId = placeId;
+        this.cachedAt = OffsetDateTime.now(KST);
+    }
+
+    public void refreshAsMiss(String queryText) {
+        this.queryText = queryText;
+        this.matched = false;
+        this.name = null;
+        this.address = null;
+        this.lat = null;
+        this.lng = null;
+        this.placeId = null;
+        this.cachedAt = OffsetDateTime.now(KST);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
@@ -3,12 +3,13 @@ package com.todayway.backend.geocode.domain;
 /**
  * V1__init.sql {@code geocode_cache.provider} ENUM. 명세 §8.1 / §11.1 정합.
  *
- * <p>{@link #KAKAO_LOCAL} — Kakao Local API 응답을 그대로 캐시 (현 MVP 사용).
- * <p>{@link #NAVER} — NAVER Geocoding 도입 시 (P1 예정).
+ * <p>{@link #KAKAO_LOCAL} — Kakao Local API 응답을 그대로 캐시 (MVP 사용).
+ * <p>{@link #NAVER} — V1__init.sql ENUM 정합. NAVER Geocoding 도입 시 활성화.
  *
  * <p>주의: 명세 §11.1 {@code Place.provider} 는 도메인 추상화 ENUM
  * ({@code NAVER/KAKAO/ODSAY/MANUAL}) 이고, schedule 저장 시 {@code KAKAO_LOCAL → KAKAO} 변환
- * 필요 (명세 §8.1 v1.1.4 변환표). 본 enum 은 캐시 키 구분용으로만 사용.
+ * 필요 (명세 §8.1 v1.1.4 변환표). 본 enum 은 캐시 키 구분용으로만 사용. 변환 책임은 frontend
+ * (geocode 응답을 schedule 등록 payload 로 round-trip 시 KAKAO 로 매핑).
  */
 public enum GeocodeCacheProvider {
     NAVER,

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
@@ -1,0 +1,16 @@
+package com.todayway.backend.geocode.domain;
+
+/**
+ * V1__init.sql {@code geocode_cache.provider} ENUM. 명세 §8.1 / §11.1 정합.
+ *
+ * <p>{@link #KAKAO_LOCAL} — Kakao Local API 응답을 그대로 캐시 (현 MVP 사용).
+ * <p>{@link #NAVER} — NAVER Geocoding 도입 시 (P1 예정).
+ *
+ * <p>주의: 명세 §11.1 {@code Place.provider} 는 도메인 추상화 ENUM
+ * ({@code NAVER/KAKAO/ODSAY/MANUAL}) 이고, schedule 저장 시 {@code KAKAO_LOCAL → KAKAO} 변환
+ * 필요 (명세 §8.1 v1.1.4 변환표). 본 enum 은 캐시 키 구분용으로만 사용.
+ */
+public enum GeocodeCacheProvider {
+    NAVER,
+    KAKAO_LOCAL
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/MatchedFields.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/MatchedFields.java
@@ -1,0 +1,13 @@
+package com.todayway.backend.geocode.domain;
+
+import java.math.BigDecimal;
+
+/**
+ * 명세 §8.1 — 매칭된 지오코딩 결과의 도메인 표현. {@code GeocodeCache} factory / refresh 인자 +
+ * {@link com.todayway.backend.geocode.service.KakaoLocalToGeocodeMapper} 의 변환 결과 가 모두 본
+ * record 를 사용해 9-positional-arg 의 silent argument-swap 위험 (lat/lng 또는 name/address) 차단.
+ *
+ * <p>{@code lat/lng} 는 {@code BigDecimal} — DB DECIMAL(10,7) 정밀도 보존.
+ */
+public record MatchedFields(String name, String address, BigDecimal lat, BigDecimal lng, String placeId) {
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeRequest.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeRequest.java
@@ -1,0 +1,17 @@
+package com.todayway.backend.geocode.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 명세 §8.1 — {@code POST /geocode} 요청. {@code query} 는 주소 또는 장소명.
+ *
+ * <p>{@code @Size(max=255)} 는 V1__init.sql {@code geocode_cache.query_text VARCHAR(255)} 와 동기 —
+ * SQL truncation 500 회피용 1차 가드.
+ */
+public record GeocodeRequest(
+        @NotBlank
+        @Size(max = 255)
+        String query
+) {
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeResponse.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeResponse.java
@@ -1,0 +1,36 @@
+package com.todayway.backend.geocode.dto;
+
+import com.todayway.backend.geocode.domain.GeocodeCache;
+
+/**
+ * 명세 §8.1 — {@code POST /geocode} 응답.
+ *
+ * <p>service 흐름상 미스(documents 빈 배열) 는 404 GEOCODE_NO_MATCH 로 던지므로 본 record 는
+ * 항상 매치된 결과 ({@code matched=true}) 만 표현. {@code matched} 필드 자체는 명세 §8.1 응답 예시에
+ * 박혀있으니 그대로 노출.
+ *
+ * <p>{@code provider} 는 명세 §8.1 v1.1.4 변환표대로 {@code "KAKAO_LOCAL"} 그대로 노출 — schedule
+ * 저장 시점에 {@code "KAKAO"} 로 변환하는 책임은 schedule 도메인 (frontend 또는 ScheduleService).
+ */
+public record GeocodeResponse(
+        boolean matched,
+        String name,
+        String address,
+        double lat,
+        double lng,
+        String placeId,
+        String provider
+) {
+
+    public static GeocodeResponse from(GeocodeCache c) {
+        return new GeocodeResponse(
+                c.isMatched(),
+                c.getName(),
+                c.getAddress(),
+                c.getLat() != null ? c.getLat().doubleValue() : 0.0,
+                c.getLng() != null ? c.getLng().doubleValue() : 0.0,
+                c.getPlaceId(),
+                c.getProvider().name()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/repository/GeocodeCacheRepository.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/repository/GeocodeCacheRepository.java
@@ -1,0 +1,24 @@
+package com.todayway.backend.geocode.repository;
+
+import com.todayway.backend.geocode.domain.GeocodeCache;
+import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface GeocodeCacheRepository extends JpaRepository<GeocodeCache, Long> {
+
+    /**
+     * 명세 §8.1 — TTL filter (cached_at > NOW - 30 days) 적용한 cache hit 조회.
+     * UNIQUE (query_hash, provider) 라 단일 row.
+     */
+    Optional<GeocodeCache> findByQueryHashAndProviderAndCachedAtAfter(
+            String queryHash, GeocodeCacheProvider provider, OffsetDateTime cutoff);
+
+    /**
+     * UPSERT race / TTL refresh 흐름에서 만료된 row 까지 fetch (cached_at 무관).
+     * 도메인 흐름: 1차로 위 TTL 쿼리로 hit 확인, miss 시 외부 호출 후 refresh 가 필요하면 본 메서드 사용.
+     */
+    Optional<GeocodeCache> findByQueryHashAndProvider(String queryHash, GeocodeCacheProvider provider);
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
@@ -2,6 +2,7 @@ package com.todayway.backend.geocode.service;
 
 import com.todayway.backend.geocode.domain.GeocodeCache;
 import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.domain.MatchedFields;
 import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -32,15 +33,13 @@ public class GeocodeCacheUpserter {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public GeocodeCache upsertMatch(String queryHash, String queryText, GeocodeCacheProvider provider,
-                                    KakaoLocalToGeocodeMapper.MatchedFields m) {
+                                    MatchedFields fields) {
         Optional<GeocodeCache> existing = repository.findByQueryHashAndProvider(queryHash, provider);
         if (existing.isPresent()) {
-            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            existing.get().refreshAsMatch(queryText, fields);
             return existing.get();
         }
-        return repository.saveAndFlush(GeocodeCache.match(
-                queryHash, queryText, provider,
-                m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+        return repository.saveAndFlush(GeocodeCache.match(queryHash, queryText, provider, fields));
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
@@ -1,0 +1,55 @@
+package com.todayway.backend.geocode.service;
+
+import com.todayway.backend.geocode.domain.GeocodeCache;
+import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 명세 §8.1 cache UPSERT 의 race-safe 처리. 외부({@link GeocodeService})의 transaction 과 분리된
+ * {@code REQUIRES_NEW} 트랜잭션 안에서 INSERT/UPDATE 를 수행한다.
+ *
+ * <p>왜 별도 service?
+ * {@code saveAndFlush} 후 {@link DataIntegrityViolationException} 이 발생하면 Hibernate 는 현재
+ * session 의 트랜잭션을 rollback-only 로 표시한다. 같은 트랜잭션 안에서 catch 후 entity 를 dirty-
+ * mutate 하면 commit 시점에 {@link org.springframework.transaction.UnexpectedRollbackException}
+ * 으로 떨어져 race window 가 silent 500 으로 변한다. 별도 {@code REQUIRES_NEW} 메서드로 분리하면
+ * 충돌이 inner tx 안에서 끝나고 outer tx 는 영향받지 않는다.
+ *
+ * <p>{@code DataIntegrityViolationException} 은 그대로 outer 로 propagate — outer 가 1회 retry.
+ */
+@Service
+@RequiredArgsConstructor
+public class GeocodeCacheUpserter {
+
+    private final GeocodeCacheRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GeocodeCache upsertMatch(String queryHash, String queryText, GeocodeCacheProvider provider,
+                                    KakaoLocalToGeocodeMapper.MatchedFields m) {
+        Optional<GeocodeCache> existing = repository.findByQueryHashAndProvider(queryHash, provider);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            return existing.get();
+        }
+        return repository.saveAndFlush(GeocodeCache.match(
+                queryHash, queryText, provider,
+                m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GeocodeCache upsertMiss(String queryHash, String queryText, GeocodeCacheProvider provider) {
+        Optional<GeocodeCache> existing = repository.findByQueryHashAndProvider(queryHash, provider);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMiss(queryText);
+            return existing.get();
+        }
+        return repository.saveAndFlush(GeocodeCache.miss(queryHash, queryText, provider));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -85,8 +85,17 @@ public class GeocodeService {
             throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
         }
 
-        KakaoLocalToGeocodeMapper.MatchedFields m =
-                KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
+        KakaoLocalToGeocodeMapper.MatchedFields m;
+        try {
+            m = KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
+        } catch (NumberFormatException | NullPointerException e) {
+            // Kakao 가 x/y 를 빈 문자열/null/non-numeric 으로 반환 — 명세 §8.1 "외부 API 응답 이상"
+            // 분류로 502 매핑 (catch-all 500 으로 떨어지지 않게). miss 캐시는 안 함 — 일시적
+            // Kakao 응답 손상 가능성이라 다음 호출에서 정상 응답을 받을 기회 보존.
+            log.warn("Kakao Local 응답 매핑 실패 — x/y 비정상 query={}, cause={}",
+                    trimmed, e.getClass().getSimpleName(), e);
+            throw new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
+        }
         GeocodeCache saved = upsertMatch(hash, trimmed, m);
         return GeocodeResponse.from(saved);
     }

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -27,19 +27,13 @@ import java.util.Optional;
 /**
  * 명세 §8.1 — 주소/장소 지오코딩. Kakao Local 외부 호출 + {@code geocode_cache} TTL 30일.
  *
- * <p>흐름:
- * <ol>
- *   <li>{@code queryHash = SHA-256(query.trim())} — 명세 §8.1 v1.1.4 정규화 룰.</li>
- *   <li>TTL filter cache lookup (cached_at &gt; NOW - 30일). hit 면 즉시 응답.</li>
- *   <li>matched=false 캐시 hit → 404 GEOCODE_NO_MATCH (외부 API 호출 차단).</li>
- *   <li>miss → Kakao Local 호출. {@link ExternalApiException} 은 명세 §8.1 매핑표대로
- *       {@link BusinessException} 으로 변환 (401/403 → 503, timeout → 504, 그 외 → 502).</li>
- *   <li>documents 빈 배열 → miss row UPSERT + 404.</li>
- *   <li>매치 → match row UPSERT + 응답.</li>
- * </ol>
- *
- * <p>UPSERT race-safe: existing row 있으면 refresh, 없으면 save. {@link DataIntegrityViolationException}
- * (unique (query_hash, provider) 동시 INSERT 충돌) 은 catch 후 재조회 + refresh.
+ * <p>핵심 invariant:
+ * <ul>
+ *   <li>cache TTL filter — 명세 §8.1 30일. miss 캐시도 hit 처리해 외부 API quota 보호.</li>
+ *   <li>외부 호출 실패 → 명세 §8.1 매핑표 (401/403=503, 5xx=502, timeout=504).</li>
+ *   <li>UPSERT race 는 {@link GeocodeCacheUpserter} 의 {@code REQUIRES_NEW} 트랜잭션이 격리 처리 —
+ *       outer 의 read-only tx 가 inner 의 rollback-only 영향을 받지 않게 한다.</li>
+ * </ul>
  */
 @Service
 @RequiredArgsConstructor
@@ -52,17 +46,9 @@ public class GeocodeService {
     private static final int CACHE_TTL_DAYS = 30;
 
     private final GeocodeCacheRepository cacheRepository;
+    private final GeocodeCacheUpserter cacheUpserter;
     private final KakaoLocalClient kakaoLocalClient;
 
-    /**
-     * {@code noRollbackFor = BusinessException.class} — 의도된 응답 흐름(404 GEOCODE_NO_MATCH /
-     * 502/503/504 외부 API 매핑) 에서도 cache INSERT/refresh 부수효과를 보존하기 위함.
-     * miss 캐시는 명세 §8.1 의 의도 (반복 미스 query 의 외부 API 호출 차단). default rollback 이면
-     * GEOCODE_NO_MATCH 던지는 순간 miss row 가 함께 롤백되어 다음 호출 때 또 Kakao 를 부른다.
-     * 진짜 inconsistency 는 BusinessException 외 RuntimeException (DataAccessException 등) 으로 던져
-     * 자동 롤백.
-     */
-    @Transactional(noRollbackFor = BusinessException.class)
     public GeocodeResponse geocode(GeocodeRequest req) {
         String trimmed = req.query().trim();
         String hash = sha256Hex(trimmed);
@@ -81,7 +67,7 @@ public class GeocodeService {
         KakaoLocalSearchResponse raw = callKakao(trimmed);
 
         if (raw.documents() == null || raw.documents().isEmpty()) {
-            upsertMiss(hash, trimmed);
+            upsertWithRetry(() -> cacheUpserter.upsertMiss(hash, trimmed, PROVIDER), hash);
             throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
         }
 
@@ -90,13 +76,13 @@ public class GeocodeService {
             m = KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
         } catch (NumberFormatException | NullPointerException e) {
             // Kakao 가 x/y 를 빈 문자열/null/non-numeric 으로 반환 — 명세 §8.1 "외부 API 응답 이상"
-            // 분류로 502 매핑 (catch-all 500 으로 떨어지지 않게). miss 캐시는 안 함 — 일시적
-            // Kakao 응답 손상 가능성이라 다음 호출에서 정상 응답을 받을 기회 보존.
+            // 분류로 502 매핑 (catch-all 500 으로 떨어지지 않게).
             log.warn("Kakao Local 응답 매핑 실패 — x/y 비정상 query={}, cause={}",
                     trimmed, e.getClass().getSimpleName(), e);
             throw new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
         }
-        GeocodeCache saved = upsertMatch(hash, trimmed, m);
+        GeocodeCache saved = upsertWithRetry(
+                () -> cacheUpserter.upsertMatch(hash, trimmed, PROVIDER, m), hash);
         return GeocodeResponse.from(saved);
     }
 
@@ -115,43 +101,22 @@ public class GeocodeService {
         }
     }
 
-    private GeocodeCache upsertMatch(String hash, String queryText, KakaoLocalToGeocodeMapper.MatchedFields m) {
-        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
-        if (existing.isPresent()) {
-            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
-            return existing.get();
-        }
+    /**
+     * inner upserter 의 race 충돌은 1회 retry — race window 내 다른 호출이 먼저 INSERT 했다면
+     * findByQueryHashAndProvider 가 즉시 hit 한다. 두 번째 시도도 fail 이면 데이터 불일치 — 500.
+     */
+    private GeocodeCache upsertWithRetry(java.util.function.Supplier<GeocodeCache> action, String hash) {
         try {
-            return cacheRepository.saveAndFlush(
-                    GeocodeCache.match(hash, queryText, PROVIDER,
-                            m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+            return action.get();
         } catch (DataIntegrityViolationException e) {
-            // race: 동시 INSERT 충돌 — 재조회 후 refresh.
-            log.info("Geocode UPSERT match race — retrying via findByQueryHashAndProvider, cause={}",
-                    e.getMostSpecificCause().getClass().getSimpleName());
-            GeocodeCache row = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
-                    .orElseThrow(() -> {
-                        log.error("Geocode UPSERT inconsistency — DataIntegrityViolation but row not found", e);
-                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-                    });
-            row.refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
-            return row;
-        }
-    }
-
-    private void upsertMiss(String hash, String queryText) {
-        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
-        if (existing.isPresent()) {
-            existing.get().refreshAsMiss(queryText);
-            return;
-        }
-        try {
-            cacheRepository.saveAndFlush(GeocodeCache.miss(hash, queryText, PROVIDER));
-        } catch (DataIntegrityViolationException e) {
-            log.info("Geocode UPSERT miss race — retrying via findByQueryHashAndProvider, cause={}",
-                    e.getMostSpecificCause().getClass().getSimpleName());
-            cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
-                    .ifPresent(c -> c.refreshAsMiss(queryText));
+            log.info("Geocode UPSERT race detected — single retry, hash={}, cause={}",
+                    hash, e.getMostSpecificCause().getClass().getSimpleName());
+            try {
+                return action.get();
+            } catch (DataIntegrityViolationException retryEx) {
+                log.error("Geocode UPSERT inconsistency after retry — hash={}", hash, retryEx);
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         }
     }
 
@@ -162,7 +127,6 @@ public class GeocodeService {
                     .digest(input.getBytes(StandardCharsets.UTF_8));
             return HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
-            // SHA-256 은 JDK 표준 — 발생 불가. 발생 시 fail-fast.
             throw new IllegalStateException("SHA-256 not available", e);
         }
     }
@@ -176,7 +140,7 @@ public class GeocodeService {
         return status != null && (status == 401 || status == 403);
     }
 
-    /** 명세 §8.1 매핑표 — ExternalApiException → BusinessException. OdsayRouteService 패턴 미러. */
+    /** 명세 §8.1 매핑표 — ExternalApiException → BusinessException. {@link com.todayway.backend.route.OdsayRouteService} 패턴 미러. */
     private static BusinessException mapToBusinessException(ExternalApiException e) {
         if (isAuthError(e)) {
             return new BusinessException(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -54,7 +54,15 @@ public class GeocodeService {
     private final GeocodeCacheRepository cacheRepository;
     private final KakaoLocalClient kakaoLocalClient;
 
-    @Transactional
+    /**
+     * {@code noRollbackFor = BusinessException.class} — 의도된 응답 흐름(404 GEOCODE_NO_MATCH /
+     * 502/503/504 외부 API 매핑) 에서도 cache INSERT/refresh 부수효과를 보존하기 위함.
+     * miss 캐시는 명세 §8.1 의 의도 (반복 미스 query 의 외부 API 호출 차단). default rollback 이면
+     * GEOCODE_NO_MATCH 던지는 순간 miss row 가 함께 롤백되어 다음 호출 때 또 Kakao 를 부른다.
+     * 진짜 inconsistency 는 BusinessException 외 RuntimeException (DataAccessException 등) 으로 던져
+     * 자동 롤백.
+     */
+    @Transactional(noRollbackFor = BusinessException.class)
     public GeocodeResponse geocode(GeocodeRequest req) {
         String trimmed = req.query().trim();
         String hash = sha256Hex(trimmed);

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -7,6 +7,7 @@ import com.todayway.backend.external.kakao.KakaoLocalClient;
 import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
 import com.todayway.backend.geocode.domain.GeocodeCache;
 import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.domain.MatchedFields;
 import com.todayway.backend.geocode.dto.GeocodeRequest;
 import com.todayway.backend.geocode.dto.GeocodeResponse;
 import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
@@ -71,7 +72,7 @@ public class GeocodeService {
             throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
         }
 
-        KakaoLocalToGeocodeMapper.MatchedFields m;
+        MatchedFields m;
         try {
             m = KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
         } catch (NumberFormatException | NullPointerException e) {

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -1,0 +1,173 @@
+package com.todayway.backend.geocode.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.kakao.KakaoLocalClient;
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import com.todayway.backend.geocode.domain.GeocodeCache;
+import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.dto.GeocodeRequest;
+import com.todayway.backend.geocode.dto.GeocodeResponse;
+import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * 명세 §8.1 — 주소/장소 지오코딩. Kakao Local 외부 호출 + {@code geocode_cache} TTL 30일.
+ *
+ * <p>흐름:
+ * <ol>
+ *   <li>{@code queryHash = SHA-256(query.trim())} — 명세 §8.1 v1.1.4 정규화 룰.</li>
+ *   <li>TTL filter cache lookup (cached_at &gt; NOW - 30일). hit 면 즉시 응답.</li>
+ *   <li>matched=false 캐시 hit → 404 GEOCODE_NO_MATCH (외부 API 호출 차단).</li>
+ *   <li>miss → Kakao Local 호출. {@link ExternalApiException} 은 명세 §8.1 매핑표대로
+ *       {@link BusinessException} 으로 변환 (401/403 → 503, timeout → 504, 그 외 → 502).</li>
+ *   <li>documents 빈 배열 → miss row UPSERT + 404.</li>
+ *   <li>매치 → match row UPSERT + 응답.</li>
+ * </ol>
+ *
+ * <p>UPSERT race-safe: existing row 있으면 refresh, 없으면 save. {@link DataIntegrityViolationException}
+ * (unique (query_hash, provider) 동시 INSERT 충돌) 은 catch 후 재조회 + refresh.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class GeocodeService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final GeocodeCacheProvider PROVIDER = GeocodeCacheProvider.KAKAO_LOCAL;
+    private static final int CACHE_TTL_DAYS = 30;
+
+    private final GeocodeCacheRepository cacheRepository;
+    private final KakaoLocalClient kakaoLocalClient;
+
+    @Transactional
+    public GeocodeResponse geocode(GeocodeRequest req) {
+        String trimmed = req.query().trim();
+        String hash = sha256Hex(trimmed);
+        OffsetDateTime cutoff = OffsetDateTime.now(KST).minusDays(CACHE_TTL_DAYS);
+
+        Optional<GeocodeCache> fresh = cacheRepository
+                .findByQueryHashAndProviderAndCachedAtAfter(hash, PROVIDER, cutoff);
+        if (fresh.isPresent()) {
+            GeocodeCache c = fresh.get();
+            if (!c.isMatched()) {
+                throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
+            }
+            return GeocodeResponse.from(c);
+        }
+
+        KakaoLocalSearchResponse raw = callKakao(trimmed);
+
+        if (raw.documents() == null || raw.documents().isEmpty()) {
+            upsertMiss(hash, trimmed);
+            throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
+        }
+
+        KakaoLocalToGeocodeMapper.MatchedFields m =
+                KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
+        GeocodeCache saved = upsertMatch(hash, trimmed, m);
+        return GeocodeResponse.from(saved);
+    }
+
+    private KakaoLocalSearchResponse callKakao(String query) {
+        try {
+            return kakaoLocalClient.searchKeyword(query);
+        } catch (ExternalApiException e) {
+            if (isAuthError(e)) {
+                log.error("Kakao Local 401/403 (auth 미설정/만료, 운영자 alert) httpStatus={}",
+                        e.getHttpStatus(), e);
+            } else {
+                log.warn("Kakao Local 호출 실패 type={} httpStatus={}",
+                        e.getType(), e.getHttpStatus(), e);
+            }
+            throw mapToBusinessException(e);
+        }
+    }
+
+    private GeocodeCache upsertMatch(String hash, String queryText, KakaoLocalToGeocodeMapper.MatchedFields m) {
+        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            return existing.get();
+        }
+        try {
+            return cacheRepository.saveAndFlush(
+                    GeocodeCache.match(hash, queryText, PROVIDER,
+                            m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+        } catch (DataIntegrityViolationException e) {
+            // race: 동시 INSERT 충돌 — 재조회 후 refresh.
+            log.info("Geocode UPSERT match race — retrying via findByQueryHashAndProvider, cause={}",
+                    e.getMostSpecificCause().getClass().getSimpleName());
+            GeocodeCache row = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
+                    .orElseThrow(() -> {
+                        log.error("Geocode UPSERT inconsistency — DataIntegrityViolation but row not found", e);
+                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+                    });
+            row.refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            return row;
+        }
+    }
+
+    private void upsertMiss(String hash, String queryText) {
+        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMiss(queryText);
+            return;
+        }
+        try {
+            cacheRepository.saveAndFlush(GeocodeCache.miss(hash, queryText, PROVIDER));
+        } catch (DataIntegrityViolationException e) {
+            log.info("Geocode UPSERT miss race — retrying via findByQueryHashAndProvider, cause={}",
+                    e.getMostSpecificCause().getClass().getSimpleName());
+            cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
+                    .ifPresent(c -> c.refreshAsMiss(queryText));
+        }
+    }
+
+    /** 명세 §8.1 v1.1.4 — query_hash = SHA-256(query.trim()). hex 64자 (CHAR(64) 정합). */
+    private static String sha256Hex(String input) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 은 JDK 표준 — 발생 불가. 발생 시 fail-fast.
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    /** 401/403 — Kakao API 키 미설정/만료. 운영자 alert. */
+    private static boolean isAuthError(ExternalApiException e) {
+        if (e.getType() != ExternalApiException.Type.CLIENT_ERROR) {
+            return false;
+        }
+        Integer status = e.getHttpStatus();
+        return status != null && (status == 401 || status == 403);
+    }
+
+    /** 명세 §8.1 매핑표 — ExternalApiException → BusinessException. OdsayRouteService 패턴 미러. */
+    private static BusinessException mapToBusinessException(ExternalApiException e) {
+        if (isAuthError(e)) {
+            return new BusinessException(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+        }
+        return switch (e.getType()) {
+            case TIMEOUT -> new BusinessException(ErrorCode.EXTERNAL_TIMEOUT);
+            case CLIENT_ERROR, SERVER_ERROR, NETWORK ->
+                    new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
+        };
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.geocode.service;
+
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+
+import java.math.BigDecimal;
+
+/**
+ * 명세 §8.1 v1.1.4 — Kakao Local 응답 → 캐시 entity / 명세 응답 필드 변환 규칙.
+ *
+ * <p>매핑표:
+ * <ul>
+ *   <li>{@code name} ← {@code documents[0].place_name}</li>
+ *   <li>{@code address} ← {@code documents[0].road_address_name} (빈값이면 {@code address_name} fallback)</li>
+ *   <li>{@code lat} ← {@code Double.parseDouble(documents[0].y)} (Kakao 는 string 반환)</li>
+ *   <li>{@code lng} ← {@code Double.parseDouble(documents[0].x)}</li>
+ *   <li>{@code placeId} ← {@code documents[0].id}</li>
+ * </ul>
+ *
+ * <p>{@code matched} / {@code provider} / cache 라이프사이클 결정은 caller 책임 (GeocodeService).
+ */
+final class KakaoLocalToGeocodeMapper {
+
+    private KakaoLocalToGeocodeMapper() {
+    }
+
+    /**
+     * Kakao document → 캐시 INSERT/refresh 에 필요한 매칭 결과 record. lat/lng 는 {@code BigDecimal}
+     * (DB DECIMAL(10,7) 정밀도 보존).
+     */
+    static MatchedFields toMatchedFields(KakaoLocalSearchResponse.Document doc) {
+        return new MatchedFields(
+                doc.placeName(),
+                preferRoadAddress(doc),
+                new BigDecimal(doc.y()),
+                new BigDecimal(doc.x()),
+                doc.id()
+        );
+    }
+
+    private static String preferRoadAddress(KakaoLocalSearchResponse.Document doc) {
+        String road = doc.roadAddressName();
+        if (road != null && !road.isBlank()) {
+            return road;
+        }
+        return doc.addressName();
+    }
+
+    record MatchedFields(String name, String address, BigDecimal lat, BigDecimal lng, String placeId) {
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
@@ -1,18 +1,19 @@
 package com.todayway.backend.geocode.service;
 
 import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import com.todayway.backend.geocode.domain.MatchedFields;
 
 import java.math.BigDecimal;
 
 /**
- * 명세 §8.1 v1.1.4 — Kakao Local 응답 → 캐시 entity / 명세 응답 필드 변환 규칙.
+ * 명세 §8.1 v1.1.4 — Kakao Local 응답 → {@link MatchedFields} 변환 규칙.
  *
  * <p>매핑표:
  * <ul>
  *   <li>{@code name} ← {@code documents[0].place_name}</li>
  *   <li>{@code address} ← {@code documents[0].road_address_name} (빈값이면 {@code address_name} fallback)</li>
- *   <li>{@code lat} ← {@code Double.parseDouble(documents[0].y)} (Kakao 는 string 반환)</li>
- *   <li>{@code lng} ← {@code Double.parseDouble(documents[0].x)}</li>
+ *   <li>{@code lat} ← {@code BigDecimal(documents[0].y)} (Kakao 는 string 반환, DB DECIMAL(10,7) 정밀도 보존)</li>
+ *   <li>{@code lng} ← {@code BigDecimal(documents[0].x)}</li>
  *   <li>{@code placeId} ← {@code documents[0].id}</li>
  * </ul>
  *
@@ -23,10 +24,6 @@ final class KakaoLocalToGeocodeMapper {
     private KakaoLocalToGeocodeMapper() {
     }
 
-    /**
-     * Kakao document → 캐시 INSERT/refresh 에 필요한 매칭 결과 record. lat/lng 는 {@code BigDecimal}
-     * (DB DECIMAL(10,7) 정밀도 보존).
-     */
     static MatchedFields toMatchedFields(KakaoLocalSearchResponse.Document doc) {
         return new MatchedFields(
                 doc.placeName(),
@@ -43,8 +40,5 @@ final class KakaoLocalToGeocodeMapper {
             return road;
         }
         return doc.addressName();
-    }
-
-    record MatchedFields(String name, String address, BigDecimal lat, BigDecimal lng, String placeId) {
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
+++ b/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.map.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 명세 §4.2 — {@code GET /map/config} 정적 응답 source.
+ * {@code application.yml} {@code map.*} 키에서 주입. 운영 환경에서 환경변수 override 허용.
+ *
+ * <p>설정값 자체가 부적합하면 {@code @Validated} 로 ApplicationContext 시작 시점에 fail —
+ * 런타임 503 케이스가 도달하지 않도록 fail-fast.
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "map")
+public class MapConfigProperties {
+
+    /** 클라이언트 지도 SDK 식별자. 명세 §4.2 예시 {@code "NAVER"}. */
+    @NotBlank
+    private String provider;
+
+    /** 초기 줌 레벨. 일반 지도 SDK 범위 (0=세계, 20=상세). */
+    @Min(0)
+    @Max(20)
+    private int defaultZoom;
+
+    /** 위치 정보 부재 시 지도 초기 중심 좌표. */
+    @Valid
+    @NotNull
+    private DefaultCenter defaultCenter;
+
+    /** 타일 스타일 식별자 (예: {@code "basic"}). 클라이언트가 SDK 에 그대로 전달. */
+    @NotBlank
+    private String tileStyle;
+
+    @Getter
+    @Setter
+    public static class DefaultCenter {
+        private double lat;
+        private double lng;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
+++ b/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -16,42 +14,21 @@ import org.springframework.validation.annotation.Validated;
  * 명세 §4.2 — {@code GET /map/config} 정적 응답 source.
  * {@code application.yml} {@code map.*} 키에서 주입. 운영 환경에서 환경변수 override 허용.
  *
- * <p>설정값 자체가 부적합하면 {@code @Validated} 로 ApplicationContext 시작 시점에 fail —
- * 런타임 503 케이스가 도달하지 않도록 fail-fast.
+ * <p>Spring Boot 3 record {@code @ConfigurationProperties} — 불변 + setter 노출 X.
+ * {@code @Validated} 가 ApplicationContext 시작 시점에 fail-fast.
  */
-@Getter
-@Setter
 @Validated
 @ConfigurationProperties(prefix = "map")
-public class MapConfigProperties {
+public record MapConfigProperties(
+        @NotBlank String provider,
+        @Min(0) @Max(20) int defaultZoom,
+        @Valid @NotNull DefaultCenter defaultCenter,
+        @NotBlank String tileStyle
+) {
 
-    /** 클라이언트 지도 SDK 식별자. 명세 §4.2 예시 {@code "NAVER"}. */
-    @NotBlank
-    private String provider;
-
-    /** 초기 줌 레벨. 일반 지도 SDK 범위 (0=세계, 20=상세). */
-    @Min(0)
-    @Max(20)
-    private int defaultZoom;
-
-    /** 위치 정보 부재 시 지도 초기 중심 좌표. */
-    @Valid
-    @NotNull
-    private DefaultCenter defaultCenter;
-
-    /** 타일 스타일 식별자 (예: {@code "basic"}). 클라이언트가 SDK 에 그대로 전달. */
-    @NotBlank
-    private String tileStyle;
-
-    @Getter
-    @Setter
-    public static class DefaultCenter {
-        @DecimalMin("-90.0")
-        @DecimalMax("90.0")
-        private double lat;
-
-        @DecimalMin("-180.0")
-        @DecimalMax("180.0")
-        private double lng;
+    public record DefaultCenter(
+            @DecimalMin("-90.0") @DecimalMax("90.0") double lat,
+            @DecimalMin("-180.0") @DecimalMax("180.0") double lng
+    ) {
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
+++ b/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
@@ -1,6 +1,8 @@
 package com.todayway.backend.map.config;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -44,7 +46,12 @@ public class MapConfigProperties {
     @Getter
     @Setter
     public static class DefaultCenter {
+        @DecimalMin("-90.0")
+        @DecimalMax("90.0")
         private double lat;
+
+        @DecimalMin("-180.0")
+        @DecimalMax("180.0")
         private double lng;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
+++ b/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 명세 §4 — 메인/지도 (display, settings).
- * <p>{@code GET /main} 게스트 허용 + {@code GET /map/config} 인증 불필요.
- * SecurityConfig.permitAll 에 두 경로 모두 사전 등록되어 있다.
+ * <p>{@code GET /main} 은 명세 §4.1 게스트 허용 ({@code @CurrentMember(required=false)}),
+ * {@code GET /map/config} 는 인증 불필요. 두 경로 모두 통합 테스트가 401 회귀 가드 담당.
  */
 @RestController
 @RequestMapping("/api/v1")

--- a/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
+++ b/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
@@ -1,0 +1,28 @@
+package com.todayway.backend.map.controller;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.map.dto.MapConfigResponse;
+import com.todayway.backend.map.service.MapConfigService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 명세 §4 — 메인/지도 (display, settings).
+ * <p>{@code GET /main} 게스트 허용 + {@code GET /map/config} 인증 불필요.
+ * SecurityConfig.permitAll 에 두 경로 모두 사전 등록되어 있다.
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class MapController {
+
+    private final MapConfigService mapConfigService;
+
+    @GetMapping("/map/config")
+    public ResponseEntity<ApiResponse<MapConfigResponse>> getMapConfig() {
+        return ResponseEntity.ok(ApiResponse.of(mapConfigService.getConfig()));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
+++ b/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
@@ -1,12 +1,16 @@
 package com.todayway.backend.map.controller;
 
 import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.map.dto.MainResponse;
 import com.todayway.backend.map.dto.MapConfigResponse;
+import com.todayway.backend.map.service.MainService;
 import com.todayway.backend.map.service.MapConfigService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -19,7 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MapController {
 
+    private final MainService mainService;
     private final MapConfigService mapConfigService;
+
+    @GetMapping("/main")
+    public ResponseEntity<ApiResponse<MainResponse>> getMain(
+            @CurrentMember(required = false) String memberUid,
+            @RequestParam(required = false) Double lat,
+            @RequestParam(required = false) Double lng) {
+        return ResponseEntity.ok(ApiResponse.of(mainService.compose(memberUid, lat, lng)));
+    }
 
     @GetMapping("/map/config")
     public ResponseEntity<ApiResponse<MapConfigResponse>> getMapConfig() {

--- a/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
@@ -1,11 +1,11 @@
 package com.todayway.backend.map.dto;
 
 /**
- * 명세 §4 응답에 등장하는 위경도 좌표 (예: {@code mapCenter}, {@code defaultCenter}).
+ * 명세 §4 응답의 위경도 좌표 ({@code mapCenter}, {@code defaultCenter}).
  *
- * <p>compact constructor 가 NaN/Infinity/range 를 거부 — {@code Coordinate(0,0)} 같은 silent
- * "Null Island" 좌표는 명세상 valid 범위 안이라 통과시키되, 그 외 비정상 값은 즉시 차단해
- * 클라이언트가 의도한 좌표를 보내지 않은 케이스가 silent corruption 으로 흘러가지 않도록 한다.
+ * <p>compact constructor 가 NaN/Infinity/range 를 거부 — query 파라미터의 비정상 값이 silent 로
+ * 흘러가지 않게 한다. {@code (0, 0)} 은 valid 범위 안이라 통과되지만 운영 측면에선 "Null Island"
+ * 사고 신호일 수 있다 (호출자가 좌표를 셋업 안 한 채 호출).
  */
 public record Coordinate(double lat, double lng) {
 

--- a/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
@@ -2,7 +2,19 @@ package com.todayway.backend.map.dto;
 
 /**
  * 명세 §4 응답에 등장하는 위경도 좌표 (예: {@code mapCenter}, {@code defaultCenter}).
- * 직렬화는 {@code {"lat": ..., "lng": ...}} 형태.
+ *
+ * <p>compact constructor 가 NaN/Infinity/range 를 거부 — {@code Coordinate(0,0)} 같은 silent
+ * "Null Island" 좌표는 명세상 valid 범위 안이라 통과시키되, 그 외 비정상 값은 즉시 차단해
+ * 클라이언트가 의도한 좌표를 보내지 않은 케이스가 silent corruption 으로 흘러가지 않도록 한다.
  */
 public record Coordinate(double lat, double lng) {
+
+    public Coordinate {
+        if (Double.isNaN(lat) || Double.isInfinite(lat) || lat < -90 || lat > 90) {
+            throw new IllegalArgumentException("lat 은 [-90, 90] 범위의 유한 값이어야 함: " + lat);
+        }
+        if (Double.isNaN(lng) || Double.isInfinite(lng) || lng < -180 || lng > 180) {
+            throw new IllegalArgumentException("lng 은 [-180, 180] 범위의 유한 값이어야 함: " + lng);
+        }
+    }
 }

--- a/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
@@ -1,0 +1,8 @@
+package com.todayway.backend.map.dto;
+
+/**
+ * 명세 §4 응답에 등장하는 위경도 좌표 (예: {@code mapCenter}, {@code defaultCenter}).
+ * 직렬화는 {@code {"lat": ..., "lng": ...}} 형태.
+ */
+public record Coordinate(double lat, double lng) {
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MainPlaceDto.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MainPlaceDto.java
@@ -1,0 +1,8 @@
+package com.todayway.backend.map.dto;
+
+/**
+ * 명세 §4.1 — {@code nearestSchedule.origin / destination} 의 응답 형태.
+ * 명세 §11.1 {@code Place} 의 sub-shape (name + 좌표만 노출).
+ */
+public record MainPlaceDto(String name, double lat, double lng) {
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
@@ -1,17 +1,14 @@
 package com.todayway.backend.map.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 /**
  * 명세 §4.1 — {@code GET /main} 응답.
  *
- * <p>{@code nearestSchedule} 은 미인증 / 미래 일정 없을 시 {@code null}. Jackson 의
- * {@code @JsonInclude(NON_NULL)} 로 직렬화에서 키 자체가 사라지지 않도록 record 레벨에는 적용하지
- * 않고 그대로 둔다 — 명세 §4.1 응답 예시에 {@code nearestSchedule} 키가 항상 등장하기 때문.
- * 다만 mapCenter 는 항상 채워진다.
+ * <p>{@code nearestSchedule} 은 미인증 / 미래 일정 없을 시 {@code null} 로 직렬화되어 명세 응답 예시의
+ * {@code "nearestSchedule": null} 과 정합. {@code application.yml} 에 global non-null 설정이 없고
+ * Jackson 의 디폴트가 {@code Include.ALWAYS} 라 별도 어노테이션 불필요. {@code mapCenter} 는 항상 채워진다.
  */
 public record MainResponse(
-        @JsonInclude NearestScheduleDto nearestSchedule,
+        NearestScheduleDto nearestSchedule,
         Coordinate mapCenter
 ) {
 }

--- a/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
@@ -1,0 +1,17 @@
+package com.todayway.backend.map.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 명세 §4.1 — {@code GET /main} 응답.
+ *
+ * <p>{@code nearestSchedule} 은 미인증 / 미래 일정 없을 시 {@code null}. Jackson 의
+ * {@code @JsonInclude(NON_NULL)} 로 직렬화에서 키 자체가 사라지지 않도록 record 레벨에는 적용하지
+ * 않고 그대로 둔다 — 명세 §4.1 응답 예시에 {@code nearestSchedule} 키가 항상 등장하기 때문.
+ * 다만 mapCenter 는 항상 채워진다.
+ */
+public record MainResponse(
+        @JsonInclude NearestScheduleDto nearestSchedule,
+        Coordinate mapCenter
+) {
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
@@ -1,0 +1,23 @@
+package com.todayway.backend.map.dto;
+
+import com.todayway.backend.map.config.MapConfigProperties;
+
+/**
+ * 명세 §4.2 — {@code GET /map/config} 응답. 클라이언트 API 키는 포함하지 않는다 (프론트 빌드시 주입).
+ */
+public record MapConfigResponse(
+        String provider,
+        int defaultZoom,
+        Coordinate defaultCenter,
+        String tileStyle
+) {
+
+    public static MapConfigResponse from(MapConfigProperties p) {
+        return new MapConfigResponse(
+                p.getProvider(),
+                p.getDefaultZoom(),
+                new Coordinate(p.getDefaultCenter().getLat(), p.getDefaultCenter().getLng()),
+                p.getTileStyle()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
@@ -14,10 +14,10 @@ public record MapConfigResponse(
 
     public static MapConfigResponse from(MapConfigProperties p) {
         return new MapConfigResponse(
-                p.getProvider(),
-                p.getDefaultZoom(),
-                new Coordinate(p.getDefaultCenter().getLat(), p.getDefaultCenter().getLng()),
-                p.getTileStyle()
+                p.provider(),
+                p.defaultZoom(),
+                new Coordinate(p.defaultCenter().lat(), p.defaultCenter().lng()),
+                p.tileStyle()
         );
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
@@ -1,0 +1,39 @@
+package com.todayway.backend.map.dto;
+
+import com.todayway.backend.common.web.IdPrefixes;
+import com.todayway.backend.schedule.domain.Schedule;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 명세 §4.1 {@code data.nearestSchedule} 응답. 시간상 가장 가까운 미래 일정 한 건.
+ * 미인증 또는 일정 없을 시 응답에서 {@code null}.
+ *
+ * <p>{@code hasCalculatedRoute} 는 명세 §4.1 비고대로 {@code route_summary_json IS NOT NULL} 여부.
+ */
+public record NearestScheduleDto(
+        String scheduleId,
+        String title,
+        OffsetDateTime arrivalTime,
+        MainPlaceDto origin,
+        MainPlaceDto destination,
+        boolean hasCalculatedRoute,
+        OffsetDateTime recommendedDepartureTime,
+        OffsetDateTime reminderAt
+) {
+
+    public static NearestScheduleDto from(Schedule s) {
+        return new NearestScheduleDto(
+                IdPrefixes.SCHEDULE + s.getScheduleUid(),
+                s.getTitle(),
+                s.getArrivalTime(),
+                new MainPlaceDto(s.getOriginName(),
+                        s.getOriginLat().doubleValue(), s.getOriginLng().doubleValue()),
+                new MainPlaceDto(s.getDestinationName(),
+                        s.getDestinationLat().doubleValue(), s.getDestinationLng().doubleValue()),
+                s.getRouteSummaryJson() != null,
+                s.getRecommendedDepartureTime(),
+                s.getReminderAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
@@ -23,6 +23,11 @@ public record NearestScheduleDto(
 ) {
 
     public static NearestScheduleDto from(Schedule s) {
+        // V1 schema 는 origin/destination lat/lng 를 NOT NULL 로 강제하지만 JPA field 는 BigDecimal
+        // (JVM-nullable). DB 마이그레이션 / 직접 SQL 우회 등으로 null 이 흘러들어오면 NPE → 500 generic
+        // 으로 떨어지므로 명시 가드 + scheduleUid 를 메시지에 박아 운영 진단 가능하게 한다.
+        requireCoord(s.getOriginLat(), s.getOriginLng(), "origin", s.getScheduleUid());
+        requireCoord(s.getDestinationLat(), s.getDestinationLng(), "destination", s.getScheduleUid());
         return new NearestScheduleDto(
                 IdPrefixes.SCHEDULE + s.getScheduleUid(),
                 s.getTitle(),
@@ -35,5 +40,13 @@ public record NearestScheduleDto(
                 s.getRecommendedDepartureTime(),
                 s.getReminderAt()
         );
+    }
+
+    private static void requireCoord(java.math.BigDecimal lat, java.math.BigDecimal lng,
+                                     String label, String scheduleUid) {
+        if (lat == null || lng == null) {
+            throw new IllegalStateException(
+                    "Schedule " + scheduleUid + " has null " + label + " coordinate (data corruption)");
+        }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/service/MainService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MainService.java
@@ -74,7 +74,7 @@ public class MainService {
         if (nearest != null) {
             return new Coordinate(nearest.origin().lat(), nearest.origin().lng());
         }
-        MapConfigProperties.DefaultCenter dc = mapConfigProperties.getDefaultCenter();
-        return new Coordinate(dc.getLat(), dc.getLng());
+        MapConfigProperties.DefaultCenter dc = mapConfigProperties.defaultCenter();
+        return new Coordinate(dc.lat(), dc.lng());
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/service/MainService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MainService.java
@@ -8,6 +8,7 @@ import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.repository.MemberRepository;
 import com.todayway.backend.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,7 @@ import java.time.ZoneId;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class MainService {
 
@@ -50,11 +52,17 @@ public class MainService {
         }
         // 탈퇴 회원의 토큰이 살아있는 경우 — 명세 §1.7 / §3.3 정합으로 nearestSchedule = null
         // (UNAUTHORIZED 던지지 않고 graceful 게스트 처리. 로그인 필요 흐름은 다른 endpoint 가 담당).
-        return memberRepository.findByMemberUid(memberUid)
+        // 단 silent 처리는 token-revocation 파이프라인 고장을 가리므로 WARN 로깅으로 신호 보존.
+        Long memberId = memberRepository.findByMemberUid(memberUid)
                 .map(Member::getId)
-                .flatMap(memberId -> scheduleRepository
-                        .findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(
-                                memberId, OffsetDateTime.now(KST)))
+                .orElse(null);
+        if (memberId == null) {
+            log.warn("Authenticated /main with valid JWT but member not found — graceful guest fallback. memberUid={}",
+                    memberUid);
+            return null;
+        }
+        return scheduleRepository
+                .findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(memberId, OffsetDateTime.now(KST))
                 .map(NearestScheduleDto::from)
                 .orElse(null);
     }

--- a/backend/src/main/java/com/todayway/backend/map/service/MainService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MainService.java
@@ -1,0 +1,72 @@
+package com.todayway.backend.map.service;
+
+import com.todayway.backend.map.config.MapConfigProperties;
+import com.todayway.backend.map.dto.Coordinate;
+import com.todayway.backend.map.dto.MainResponse;
+import com.todayway.backend.map.dto.NearestScheduleDto;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+/**
+ * 명세 §4.1 — {@code GET /main} 메인 화면 데이터 조회 (게스트 허용).
+ *
+ * <p>{@code memberUid} 가 {@code null} 인 게스트 호출은 nearestSchedule=null 로 응답.
+ * 인증된 호출은 시간상 가장 가까운 미래 일정 한 건을 노출.
+ *
+ * <p>mapCenter 결정 우선순위 (명세 §4.1 비고):
+ * <ol>
+ *   <li>query lat/lng</li>
+ *   <li>nearestSchedule.origin</li>
+ *   <li>{@link MapConfigProperties} default-center (예: 서울시청)</li>
+ * </ol>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MainService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final MapConfigProperties mapConfigProperties;
+
+    public MainResponse compose(String memberUid, Double lat, Double lng) {
+        NearestScheduleDto nearest = resolveNearest(memberUid);
+        Coordinate mapCenter = decideMapCenter(lat, lng, nearest);
+        return new MainResponse(nearest, mapCenter);
+    }
+
+    private NearestScheduleDto resolveNearest(String memberUid) {
+        if (memberUid == null) {
+            return null;
+        }
+        // 탈퇴 회원의 토큰이 살아있는 경우 — 명세 §1.7 / §3.3 정합으로 nearestSchedule = null
+        // (UNAUTHORIZED 던지지 않고 graceful 게스트 처리. 로그인 필요 흐름은 다른 endpoint 가 담당).
+        return memberRepository.findByMemberUid(memberUid)
+                .map(Member::getId)
+                .flatMap(memberId -> scheduleRepository
+                        .findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(
+                                memberId, OffsetDateTime.now(KST)))
+                .map(NearestScheduleDto::from)
+                .orElse(null);
+    }
+
+    private Coordinate decideMapCenter(Double lat, Double lng, NearestScheduleDto nearest) {
+        if (lat != null && lng != null) {
+            return new Coordinate(lat, lng);
+        }
+        if (nearest != null) {
+            return new Coordinate(nearest.origin().lat(), nearest.origin().lng());
+        }
+        MapConfigProperties.DefaultCenter dc = mapConfigProperties.getDefaultCenter();
+        return new Coordinate(dc.getLat(), dc.getLng());
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
@@ -1,0 +1,24 @@
+package com.todayway.backend.map.service;
+
+import com.todayway.backend.map.config.MapConfigProperties;
+import com.todayway.backend.map.dto.MapConfigResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 명세 §4.2 — 지도 SDK 설정 정적 응답. DB 미사용.
+ *
+ * <p>설정값 자체가 부적합하면 {@link MapConfigProperties} 의 {@code @Validated} 가 ApplicationContext
+ * 시작 시점에 fail 시키므로 본 service 는 단순 변환만 수행. 명세에 박힌 503 MAP_PROVIDER_UNAVAILABLE 은
+ * 정적 설정 흐름에서는 도달 불가 (P1 — 외부 SDK 헬스체크 도입 시 발화 예정).
+ */
+@Service
+@RequiredArgsConstructor
+public class MapConfigService {
+
+    private final MapConfigProperties properties;
+
+    public MapConfigResponse getConfig() {
+        return MapConfigResponse.from(properties);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
  * 명세 §4.2 — 지도 SDK 설정 정적 응답. DB 미사용.
  *
  * <p>설정값 자체가 부적합하면 {@link MapConfigProperties} 의 {@code @Validated} 가 ApplicationContext
- * 시작 시점에 fail 시키므로 본 service 는 단순 변환만 수행. 명세에 박힌 503 MAP_PROVIDER_UNAVAILABLE 은
- * 정적 설정 흐름에서는 도달 불가 (P1 — 외부 SDK 헬스체크 도입 시 발화 예정).
+ * 시작 시점에 fail 시키므로 본 service 는 단순 변환만 수행. 명세 §4.2 의 503 MAP_PROVIDER_UNAVAILABLE
+ * 은 정적 설정 흐름에선 도달 불가 — 외부 SDK 헬스체크가 추가될 때 발화 경로가 생긴다.
  */
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/todayway/backend/push/service/PushService.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushService.java
@@ -15,17 +15,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 명세 §7 — Web Push 구독 도메인 서비스. UPSERT(by endpoint) + soft revoke.
+ * 명세 §7 — Web Push 구독 도메인 서비스. UPSERT (by endpoint) + soft revoke.
  *
- * <p>{@link #subscribe} 의 race condition 정책:
- * <ul>
- *   <li>endpoint UNIQUE 제약으로 동시 INSERT 시 두 번째가 {@link DataIntegrityViolationException}.
- *       catch 후 재조회 → reactivate.</li>
- *   <li>{@code saveAndFlush} 로 commit 미루지 않고 즉시 발견 — silent late-commit 충돌 방지.</li>
- * </ul>
+ * <p>UPSERT 의 race 처리는 {@link PushSubscriptionUpserter} 의 {@code REQUIRES_NEW} 트랜잭션이
+ * 격리한다. 본 서비스의 outer transaction 은 read-only — inner 의 rollback-only 가 outer commit 에
+ * 영향을 주지 않게 해 race 가 silent 500 으로 떨어지지 않게 한다.
  *
- * <p>다른 회원이 동일 endpoint 재구독 시도: 명세 미정의 영역이라 안전하게 {@code 403 FORBIDDEN_RESOURCE}
- * reject. push provider 가 endpoint 를 device-bound 로 발급하므로 실제 발생 빈도 매우 낮음.
+ * <p>다른 회원이 동일 endpoint 재구독 시도: 명세 §7.1 미정의 영역이라 {@link PushSubscriptionUpserter}
+ * 안에서 안전하게 {@code 403 FORBIDDEN_RESOURCE} reject. push provider 가 endpoint 를 device-bound
+ * 로 발급하므로 실제 발생 빈도 매우 낮음.
  */
 @Service
 @RequiredArgsConstructor
@@ -35,11 +33,11 @@ public class PushService {
 
     private final MemberRepository memberRepository;
     private final PushSubscriptionRepository subscriptionRepository;
+    private final PushSubscriptionUpserter upserter;
 
-    @Transactional
     public PushSubscribeResponse subscribe(String memberUid, PushSubscribeRequest req, String userAgent) {
         Long memberId = resolveMemberId(memberUid);
-        PushSubscription saved = upsertByEndpoint(memberId, req, userAgent);
+        PushSubscription saved = upsertWithRetry(memberId, req, userAgent);
         return PushSubscribeResponse.from(saved);
     }
 
@@ -54,36 +52,23 @@ public class PushService {
         s.revoke();
     }
 
-    private PushSubscription upsertByEndpoint(Long memberId, PushSubscribeRequest req, String userAgent) {
+    /**
+     * inner upserter race 충돌은 1회 retry — race window 내 다른 호출이 먼저 INSERT 했다면
+     * findByEndpoint 가 즉시 hit. 두 번째 시도도 fail 이면 데이터 불일치 — 500.
+     */
+    private PushSubscription upsertWithRetry(Long memberId, PushSubscribeRequest req, String userAgent) {
         try {
-            return subscriptionRepository.findByEndpoint(req.endpoint())
-                    .map(existing -> reactivateOwned(existing, memberId, req, userAgent))
-                    .orElseGet(() -> subscriptionRepository.saveAndFlush(
-                            PushSubscription.create(memberId, req.endpoint(),
-                                    req.keys().p256dh(), req.keys().auth(), userAgent)));
+            return upserter.upsert(memberId, req, userAgent);
         } catch (DataIntegrityViolationException e) {
-            // race: 동시 INSERT 충돌 — 두 번째 요청이 unique 위반. 재조회 후 reactivate.
-            // cause 클래스명 함께 로깅 — endpoint 이외 제약(member_id FK 등) 위반 시 진단 가능.
-            log.info("Push subscribe UPSERT race — retrying via findByEndpoint, cause={}",
+            log.info("Push subscribe UPSERT race detected — single retry, cause={}",
                     e.getMostSpecificCause().getClass().getSimpleName());
-            PushSubscription existing = subscriptionRepository.findByEndpoint(req.endpoint())
-                    .orElseThrow(() -> {
-                        // unique 위반 났는데 endpoint 가 안 나오면 다른 제약 위반 — 원인 보존 후 500.
-                        log.error("Push subscribe UPSERT inconsistency — DataIntegrityViolation but endpoint not found",
-                                e);
-                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-                    });
-            return reactivateOwned(existing, memberId, req, userAgent);
+            try {
+                return upserter.upsert(memberId, req, userAgent);
+            } catch (DataIntegrityViolationException retryEx) {
+                log.error("Push subscribe UPSERT inconsistency after retry", retryEx);
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         }
-    }
-
-    private PushSubscription reactivateOwned(PushSubscription existing, Long memberId,
-                                             PushSubscribeRequest req, String userAgent) {
-        if (!existing.belongsTo(memberId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
-        }
-        existing.reactivate(req.keys().p256dh(), req.keys().auth(), userAgent);
-        return existing;
     }
 
     private Long resolveMemberId(String memberUid) {

--- a/backend/src/main/java/com/todayway/backend/push/service/PushSubscriptionUpserter.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushSubscriptionUpserter.java
@@ -1,0 +1,54 @@
+package com.todayway.backend.push.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.push.domain.PushSubscription;
+import com.todayway.backend.push.dto.PushSubscribeRequest;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 명세 §7.1 — UPSERT (by endpoint) 의 race-safe 처리. {@link PushService} 의 outer 트랜잭션과 분리된
+ * {@code REQUIRES_NEW} 트랜잭션 안에서 INSERT/UPDATE 수행.
+ *
+ * <p>{@code saveAndFlush} 후 {@link DataIntegrityViolationException} 이 발생하면 Hibernate session 의
+ * 트랜잭션이 rollback-only 로 마킹된다. 같은 트랜잭션 안에서 catch + dirty mutate 는 commit 시점에
+ * {@link org.springframework.transaction.UnexpectedRollbackException} → silent 500 위험. 별도
+ * {@code REQUIRES_NEW} 메서드로 분리해 충돌이 inner tx 안에서 끝나게 한다.
+ *
+ * <p>다른 회원이 동일 endpoint 재구독 시도는 명세 §7.1 미정의 영역이므로 안전하게 {@code 403
+ * FORBIDDEN_RESOURCE} reject — 본 메서드 내부에서 처리.
+ *
+ * <p>{@code DataIntegrityViolationException} 은 outer 로 propagate — outer 가 1회 retry.
+ */
+@Service
+@RequiredArgsConstructor
+public class PushSubscriptionUpserter {
+
+    private final PushSubscriptionRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PushSubscription upsert(Long memberId, PushSubscribeRequest req, String userAgent) {
+        Optional<PushSubscription> existing = repository.findByEndpoint(req.endpoint());
+        if (existing.isPresent()) {
+            return reactivateOwned(existing.get(), memberId, req, userAgent);
+        }
+        return repository.saveAndFlush(PushSubscription.create(
+                memberId, req.endpoint(), req.keys().p256dh(), req.keys().auth(), userAgent));
+    }
+
+    private PushSubscription reactivateOwned(PushSubscription existing, Long memberId,
+                                             PushSubscribeRequest req, String userAgent) {
+        if (!existing.belongsTo(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
+        existing.reactivate(req.keys().p256dh(), req.keys().auth(), userAgent);
+        return existing;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/PlaceProvider.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/PlaceProvider.java
@@ -1,8 +1,11 @@
 package com.todayway.backend.schedule.domain;
 
 /**
- * 장소 정보의 출처 (origin_provider / destination_provider).
- * DB ENUM과 정합 (V1__init.sql).
+ * 장소 정보의 출처 (origin_provider / destination_provider). 명세 §11.1 / V1__init.sql 정합.
+ *
+ * <p>본 ENUM 은 도메인 추상화 — schedule 도메인에서만 사용. 명세 §8.1 v1.1.4 변환표에 따라 geocode
+ * 응답의 {@link com.todayway.backend.geocode.domain.GeocodeCacheProvider#KAKAO_LOCAL} 는 schedule
+ * 저장 시 {@link #KAKAO} 로 변환되어 들어온다 (변환 책임은 frontend).
  */
 public enum PlaceProvider {
     NAVER, KAKAO, ODSAY, MANUAL

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -66,3 +66,11 @@ push:
     window-minutes: 5                          # 명세 §9.1 — 누락 방지 윈도우
     odsay-max-attempts: 2                      # 명세 §9.1 — 최대 2회 시도
     odsay-retry-interval-ms: 1000              # 명세 §9.1 — 1초 간격
+
+map:                                            # 명세 §4.2 GET /map/config 정적 응답
+  provider: ${MAP_PROVIDER:NAVER}
+  default-zoom: ${MAP_DEFAULT_ZOOM:15}
+  default-center:
+    lat: ${MAP_DEFAULT_CENTER_LAT:37.5665}     # 서울시청 (명세 예시 디폴트)
+    lng: ${MAP_DEFAULT_CENTER_LNG:126.9780}
+  tile-style: ${MAP_TILE_STYLE:basic}

--- a/backend/src/test/java/com/todayway/backend/common/jwt/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/jwt/JwtAuthenticationFilterTest.java
@@ -91,4 +91,23 @@ class JwtAuthenticationFilterTest {
         assertThat(response.getStatus()).isEqualTo(200);
         verify(chain, times(1)).doFilter(request, response);
     }
+
+    @Test
+    void 만료된_토큰이지만_permitAll_path_GET_main이면_401_차단_X_체인_진행_명세_4_1_게스트_허용() throws Exception {
+        // Step 8 self-review F-F — 만료 토큰 + permitAll endpoint = 게스트 흐름. 인증 필요 endpoint 만 401.
+        JwtProvider expiredProvider = new JwtProvider(new JwtProperties(TEST_SECRET, 0, 0, ISSUER));
+        String expiredToken = expiredProvider.issueAccessToken(MEMBER_UID);
+        Thread.sleep(50);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/main");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain, times(1)).doFilter(request, response);
+    }
 }

--- a/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
@@ -15,11 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Resolver 단위 테스트.
- * SecurityFilterChain 의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
- *
- * <p>{@code MethodParameter} 는 더미 메서드 시그니처에서 추출 — production 환경에서는 Spring 이
- * controller 메서드의 파라미터로부터 항상 valid {@code MethodParameter} 를 전달한다.
+ * Resolver 단위 테스트. SecurityFilterChain 의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
  */
 class CurrentMemberArgumentResolverTest {
 

--- a/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
@@ -4,21 +4,45 @@ import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Resolver 단위 테스트 (claude.ai PR #7 리뷰 P2 흡수).
- * SecurityFilterChain의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
+ * Resolver 단위 테스트.
+ * SecurityFilterChain 의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
+ *
+ * <p>{@code MethodParameter} 는 더미 메서드 시그니처에서 추출 — production 환경에서는 Spring 이
+ * controller 메서드의 파라미터로부터 항상 valid {@code MethodParameter} 를 전달한다.
  */
 class CurrentMemberArgumentResolverTest {
 
     private final CurrentMemberArgumentResolver resolver = new CurrentMemberArgumentResolver();
+
+    @SuppressWarnings("unused")
+    private static class TargetMethods {
+        void requiredMethod(@CurrentMember String memberUid) {
+        }
+
+        void optionalMethod(@CurrentMember(required = false) String memberUid) {
+        }
+    }
+
+    private static MethodParameter requiredParam() throws NoSuchMethodException {
+        Method m = TargetMethods.class.getDeclaredMethod("requiredMethod", String.class);
+        return new MethodParameter(m, 0);
+    }
+
+    private static MethodParameter optionalParam() throws NoSuchMethodException {
+        Method m = TargetMethods.class.getDeclaredMethod("optionalMethod", String.class);
+        return new MethodParameter(m, 0);
+    }
 
     @AfterEach
     void clearSecurityContext() {
@@ -26,29 +50,32 @@ class CurrentMemberArgumentResolverTest {
     }
 
     @Test
-    void resolveArgument_whenAuthenticationNull_throwsUnauthorized() {
+    void resolveArgument_whenAuthenticationNull_throwsUnauthorized() throws Exception {
         SecurityContextHolder.clearContext();
-        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+        MethodParameter param = requiredParam();
+        assertThatThrownBy(() -> resolver.resolveArgument(param, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.UNAUTHORIZED);
     }
 
     @Test
-    void resolveArgument_whenPrincipalNotString_throwsUnauthorized() {
+    void resolveArgument_whenPrincipalNotString_throwsUnauthorized() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(new Object(), null, List.of()));
-        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+        MethodParameter param = requiredParam();
+        assertThatThrownBy(() -> resolver.resolveArgument(param, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.UNAUTHORIZED);
     }
 
     @Test
-    void resolveArgument_whenMemberUidBlank_throwsUnauthorized() {
+    void resolveArgument_whenMemberUidBlank_throwsUnauthorized() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("   ", null, List.of()));
-        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+        MethodParameter param = requiredParam();
+        assertThatThrownBy(() -> resolver.resolveArgument(param, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.UNAUTHORIZED);
@@ -58,7 +85,26 @@ class CurrentMemberArgumentResolverTest {
     void resolveArgument_whenValidPrincipal_returnsMemberUid() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("01HAA0123456789ABCDEFGHJK", null, List.of()));
-        Object result = resolver.resolveArgument(null, null, null, null);
+        MethodParameter param = requiredParam();
+        Object result = resolver.resolveArgument(param, null, null, null);
+        assertThat(result).isEqualTo("01HAA0123456789ABCDEFGHJK");
+    }
+
+    @Test
+    void resolveArgument_whenOptional_andUnauthenticated_returnsNull() throws Exception {
+        // 명세 §4.1 — GET /main 게스트 허용. @CurrentMember(required=false) 면 null 주입.
+        SecurityContextHolder.clearContext();
+        MethodParameter param = optionalParam();
+        Object result = resolver.resolveArgument(param, null, null, null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void resolveArgument_whenOptional_andAuthenticated_returnsMemberUid() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("01HAA0123456789ABCDEFGHJK", null, List.of()));
+        MethodParameter param = optionalParam();
+        Object result = resolver.resolveArgument(param, null, null, null);
         assertThat(result).isEqualTo("01HAA0123456789ABCDEFGHJK");
     }
 }

--- a/backend/src/test/java/com/todayway/backend/geocode/controller/GeocodeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/geocode/controller/GeocodeControllerIntegrationTest.java
@@ -1,0 +1,260 @@
+package com.todayway.backend.geocode.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.kakao.KakaoLocalClient;
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §8.1 — POST /geocode 통합 테스트.
+ *
+ * <p>{@link KakaoLocalClient} 는 {@code @MockitoBean} — 외부 호출 격리, 매핑/캐시 흐름만 검증.
+ *
+ * <p>회귀 가드 매트릭스:
+ * <ul>
+ *   <li>정상 매치 / 캐시 hit (Kakao 호출 1회)</li>
+ *   <li>미스 → 404 / 미스 캐시 hit</li>
+ *   <li>401 → 503 / 5xx → 502 / timeout → 504 (명세 §8.1 매핑표)</li>
+ *   <li>인증 401 / query blank → 400</li>
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class GeocodeControllerIntegrationTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean KakaoLocalClient kakaoLocalClient;
+
+    @Test
+    void 정상_매치_200_GeocodeResponse_v1_1_4_매핑표_정합() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(matchedResponse());
+
+        String token = signupAndGetToken("geo01", "정상");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"국민대학교 geo01\" }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.matched").value(true))
+                .andExpect(jsonPath("$.data.name").value("국민대학교"))
+                // road_address_name 우선 (명세 §8.1 v1.1.4)
+                .andExpect(jsonPath("$.data.address").value("서울 성북구 정릉로 77"))
+                .andExpect(jsonPath("$.data.lat").value(37.6103))
+                .andExpect(jsonPath("$.data.lng").value(126.9969))
+                .andExpect(jsonPath("$.data.placeId").value("1234567"))
+                .andExpect(jsonPath("$.data.provider").value("KAKAO_LOCAL"));
+    }
+
+    @Test
+    void 캐시_hit_같은_query_두번째_호출시_Kakao_X_verify_times_1() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(matchedResponse());
+        String token = signupAndGetToken("geocache01", "캐시");
+
+        // 1차 호출 — Kakao 호출 + 캐시 INSERT
+        callGeocode(token, "국민대학교 cache01");
+        // 2차 호출 — TTL 안 → cache hit, Kakao 호출 X
+        callGeocode(token, "국민대학교 cache01");
+
+        verify(kakaoLocalClient, times(1)).searchKeyword(any());
+    }
+
+    @Test
+    void road_address_빈값이면_address_name_fallback() throws Exception {
+        // 명세 §8.1 v1.1.4 — road_address_name 빈값이면 address_name fallback.
+        KakaoLocalSearchResponse.Document doc = new KakaoLocalSearchResponse.Document(
+                "9876", "어떤장소", "서울 성북구 정릉동 100", "", "", "127.001", "37.600");
+        KakaoLocalSearchResponse resp = new KakaoLocalSearchResponse(
+                new KakaoLocalSearchResponse.Meta(1, 1, true), List.of(doc));
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(resp);
+
+        String token = signupAndGetToken("geofallback01", "fallback");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"어떤장소 fb01\" }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.address").value("서울 성북구 정릉동 100"));
+    }
+
+    @Test
+    void documents_빈배열_404_GEOCODE_NO_MATCH() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(emptyResponse());
+
+        String token = signupAndGetToken("geomiss01", "미스");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"asdfasdfasdf miss01\" }"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GEOCODE_NO_MATCH"));
+    }
+
+    @Test
+    void 미스_캐시_hit_두번째_호출시_Kakao_X_verify_times_1() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(emptyResponse());
+        String token = signupAndGetToken("geomisscache01", "미스캐시");
+
+        // 1차 — Kakao 호출 + miss row INSERT + 404
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"asdf misscache01\" }"))
+                .andExpect(status().isNotFound());
+        // 2차 — cache hit (matched=false) → 404, Kakao 호출 X
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"asdf misscache01\" }"))
+                .andExpect(status().isNotFound());
+
+        verify(kakaoLocalClient, times(1)).searchKeyword(any());
+    }
+
+    @Test
+    void Kakao_401_503_EXTERNAL_AUTH_MISCONFIGURED() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenThrow(new ExternalApiException(
+                ExternalApiException.Source.KAKAO_LOCAL,
+                ExternalApiException.Type.CLIENT_ERROR, 401, "401", null));
+        String token = signupAndGetToken("geo401", "auth");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"q401\" }"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_AUTH_MISCONFIGURED"));
+    }
+
+    @Test
+    void Kakao_5xx_502_EXTERNAL_ROUTE_API_FAILED() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenThrow(new ExternalApiException(
+                ExternalApiException.Source.KAKAO_LOCAL,
+                ExternalApiException.Type.SERVER_ERROR, 502, "502", null));
+        String token = signupAndGetToken("geo502", "5xx");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"q502\" }"))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_ROUTE_API_FAILED"));
+    }
+
+    @Test
+    void Kakao_timeout_504_EXTERNAL_TIMEOUT() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenThrow(new ExternalApiException(
+                ExternalApiException.Source.KAKAO_LOCAL,
+                ExternalApiException.Type.TIMEOUT, null, "timeout", null));
+        String token = signupAndGetToken("geotimeout", "timeout");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"qtimeout\" }"))
+                .andExpect(status().isGatewayTimeout())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_TIMEOUT"));
+    }
+
+    @Test
+    void 인증_없이_geocode_401() throws Exception {
+        mockMvc.perform(post("/api/v1/geocode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"국민대\" }"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void query_blank이면_400_VALIDATION_ERROR() throws Exception {
+        String token = signupAndGetToken("geoval", "검증");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"\" }"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    // ───── helpers ─────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private void callGeocode(String token, String query) throws Exception {
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"" + query + "\" }"))
+                .andExpect(status().isOk());
+    }
+
+    private static KakaoLocalSearchResponse matchedResponse() {
+        KakaoLocalSearchResponse.Document doc = new KakaoLocalSearchResponse.Document(
+                "1234567",
+                "국민대학교",
+                "서울 성북구 정릉동 861-1",
+                "서울 성북구 정릉로 77",
+                "SC4",
+                "126.9969",   // x = lng (Kakao string)
+                "37.6103"     // y = lat
+        );
+        return new KakaoLocalSearchResponse(
+                new KakaoLocalSearchResponse.Meta(1, 1, true), List.of(doc));
+    }
+
+    private static KakaoLocalSearchResponse emptyResponse() {
+        return new KakaoLocalSearchResponse(
+                new KakaoLocalSearchResponse.Meta(0, 0, true), List.of());
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -85,7 +86,7 @@ class MapControllerIntegrationTest {
     void main_게스트_토큰없이_200_nearestSchedule_null_mapCenter_default() throws Exception {
         mockMvc.perform(get("/api/v1/main"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.nearestSchedule").value(nullValue()))
                 .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665))
                 .andExpect(jsonPath("$.data.mapCenter.lng").value(126.9780));
     }
@@ -94,7 +95,7 @@ class MapControllerIntegrationTest {
     void main_게스트_query_lat_lng_제공시_mapCenter_query() throws Exception {
         mockMvc.perform(get("/api/v1/main?lat=37.66&lng=127.01"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.nearestSchedule").value(nullValue()))
                 .andExpect(jsonPath("$.data.mapCenter.lat").value(37.66))
                 .andExpect(jsonPath("$.data.mapCenter.lng").value(127.01));
     }
@@ -105,7 +106,7 @@ class MapControllerIntegrationTest {
 
         mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.nearestSchedule").value(nullValue()))
                 .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665));
     }
 

--- a/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.todayway.backend.map.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.Schedule;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §4.1 (GET /main) + §4.2 (GET /map/config) 통합 테스트.
+ *
+ * <p>{@link RouteService} 는 {@code @MockitoBean} — schedule 등록 흐름의 ODsay 호출 격리.
+ * push.scheduler.enabled=false 로 통합 테스트 중 자동 트리거 차단.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MapControllerIntegrationTest {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean RouteService routeService;
+
+    // ─────────── §4.2 GET /map/config ───────────
+
+    @Test
+    void mapConfig_정상_200_명세_4_2_정적_응답() throws Exception {
+        mockMvc.perform(get("/api/v1/map/config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.provider").value("NAVER"))
+                .andExpect(jsonPath("$.data.defaultZoom").value(15))
+                .andExpect(jsonPath("$.data.defaultCenter.lat").value(37.5665))
+                .andExpect(jsonPath("$.data.defaultCenter.lng").value(126.9780))
+                .andExpect(jsonPath("$.data.tileStyle").value("basic"));
+    }
+
+    @Test
+    void mapConfig_인증_없이도_200_permitAll() throws Exception {
+        // /map/config 는 SecurityConfig.permitAll 등록 — Authorization 헤더 없음에도 200.
+        mockMvc.perform(get("/api/v1/map/config"))
+                .andExpect(status().isOk());
+    }
+
+    // ─────────── §4.1 GET /main ───────────
+
+    @Test
+    void main_게스트_토큰없이_200_nearestSchedule_null_mapCenter_default() throws Exception {
+        mockMvc.perform(get("/api/v1/main"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(126.9780));
+    }
+
+    @Test
+    void main_게스트_query_lat_lng_제공시_mapCenter_query() throws Exception {
+        mockMvc.perform(get("/api/v1/main?lat=37.66&lng=127.01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.66))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(127.01));
+    }
+
+    @Test
+    void main_인증_일정없음_nearestSchedule_null_mapCenter_default() throws Exception {
+        String token = signupAndGetToken("mainnoschd01", "일정없음");
+
+        mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665));
+    }
+
+    @Test
+    void main_인증_일정있음_nearestSchedule_채워지고_mapCenter_origin() throws Exception {
+        // refresh 실패 stub (graceful) — schedule 등록은 성공, hasCalculatedRoute=false
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String token = signupAndGetToken("mainwithschd01", "일정있음");
+        String externalScheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule.scheduleId").value(externalScheduleId))
+                .andExpect(jsonPath("$.data.nearestSchedule.title").value("메인테스트"))
+                .andExpect(jsonPath("$.data.nearestSchedule.origin.name").value("우이동"))
+                .andExpect(jsonPath("$.data.nearestSchedule.origin.lat").value(37.6612))
+                .andExpect(jsonPath("$.data.nearestSchedule.origin.lng").value(127.0124))
+                .andExpect(jsonPath("$.data.nearestSchedule.destination.name").value("국민대"))
+                .andExpect(jsonPath("$.data.nearestSchedule.hasCalculatedRoute").value(false))
+                // mapCenter 우선순위 ② nearestSchedule.origin (query lat/lng 없음)
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.6612))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(127.0124));
+    }
+
+    @Test
+    void main_인증_일정있고_query_제공시_mapCenter_query_우선() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        String token = signupAndGetToken("mainquery01", "쿼리우선");
+        createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/main?lat=37.50&lng=127.30")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                // ① query 가 ② origin 보다 우선
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.50))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(127.30));
+    }
+
+    @Test
+    void main_인증_일정있고_route_계산완료시_hasCalculatedRoute_true() throws Exception {
+        // refreshRouteSync 가 schedule.updateRouteInfo 를 호출해 routeSummaryJson 채움 → hasCalculatedRoute=true
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            s.updateRouteInfo(34, s.getArrivalTime().minusMinutes(34),
+                    "{\"path\":{},\"lane\":null}", OffsetDateTime.now(KST));
+            return true;
+        });
+        String token = signupAndGetToken("mainroute01", "경로있음");
+        createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule.hasCalculatedRoute").value(true))
+                .andExpect(jsonPath("$.data.nearestSchedule.recommendedDepartureTime").exists());
+    }
+
+    // ─────────── helpers ───────────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private String createSchedule(String token) throws Exception {
+        OffsetDateTime arrival = OffsetDateTime.now(KST).plusMinutes(60);
+        OffsetDateTime depart = arrival.minusMinutes(30);
+        String body = """
+                {
+                  "title": "메인테스트",
+                  "origin": {"name":"우이동","lat":37.6612,"lng":127.0124},
+                  "destination": {"name":"국민대","lat":37.6103,"lng":126.9969},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s",
+                  "reminderOffsetMinutes": 5
+                }
+                """.formatted(depart, arrival);
+        String resp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("scheduleId").asText();
+    }
+}


### PR DESCRIPTION
## Summary
- 명세 §4.1 `GET /main` (게스트 허용) + §4.2 `GET /map/config` (인증 X) + §8.1 `POST /geocode` (인증 + cache + Kakao Local).
- `@CurrentMember(required=false)` 옵션 추가 — 게스트 허용 endpoint 지원 (default `true` 라 기존 사용처 영향 0).
- 셀프리뷰 16건 fix 모두 동일 PR 에 흡수 (사용자 발화 "이 PR 로 끝, 모든 거 담아").

## 도메인 작업 (8 commits)
| | 영역 | 내용 |
|---|---|---|
| §4.2 | map | `MapConfigProperties` (record, @Validated) + `application.yml map.*` + `MapConfigService` + `GET /map/config` (정적 응답, 4 필드) |
| §4.1 | map | `MainService` + `NearestScheduleDto` + `MainPlaceDto` + `Coordinate` (NaN/range guard) + `GET /main` (게스트 허용, mapCenter 우선순위 ① query → ② origin → ③ default) |
| §8.1 | geocode | `GeocodeCache` JPA entity + `GeocodeCacheRepository` (TTL 30일 + 만료 row fetch) |
| §8.1 v1.1.4 | geocode | `KakaoLocalToGeocodeMapper` (place_name/road_address fallback/x→lng/y→lat/id→placeId) + `MatchedFields` record (도메인 promote, argument-swap 방지) |
| §8.1 | geocode | `GeocodeService` (cache TTL filter / Kakao 호출 / `mapToBusinessException` ODsayRouteService 패턴 미러) + `GeocodeCacheUpserter` (REQUIRES_NEW 별도 tx, race 격리) |
| §8.1 | geocode | `POST /geocode` (인증, @Valid) |

## 셀프리뷰 16건 fix (commit 10–15)

### 🔴 CRITICAL (production silent bug)
- **F-A**: `CurrentMemberArgumentResolver` — Spring Security 의 `AnonymousAuthenticationToken` (principal=`"anonymousUser"`) 를 valid memberUid 처럼 통과시키던 gap → `instanceof AnonymousAuthenticationToken` 명시 제외. 게스트 흐름이 정확히 발화.
- **F-B**: `Coordinate` compact constructor (NaN/Infinity/range 거부) + `NearestScheduleDto.from` 좌표 null 가드 (entity corruption silent NPE → IllegalStateException with scheduleUid).
- **F-C**: Kakao x/y malformed (빈 문자열/null/non-numeric) → `NumberFormatException` 이 catch-all 500 으로 떨어지던 명세 §8.1 위반 → 502 EXTERNAL_ROUTE_API_FAILED 명시 매핑.

### 🟠 HIGH (관측성 / 명세 정합)
- **F-G**: `MainResponse @JsonInclude` (no value) no-op 제거 + 테스트 `doesNotExist()` → `value(nullValue())` 명시 검증.
- **F-N**: `MainService.resolveNearest` — 탈퇴 회원 valid JWT 케이스 silent null → WARN 로깅 (token-revocation 파이프라인 고장 신호 보존).
- **F-M**: `MapConfigProperties.DefaultCenter` lat/lng `@DecimalMin/@DecimalMax` — primitive `double` 의 lat=0.0/lng=0.0 silent default (Null Island) 차단.
- **F-D**: UPSERT race rollback-only → `UnexpectedRollbackException` silent 500 — `GeocodeCacheUpserter` / `PushSubscriptionUpserter` 신설 (REQUIRES_NEW) + outer service 1회 retry. PR #24 PushService 도 같은 패턴이라 함께 fix.
- **F-F**: 만료 JWT + permitAll endpoint 401 차단 → 명세 §4.1 게스트 허용 위반. `PermitAllPaths` 단일 source + `JwtAuthenticationFilter` 의 expired 분기 graceful 처리.

### 🟡 MEDIUM (cleanup / refactor)
- **F-L**: `MapConfigProperties` + nested `DefaultCenter` → Spring Boot 3 record `@ConfigurationProperties` (불변 + setter 제거).
- **F-P**: `GeocodeCache.match` 9-positional-arg → `MatchedFields` record 단일 인자 (lat/lng / name/address swap 위험 차단). `MatchedFields` 를 geocode.domain 으로 promote.
- **F-H**: P1 rot markers 제거 (MapConfigService / GeocodeCacheProvider).
- **F-J**: MapController / GeocodeController 의 SecurityConfig coupling 주석 정정 (drift 위험 → 통합 테스트 회귀 가드 언급으로 대체).
- **F-K**: `Coordinate` doc 정정.
- **F-O**: `CurrentMemberArgumentResolverTest` `<p>` 단락 narration 제거.
- **F-Q**: `PlaceProvider` 에 `GeocodeCacheProvider` cross-reference doc 추가 (KAKAO_LOCAL → KAKAO 변환 책임 명시).
- **+**: `GlobalExceptionHandler` 에 `IllegalArgumentException` / `HandlerMethodValidationException` / `HttpMessageNotReadableException` (issue #16) / `ConstraintViolation` 등 일괄 400 매핑 — catch-all 500 generic 오염 차단.

## 통합 테스트 (총 18건)
- `MapControllerIntegrationTest` 7건 — /map/config 200/permitAll, /main 게스트/인증/일정유무/query/route 계산.
- `GeocodeControllerIntegrationTest` 10건 — 정상 매치/캐시 hit/road_address fallback/empty docs/미스 캐시 hit/401/5xx/timeout/인증/blank query.
- `CurrentMemberArgumentResolverTest` 6건 (기존 4 + required=false 게스트 흐름 2).
- `JwtAuthenticationFilterTest` 5건 (기존 + 만료 토큰 + permitAll graceful 1).

## 명세 변경 동반
- 없음. 코드 변경은 모두 명세 §4.1 / §4.2 / §8.1 / §1.6 본문 정합.

## Test plan
- [x] `./gradlew test` 전체 GREEN (Testcontainers MySQL 8 + 기존 + 신규 18건).
- [x] `compileJava` / `compileTestJava` GREEN.
- [x] 명세 §4.1 / §4.2 / §8.1 v1.1.4 매핑표 1:1 검증 (plugin agent 4종 + 직접 layer + WebSearch 검증된 기술 stack).
- [x] silent failure 영역 catch-up 완료 (anonymous principal / 좌표 corruption / Kakao 매핑 / UPSERT race / 만료 JWT permitAll).