### PR TITLE
feat(backend/map,geocode): Step 8 — 메인/지도 (§4) + 지오코딩 (§8) + 셀프리뷰 16건 fix

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
 > **버전**: v1.1.13-MVP
-> **최종 수정**: 2026-05-07 (이상진 — §9.2 보강 (userDepartureTime delta shift + estimatedDurationMinutes 부재 fallback), §12.5/§12.6 완료 표시. PR #24 셀프리뷰 후속.)
+> **최종 수정**: 2026-05-07 (이상진 — §9.2 보강 (userDepartureTime delta shift), §12.5/§12.6 완료 표시. PR #24 셀프리뷰 후속.)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -29,7 +29,7 @@
 | **v1.1.10** | **2026-05-04** | **§6.1 transit path 출처 승격 (이상진) — `passStopList` 정류장 직선 → ODsay `loadLane` 도로 곡선 (`lane[i].section[].graphPos[]`) 정식 사용. `route_summary_json`을 `{"path":..., "lane":...}` wrapped 형식으로 저장 — 캐시 hit 시 재호출 없이 곡선 복원. loadLane 실패는 graceful — `passStopList` 직선 fallback. ODsay 호출 cache miss 1회당 1회 → 2회 (직렬, mapObj 의존).** |
 | **v1.1.11** | **2026-05-04** | **§6.1 응답 예시 WALK `from`/`to` 제거 — `RouteSegment` record invariant + `@JsonInclude(NON_NULL)` 정합 cleanup. 코드 동작 변경 X (record가 WALK에서 reject + Jackson이 null drop).** |
 | **v1.1.12** | **2026-05-07** | **§12.3 분담표 갱신 — `push` 도메인 황찬우→이상진 위임 (issue #9 본문 + 황찬우 직접 위임 발화 확정). `route` 완료 표시. Step 7 PR(`feat/backend-step7-push`)에 §7.1·§7.2·§9.1·§9.2 글루·#9 cascade 동반.** |
-| **v1.1.13** | **2026-05-07** | **§9.2 보강 — (1) `userDepartureTime` delta shift 명시 (silent corruption 방지: routine advance 후 `departureAdvice` 정합), (2) `estimatedDurationMinutes` 부재 시 `reminder_at = arrival_time - reminder_offset_minutes` fallback (routine silent disable 방지). §12.5/§12.6 완료 표시. PR #24 셀프리뷰 후속 (이상진).** |
+| **v1.1.13** | **2026-05-07** | **§9.2 보강 — `userDepartureTime` delta shift 명시 (silent corruption 방지: routine advance 후 `departureAdvice` 정합). §12.5/§12.6 완료 표시. PR #24 셀프리뷰 후속 (이상진).** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -1172,7 +1172,6 @@ WHERE s.reminder_at <= NOW()
   > **주의**: *다음 occurrence 계산 시점*에는 ODsay를 호출하지 않는다. 며칠 뒤 일정의 소요시간 예측은 부정확하므로 무의미한 호출. 마지막 호출의 `estimated_duration_minutes`를 그대로 사용해 `reminder_at`만 미리 박아둔다.
   > **실제 알람 발송 시점**에는 9.1에 따라 ODsay를 재호출하여 실시간 정보로 갱신한 뒤 발송한다. 사용자가 받는 알람은 항상 최신 정보 기반.
 - `reminder_at = recommended_departure_time - reminder_offset_minutes`
-- 🆕 v1.1.13 — **`estimated_duration_minutes` 부재 시 fallback**: 등록 시점 ODsay 호출이 graceful 실패하여 `estimated_duration_minutes` 가 NULL 인 routine 일정의 경우, `recommended_departure_time` 은 NULL 유지하되 `reminder_at = arrival_time - reminder_offset_minutes` 로 추정해 routine 이 silent disable 되지 않도록 보장. 다음 dispatch 의 ODsay 재호출이 성공하면 `recommended_departure_time` / `reminder_at` 모두 정확한 값으로 갱신된다.
 
 ---
 

--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.12-MVP
-> **최종 수정**: 2026-05-07 (이상진 — §12.3 분담표 갱신, `push` 도메인 황찬우→이상진 위임 반영)
+> **버전**: v1.1.13-MVP
+> **최종 수정**: 2026-05-07 (이상진 — §9.2 보강 (userDepartureTime delta shift + estimatedDurationMinutes 부재 fallback), §12.5/§12.6 완료 표시. PR #24 셀프리뷰 후속.)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -29,6 +29,7 @@
 | **v1.1.10** | **2026-05-04** | **§6.1 transit path 출처 승격 (이상진) — `passStopList` 정류장 직선 → ODsay `loadLane` 도로 곡선 (`lane[i].section[].graphPos[]`) 정식 사용. `route_summary_json`을 `{"path":..., "lane":...}` wrapped 형식으로 저장 — 캐시 hit 시 재호출 없이 곡선 복원. loadLane 실패는 graceful — `passStopList` 직선 fallback. ODsay 호출 cache miss 1회당 1회 → 2회 (직렬, mapObj 의존).** |
 | **v1.1.11** | **2026-05-04** | **§6.1 응답 예시 WALK `from`/`to` 제거 — `RouteSegment` record invariant + `@JsonInclude(NON_NULL)` 정합 cleanup. 코드 동작 변경 X (record가 WALK에서 reject + Jackson이 null drop).** |
 | **v1.1.12** | **2026-05-07** | **§12.3 분담표 갱신 — `push` 도메인 황찬우→이상진 위임 (issue #9 본문 + 황찬우 직접 위임 발화 확정). `route` 완료 표시. Step 7 PR(`feat/backend-step7-push`)에 §7.1·§7.2·§9.1·§9.2 글루·#9 cascade 동반.** |
+| **v1.1.13** | **2026-05-07** | **§9.2 보강 — (1) `userDepartureTime` delta shift 명시 (silent corruption 방지: routine advance 후 `departureAdvice` 정합), (2) `estimatedDurationMinutes` 부재 시 `reminder_at = arrival_time - reminder_offset_minutes` fallback (routine silent disable 방지). §12.5/§12.6 완료 표시. PR #24 셀프리뷰 후속 (이상진).** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -1166,10 +1167,12 @@ WHERE s.reminder_at <= NOW()
 | `CUSTOM` | `arrival_time + routine_interval_days` |
 
 갱신 후:
+- `user_departure_time` 도 동일 delta(`new_arrival - old_arrival`)만큼 shift — 사용자가 입력한 출발 의도 시각이 다음 occurrence 기준으로 보존되어 `departure_advice` 가 정상 산출됨. (v1.1.13 보강)
 - `recommended_departure_time = arrival_time - estimated_duration_minutes`
   > **주의**: *다음 occurrence 계산 시점*에는 ODsay를 호출하지 않는다. 며칠 뒤 일정의 소요시간 예측은 부정확하므로 무의미한 호출. 마지막 호출의 `estimated_duration_minutes`를 그대로 사용해 `reminder_at`만 미리 박아둔다.
   > **실제 알람 발송 시점**에는 9.1에 따라 ODsay를 재호출하여 실시간 정보로 갱신한 뒤 발송한다. 사용자가 받는 알람은 항상 최신 정보 기반.
 - `reminder_at = recommended_departure_time - reminder_offset_minutes`
+- 🆕 v1.1.13 — **`estimated_duration_minutes` 부재 시 fallback**: 등록 시점 ODsay 호출이 graceful 실패하여 `estimated_duration_minutes` 가 NULL 인 routine 일정의 경우, `recommended_departure_time` 은 NULL 유지하되 `reminder_at = arrival_time - reminder_offset_minutes` 로 추정해 routine 이 silent disable 되지 않도록 보장. 다음 dispatch 의 ODsay 재호출이 성공하면 `recommended_departure_time` / `reminder_at` 모두 정확한 값으로 갱신된다.
 
 ---
 
@@ -1332,15 +1335,15 @@ WHERE s.reminder_at <= NOW()
 - [ ] graceful degradation: try-catch로 감싸 schedule 등록 자체는 성공
 
 ### 12.5 스케줄러
-- [ ] `@Scheduled(fixedDelay = 30000)` PushScheduler
-- [ ] 루틴 일정 다음 occurrence 계산 (`RoutineCalculator`)
-- [ ] 누락 방지: 5분 윈도우 내 미발송 알림 스캔
-- [ ] `push_log` 기록
+- [x] `@Scheduled(fixedDelay = 30000)` PushScheduler — Step 7 완료 (이상진)
+- [x] 루틴 일정 다음 occurrence 계산 (`RoutineCalculator`) — Step 5 schedule 도메인 (황찬우)
+- [x] 누락 방지: 5분 윈도우 내 미발송 알림 스캔 — Step 7 완료 (이상진)
+- [x] `push_log` 기록 — Step 7 완료 (이상진)
 
 ### 12.6 Web Push
 - [x] `nl.martijndwars:web-push` 의존성 — Step 1 완료
-- [ ] VAPID 키페어 application.yml에 환경변수로 주입
-- [ ] 발송 시 endpoint 만료(410 Gone) 처리 → 자동 `revoked_at` 갱신
+- [x] VAPID 키페어 application.yml에 환경변수로 주입 — Step 1 (선반영) + Step 7 PushSender 결선
+- [x] 발송 시 endpoint 만료(410 Gone) 처리 → 자동 `revoked_at` 갱신 — Step 7 완료 (이상진)
 
 ---
 

--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.11-MVP
-> **최종 수정**: 2026-05-04 (이상진 — §6.1 응답 예시 WALK `from`/`to` 제거, `RouteSegment` record invariant 정합)
+> **버전**: v1.1.12-MVP
+> **최종 수정**: 2026-05-07 (이상진 — §12.3 분담표 갱신, `push` 도메인 황찬우→이상진 위임 반영)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -28,6 +28,7 @@
 | **v1.1.9** | **2026-04-30** | **§6.1 WALK 구간 path 보충 알고리즘 명시 (Step 6 이상진) — ODsay WALK subPath에 좌표 키가 없어 `origin`/`destination`/이전 transit 끝점으로 합성. 매핑표의 `path` 행에 WALK 분기 추가.** |
 | **v1.1.10** | **2026-05-04** | **§6.1 transit path 출처 승격 (이상진) — `passStopList` 정류장 직선 → ODsay `loadLane` 도로 곡선 (`lane[i].section[].graphPos[]`) 정식 사용. `route_summary_json`을 `{"path":..., "lane":...}` wrapped 형식으로 저장 — 캐시 hit 시 재호출 없이 곡선 복원. loadLane 실패는 graceful — `passStopList` 직선 fallback. ODsay 호출 cache miss 1회당 1회 → 2회 (직렬, mapObj 의존).** |
 | **v1.1.11** | **2026-05-04** | **§6.1 응답 예시 WALK `from`/`to` 제거 — `RouteSegment` record invariant + `@JsonInclude(NON_NULL)` 정합 cleanup. 코드 동작 변경 X (record가 WALK에서 reject + Jackson이 null drop).** |
+| **v1.1.12** | **2026-05-07** | **§12.3 분담표 갱신 — `push` 도메인 황찬우→이상진 위임 (issue #9 본문 + 황찬우 직접 위임 발화 확정). `route` 완료 표시. Step 7 PR(`feat/backend-step7-push`)에 §7.1·§7.2·§9.1·§9.2 글루·#9 cascade 동반.** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -1317,10 +1318,12 @@ WHERE s.reminder_at <= NOW()
 - [ ] `BaseEntity` (createdAt, updatedAt)
 - [ ] ULID 생성 유틸
 
-### 12.3 도메인 분담 (재협의 필요)
-- [ ] `auth`, `member`, `schedule`, `push`: 황찬우
-- [ ] `map` (`/main`, `/map/config`), `geocode`: 이상진
-- [ ] **`route` 도메인 분담은 회의 후 재결정** (이상진이 ODsay 연동까지 가져갈 가능성 권장)
+### 12.3 도메인 분담 (v1.1.12 확정)
+- [ ] `auth`, `member`, `schedule`: 황찬우
+- [x] `route` (§6 + §9.1 ODsay 재호출 글루): 이상진 — Step 6 완료 (PR #11/#13/#14)
+- [ ] `push` (§7 + §9.1 + §9.2 글루): 이상진 — Step 7 (황찬우 위임, issue #9 cascade 동반)
+- [ ] `map` (§4 `/main`, `/map/config`): 이상진
+- [ ] `geocode` (§8): 이상진
 
 ### 12.4 ODsay 연동
 - [x] `OdsayClient.searchPubTransPathT(SX, SY, EX, EY)` — 외부 API 클라이언트 골격 PR 진행 중 (이상진)

--- a/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,19 @@
 package com.todayway.backend.common.exception;
 
 import com.todayway.backend.common.response.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -29,6 +35,39 @@ public class GlobalExceptionHandler {
         ErrorCode code = ErrorCode.VALIDATION_ERROR;
         return ResponseEntity.status(code.getStatus())
                 .body(ErrorResponse.of(code.name(), detail));
+    }
+
+    /**
+     * 다양한 입력 검증 실패를 일괄 400 VALIDATION_ERROR 로 매핑 (명세 §1.6 정합).
+     * <ul>
+     *   <li>{@link HandlerMethodValidationException} — Spring 6.1+ {@code @RequestParam @Min/@Max} 위반.</li>
+     *   <li>{@link ConstraintViolationException} — 레거시 path. {@code Coordinate} compact constructor 의 invalid 좌표 등 도메인 invariant 위반도 흡수.</li>
+     *   <li>{@link IllegalArgumentException} — record/entity 의 invariant 위반 (사용자 입력 가정).</li>
+     *   <li>{@link HttpMessageNotReadableException} — malformed JSON / Content-Type 누락 (issue #16).</li>
+     *   <li>{@link MissingServletRequestParameterException} — 필수 query 누락.</li>
+     *   <li>{@link MethodArgumentTypeMismatchException} — query 타입 불일치 (예: {@code lat=foo}).</li>
+     * </ul>
+     * 이전엔 catch-all 의 500 INTERNAL_SERVER_ERROR 로 떨어져 명세 §1.6 위반 + 운영 모니터링 오염 (가짜 500).
+     */
+    @ExceptionHandler({
+            HandlerMethodValidationException.class,
+            ConstraintViolationException.class,
+            IllegalArgumentException.class,
+            HttpMessageNotReadableException.class,
+            MissingServletRequestParameterException.class,
+            MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception e) {
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        ErrorCode code = ErrorCode.VALIDATION_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/backend/src/main/java/com/todayway/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/todayway/backend/common/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.todayway.backend.common.jwt;
 
+import com.todayway.backend.common.security.PermitAllPaths;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -44,6 +45,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(auth);
         } catch (ExpiredJwtException e) {
             SecurityContextHolder.clearContext();
+            // permitAll endpoint (예: 명세 §4.1 GET /main 게스트 허용) 호출자가 만료 토큰을 보내도
+            // 401 차단하지 않고 게스트 흐름으로 진행 — 명세 §4.1 "게스트 허용 (인증 시 추가 정보)" 정합.
+            // 인증 필요 endpoint 는 종전대로 401 TOKEN_EXPIRED 명시 응답.
+            if (PermitAllPaths.matches(request)) {
+                chain.doFilter(request, response);
+                return;
+            }
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");

--- a/backend/src/main/java/com/todayway/backend/common/security/PermitAllPaths.java
+++ b/backend/src/main/java/com/todayway/backend/common/security/PermitAllPaths.java
@@ -1,0 +1,35 @@
+package com.todayway.backend.common.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Set;
+
+/**
+ * 인증 없이 접근 가능한 endpoint 목록의 단일 source. {@link SecurityConfig} 의 {@code permitAll()}
+ * 등록과 {@link com.todayway.backend.common.jwt.JwtAuthenticationFilter} 의 만료 토큰 graceful 처리
+ * 모두 본 상수를 참조해 drift 차단.
+ *
+ * <p>{@link #PATHS} 는 Spring Security 의 {@code requestMatchers(String...)} 에 그대로 전달.
+ * {@link #matches} 는 filter 가 servlet path 비교용으로 사용. context-path 가 비어있는 가정 하에
+ * {@code getRequestURI()} 로 충분.
+ */
+public final class PermitAllPaths {
+
+    public static final String[] PATHS = {
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
+            "/api/v1/auth/logout",
+            "/api/v1/main",
+            "/api/v1/map/config",
+            "/actuator/health"
+    };
+
+    private static final Set<String> PATH_SET = Set.of(PATHS);
+
+    public static boolean matches(HttpServletRequest request) {
+        return PATH_SET.contains(request.getRequestURI());
+    }
+
+    private PermitAllPaths() {
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/todayway/backend/common/security/SecurityConfig.java
@@ -40,14 +40,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/v1/auth/signup",
-                                "/api/v1/auth/login",
-                                "/api/v1/auth/logout",
-                                "/api/v1/main",
-                                "/api/v1/map/config",
-                                "/actuator/health"
-                        ).permitAll()
+                        .requestMatchers(PermitAllPaths.PATHS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMember.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMember.java
@@ -8,4 +8,11 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CurrentMember {
+
+    /**
+     * {@code true} (기본): 미인증 시 {@code UNAUTHORIZED} 401 — 모든 인증 필요 endpoint 의 디폴트.
+     * {@code false}: 미인증 시 {@code null} 주입 — 명세 §4.1 {@code GET /main} 같은
+     * "게스트 허용 (인증 시 추가 정보)" endpoint 전용.
+     */
+    boolean required() default true;
 }

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -12,9 +12,12 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
- * @CurrentMember 가 붙은 String 파라미터에 SecurityContext의 raw memberUid 주입.
- * DB 호출 0회 — Authentication.getName() 만 호출. 멤버 존재 검증은 Service의 findByMemberUid 책임.
+ * {@link CurrentMember} 가 붙은 String 파라미터에 SecurityContext 의 raw memberUid 주입.
+ * DB 호출 0회 — Authentication.getPrincipal() 만 사용. 멤버 존재 검증은 Service 의 findByMemberUid 책임.
  * 명세 §1.7: JWT sub claim = prefix 없는 raw ULID 26자.
+ *
+ * <p>{@code @CurrentMember(required = false)} 인 경우 미인증 시 {@code null} 주입 — 명세 §4.1
+ * {@code GET /main} 게스트 허용 endpoint 전용. 디폴트 ({@code required = true}) 는 미인증 시 401.
  */
 @Component
 public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -31,9 +34,13 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !(auth.getPrincipal() instanceof String memberUid) || memberUid.isBlank()) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        if (auth != null && auth.getPrincipal() instanceof String memberUid && !memberUid.isBlank()) {
+            return memberUid;
         }
-        return memberUid;
+        CurrentMember annotation = parameter.getParameterAnnotation(CurrentMember.class);
+        if (annotation != null && !annotation.required()) {
+            return null;
+        }
+        throw new BusinessException(ErrorCode.UNAUTHORIZED);
     }
 }

--- a/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/CurrentMemberArgumentResolver.java
@@ -3,6 +3,7 @@ package com.todayway.backend.common.web;
 import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -34,8 +35,15 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.getPrincipal() instanceof String memberUid && !memberUid.isBlank()) {
-            return memberUid;
+        // Spring Security 의 AnonymousAuthenticationFilter 가 미인증 요청에 principal="anonymousUser"
+        // String 토큰을 박는다. 단순 `instanceof String` 검사만으로는 그 문자열이 valid memberUid
+        // 처럼 통과하므로 AnonymousAuthenticationToken 을 명시적으로 제외해야 게스트 흐름이 발화한다.
+        boolean authenticated = auth != null
+                && !(auth instanceof AnonymousAuthenticationToken)
+                && auth.getPrincipal() instanceof String memberUid
+                && !memberUid.isBlank();
+        if (authenticated) {
+            return ((String) auth.getPrincipal());
         }
         CurrentMember annotation = parameter.getParameterAnnotation(CurrentMember.class);
         if (annotation != null && !annotation.required()) {

--- a/backend/src/main/java/com/todayway/backend/common/web/IdPrefixes.java
+++ b/backend/src/main/java/com/todayway/backend/common/web/IdPrefixes.java
@@ -1,0 +1,27 @@
+package com.todayway.backend.common.web;
+
+/**
+ * 명세 §1.7 — 외부 노출 ID 의 도메인별 prefix 상수 단일 출처.
+ *
+ * <p>{@code sub_} / {@code sch_} 와 같은 prefix 가 controller / DTO / service 여러 곳에 흩뿌려져
+ * silent drift 가 일어나지 않도록 본 클래스로 모은다. (Step 6 PR #11 follow-up "stripPrefix DRY"
+ * 트리거 수렴 — Step 7 진입으로 sub_ 추가되어 두 도메인이 동일 패턴을 갖게 됨.)
+ */
+public final class IdPrefixes {
+
+    public static final String SCHEDULE = "sch_";
+    public static final String SUBSCRIPTION = "sub_";
+
+    private IdPrefixes() {
+    }
+
+    /**
+     * 외부 ID 가 prefix 로 시작하면 떼어내고, 아니면 입력 그대로 반환. {@code null} 안전.
+     */
+    public static String strip(String externalId, String prefix) {
+        if (externalId != null && externalId.startsWith(prefix)) {
+            return externalId.substring(prefix.length());
+        }
+        return externalId;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
@@ -14,9 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 명세 §8.1 — {@code POST /geocode}.
- * <p>인증은 SecurityConfig {@code anyRequest().authenticated()} 로 강제 — endpoint 가 permitAll 에
- * 등록되지 않았으므로 토큰 없으면 자동 401. {@link GeocodeService#geocode} 자체는 회원 데이터를 다루지
- * 않아 {@code @CurrentMember} 주입은 불필요 (인증 게이트만 통과하면 cache + 외부 호출만 수행).
+ * <p>{@link GeocodeService#geocode} 가 회원 데이터를 다루지 않아 {@code @CurrentMember} 주입 불필요 —
+ * 인증 게이트만 통과하면 cache + 외부 호출만 수행. 인증 미통과 401 회귀 가드는 통합 테스트가 담당.
  */
 @RestController
 @RequestMapping("/api/v1/geocode")

--- a/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/controller/GeocodeController.java
@@ -1,0 +1,33 @@
+package com.todayway.backend.geocode.controller;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.geocode.dto.GeocodeRequest;
+import com.todayway.backend.geocode.dto.GeocodeResponse;
+import com.todayway.backend.geocode.service.GeocodeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 명세 §8.1 — {@code POST /geocode}.
+ * <p>인증은 SecurityConfig {@code anyRequest().authenticated()} 로 강제 — endpoint 가 permitAll 에
+ * 등록되지 않았으므로 토큰 없으면 자동 401. {@link GeocodeService#geocode} 자체는 회원 데이터를 다루지
+ * 않아 {@code @CurrentMember} 주입은 불필요 (인증 게이트만 통과하면 cache + 외부 호출만 수행).
+ */
+@RestController
+@RequestMapping("/api/v1/geocode")
+@RequiredArgsConstructor
+public class GeocodeController {
+
+    private final GeocodeService geocodeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<GeocodeResponse>> geocode(
+            @Valid @RequestBody GeocodeRequest request) {
+        return ResponseEntity.ok(ApiResponse.of(geocodeService.geocode(request)));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
@@ -87,11 +87,11 @@ public class GeocodeCache {
         this.placeId = placeId;
     }
 
-    /** 매칭된 결과 캐시 신규 생성. */
+    /** 매칭된 결과 캐시 신규 생성. {@link MatchedFields} 로 9-positional-arg 의 swap 위험 차단. */
     public static GeocodeCache match(String queryHash, String queryText, GeocodeCacheProvider provider,
-                                     String name, String address,
-                                     BigDecimal lat, BigDecimal lng, String placeId) {
-        return new GeocodeCache(queryHash, queryText, provider, true, name, address, lat, lng, placeId);
+                                     MatchedFields fields) {
+        return new GeocodeCache(queryHash, queryText, provider, true,
+                fields.name(), fields.address(), fields.lat(), fields.lng(), fields.placeId());
     }
 
     /** Kakao documents 빈 배열 응답을 캐시 (반복 미스 query 의 외부 API 호출 차단). */
@@ -107,15 +107,14 @@ public class GeocodeCache {
     }
 
     /** TTL 만료 후 재조회 결과로 row 갱신. {@code cachedAt} 도 NOW 로 reset. */
-    public void refreshAsMatch(String queryText, String name, String address,
-                               BigDecimal lat, BigDecimal lng, String placeId) {
+    public void refreshAsMatch(String queryText, MatchedFields fields) {
         this.queryText = queryText;
         this.matched = true;
-        this.name = name;
-        this.address = address;
-        this.lat = lat;
-        this.lng = lng;
-        this.placeId = placeId;
+        this.name = fields.name();
+        this.address = fields.address();
+        this.lat = fields.lat();
+        this.lng = fields.lng();
+        this.placeId = fields.placeId();
         this.cachedAt = OffsetDateTime.now(KST);
     }
 

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCache.java
@@ -1,0 +1,132 @@
+package com.todayway.backend.geocode.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+/**
+ * 명세 §8.1 — Kakao/NAVER Geocoding 결과 캐시 (TTL 30일). V1__init.sql {@code geocode_cache} 정합.
+ *
+ * <p>row identity = {@code (query_hash, provider)} UNIQUE. 동일 쿼리·동일 provider 결과는 단일 row 로
+ * 보존되며, TTL 만료 후 재호출 시 {@link #refresh} 로 갱신 (UPSERT 시 unique 위반 catch + retry 로
+ * race-safe).
+ *
+ * <p>matched=false (Kakao documents 빈 배열) 도 캐시 — 같은 미스 query 의 반복 호출이 외부 API
+ * quota 를 소모하지 않게 한다. 서비스 흐름은 {@link #isMatched} 가 false 면 404 GEOCODE_NO_MATCH.
+ *
+ * <p>BaseEntity 미상속 ({@code updated_at} 컬럼 없음) — append + refresh 외 상태 없음.
+ */
+@Getter
+@Entity
+@Table(name = "geocode_cache")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GeocodeCache {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "query_hash", nullable = false, updatable = false, columnDefinition = "CHAR(64)")
+    private String queryHash;
+
+    @Column(name = "query_text", nullable = false, length = 255)
+    private String queryText;
+
+    @Column(name = "matched", nullable = false)
+    private boolean matched;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "address", length = 255)
+    private String address;
+
+    @Column(name = "lat", precision = 10, scale = 7)
+    private BigDecimal lat;
+
+    @Column(name = "lng", precision = 10, scale = 7)
+    private BigDecimal lng;
+
+    @Column(name = "place_id", length = 100)
+    private String placeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, updatable = false,
+            columnDefinition = "ENUM('NAVER','KAKAO_LOCAL')")
+    private GeocodeCacheProvider provider;
+
+    @Column(name = "cached_at", nullable = false)
+    private OffsetDateTime cachedAt;
+
+    private GeocodeCache(String queryHash, String queryText, GeocodeCacheProvider provider,
+                         boolean matched, String name, String address,
+                         BigDecimal lat, BigDecimal lng, String placeId) {
+        this.queryHash = queryHash;
+        this.queryText = queryText;
+        this.provider = provider;
+        this.matched = matched;
+        this.name = name;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.placeId = placeId;
+    }
+
+    /** 매칭된 결과 캐시 신규 생성. */
+    public static GeocodeCache match(String queryHash, String queryText, GeocodeCacheProvider provider,
+                                     String name, String address,
+                                     BigDecimal lat, BigDecimal lng, String placeId) {
+        return new GeocodeCache(queryHash, queryText, provider, true, name, address, lat, lng, placeId);
+    }
+
+    /** Kakao documents 빈 배열 응답을 캐시 (반복 미스 query 의 외부 API 호출 차단). */
+    public static GeocodeCache miss(String queryHash, String queryText, GeocodeCacheProvider provider) {
+        return new GeocodeCache(queryHash, queryText, provider, false, null, null, null, null, null);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (cachedAt == null) {
+            cachedAt = OffsetDateTime.now(KST);
+        }
+    }
+
+    /** TTL 만료 후 재조회 결과로 row 갱신. {@code cachedAt} 도 NOW 로 reset. */
+    public void refreshAsMatch(String queryText, String name, String address,
+                               BigDecimal lat, BigDecimal lng, String placeId) {
+        this.queryText = queryText;
+        this.matched = true;
+        this.name = name;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+        this.placeId = placeId;
+        this.cachedAt = OffsetDateTime.now(KST);
+    }
+
+    public void refreshAsMiss(String queryText) {
+        this.queryText = queryText;
+        this.matched = false;
+        this.name = null;
+        this.address = null;
+        this.lat = null;
+        this.lng = null;
+        this.placeId = null;
+        this.cachedAt = OffsetDateTime.now(KST);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
@@ -3,12 +3,13 @@ package com.todayway.backend.geocode.domain;
 /**
  * V1__init.sql {@code geocode_cache.provider} ENUM. 명세 §8.1 / §11.1 정합.
  *
- * <p>{@link #KAKAO_LOCAL} — Kakao Local API 응답을 그대로 캐시 (현 MVP 사용).
- * <p>{@link #NAVER} — NAVER Geocoding 도입 시 (P1 예정).
+ * <p>{@link #KAKAO_LOCAL} — Kakao Local API 응답을 그대로 캐시 (MVP 사용).
+ * <p>{@link #NAVER} — V1__init.sql ENUM 정합. NAVER Geocoding 도입 시 활성화.
  *
  * <p>주의: 명세 §11.1 {@code Place.provider} 는 도메인 추상화 ENUM
  * ({@code NAVER/KAKAO/ODSAY/MANUAL}) 이고, schedule 저장 시 {@code KAKAO_LOCAL → KAKAO} 변환
- * 필요 (명세 §8.1 v1.1.4 변환표). 본 enum 은 캐시 키 구분용으로만 사용.
+ * 필요 (명세 §8.1 v1.1.4 변환표). 본 enum 은 캐시 키 구분용으로만 사용. 변환 책임은 frontend
+ * (geocode 응답을 schedule 등록 payload 로 round-trip 시 KAKAO 로 매핑).
  */
 public enum GeocodeCacheProvider {
     NAVER,

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/GeocodeCacheProvider.java
@@ -1,0 +1,16 @@
+package com.todayway.backend.geocode.domain;
+
+/**
+ * V1__init.sql {@code geocode_cache.provider} ENUM. 명세 §8.1 / §11.1 정합.
+ *
+ * <p>{@link #KAKAO_LOCAL} — Kakao Local API 응답을 그대로 캐시 (현 MVP 사용).
+ * <p>{@link #NAVER} — NAVER Geocoding 도입 시 (P1 예정).
+ *
+ * <p>주의: 명세 §11.1 {@code Place.provider} 는 도메인 추상화 ENUM
+ * ({@code NAVER/KAKAO/ODSAY/MANUAL}) 이고, schedule 저장 시 {@code KAKAO_LOCAL → KAKAO} 변환
+ * 필요 (명세 §8.1 v1.1.4 변환표). 본 enum 은 캐시 키 구분용으로만 사용.
+ */
+public enum GeocodeCacheProvider {
+    NAVER,
+    KAKAO_LOCAL
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/domain/MatchedFields.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/domain/MatchedFields.java
@@ -1,0 +1,13 @@
+package com.todayway.backend.geocode.domain;
+
+import java.math.BigDecimal;
+
+/**
+ * 명세 §8.1 — 매칭된 지오코딩 결과의 도메인 표현. {@code GeocodeCache} factory / refresh 인자 +
+ * {@link com.todayway.backend.geocode.service.KakaoLocalToGeocodeMapper} 의 변환 결과 가 모두 본
+ * record 를 사용해 9-positional-arg 의 silent argument-swap 위험 (lat/lng 또는 name/address) 차단.
+ *
+ * <p>{@code lat/lng} 는 {@code BigDecimal} — DB DECIMAL(10,7) 정밀도 보존.
+ */
+public record MatchedFields(String name, String address, BigDecimal lat, BigDecimal lng, String placeId) {
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeRequest.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeRequest.java
@@ -1,0 +1,17 @@
+package com.todayway.backend.geocode.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 명세 §8.1 — {@code POST /geocode} 요청. {@code query} 는 주소 또는 장소명.
+ *
+ * <p>{@code @Size(max=255)} 는 V1__init.sql {@code geocode_cache.query_text VARCHAR(255)} 와 동기 —
+ * SQL truncation 500 회피용 1차 가드.
+ */
+public record GeocodeRequest(
+        @NotBlank
+        @Size(max = 255)
+        String query
+) {
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeResponse.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/dto/GeocodeResponse.java
@@ -1,0 +1,36 @@
+package com.todayway.backend.geocode.dto;
+
+import com.todayway.backend.geocode.domain.GeocodeCache;
+
+/**
+ * 명세 §8.1 — {@code POST /geocode} 응답.
+ *
+ * <p>service 흐름상 미스(documents 빈 배열) 는 404 GEOCODE_NO_MATCH 로 던지므로 본 record 는
+ * 항상 매치된 결과 ({@code matched=true}) 만 표현. {@code matched} 필드 자체는 명세 §8.1 응답 예시에
+ * 박혀있으니 그대로 노출.
+ *
+ * <p>{@code provider} 는 명세 §8.1 v1.1.4 변환표대로 {@code "KAKAO_LOCAL"} 그대로 노출 — schedule
+ * 저장 시점에 {@code "KAKAO"} 로 변환하는 책임은 schedule 도메인 (frontend 또는 ScheduleService).
+ */
+public record GeocodeResponse(
+        boolean matched,
+        String name,
+        String address,
+        double lat,
+        double lng,
+        String placeId,
+        String provider
+) {
+
+    public static GeocodeResponse from(GeocodeCache c) {
+        return new GeocodeResponse(
+                c.isMatched(),
+                c.getName(),
+                c.getAddress(),
+                c.getLat() != null ? c.getLat().doubleValue() : 0.0,
+                c.getLng() != null ? c.getLng().doubleValue() : 0.0,
+                c.getPlaceId(),
+                c.getProvider().name()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/repository/GeocodeCacheRepository.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/repository/GeocodeCacheRepository.java
@@ -1,0 +1,24 @@
+package com.todayway.backend.geocode.repository;
+
+import com.todayway.backend.geocode.domain.GeocodeCache;
+import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface GeocodeCacheRepository extends JpaRepository<GeocodeCache, Long> {
+
+    /**
+     * 명세 §8.1 — TTL filter (cached_at > NOW - 30 days) 적용한 cache hit 조회.
+     * UNIQUE (query_hash, provider) 라 단일 row.
+     */
+    Optional<GeocodeCache> findByQueryHashAndProviderAndCachedAtAfter(
+            String queryHash, GeocodeCacheProvider provider, OffsetDateTime cutoff);
+
+    /**
+     * UPSERT race / TTL refresh 흐름에서 만료된 row 까지 fetch (cached_at 무관).
+     * 도메인 흐름: 1차로 위 TTL 쿼리로 hit 확인, miss 시 외부 호출 후 refresh 가 필요하면 본 메서드 사용.
+     */
+    Optional<GeocodeCache> findByQueryHashAndProvider(String queryHash, GeocodeCacheProvider provider);
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
@@ -2,6 +2,7 @@ package com.todayway.backend.geocode.service;
 
 import com.todayway.backend.geocode.domain.GeocodeCache;
 import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.domain.MatchedFields;
 import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -32,15 +33,13 @@ public class GeocodeCacheUpserter {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public GeocodeCache upsertMatch(String queryHash, String queryText, GeocodeCacheProvider provider,
-                                    KakaoLocalToGeocodeMapper.MatchedFields m) {
+                                    MatchedFields fields) {
         Optional<GeocodeCache> existing = repository.findByQueryHashAndProvider(queryHash, provider);
         if (existing.isPresent()) {
-            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            existing.get().refreshAsMatch(queryText, fields);
             return existing.get();
         }
-        return repository.saveAndFlush(GeocodeCache.match(
-                queryHash, queryText, provider,
-                m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+        return repository.saveAndFlush(GeocodeCache.match(queryHash, queryText, provider, fields));
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeCacheUpserter.java
@@ -1,0 +1,55 @@
+package com.todayway.backend.geocode.service;
+
+import com.todayway.backend.geocode.domain.GeocodeCache;
+import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 명세 §8.1 cache UPSERT 의 race-safe 처리. 외부({@link GeocodeService})의 transaction 과 분리된
+ * {@code REQUIRES_NEW} 트랜잭션 안에서 INSERT/UPDATE 를 수행한다.
+ *
+ * <p>왜 별도 service?
+ * {@code saveAndFlush} 후 {@link DataIntegrityViolationException} 이 발생하면 Hibernate 는 현재
+ * session 의 트랜잭션을 rollback-only 로 표시한다. 같은 트랜잭션 안에서 catch 후 entity 를 dirty-
+ * mutate 하면 commit 시점에 {@link org.springframework.transaction.UnexpectedRollbackException}
+ * 으로 떨어져 race window 가 silent 500 으로 변한다. 별도 {@code REQUIRES_NEW} 메서드로 분리하면
+ * 충돌이 inner tx 안에서 끝나고 outer tx 는 영향받지 않는다.
+ *
+ * <p>{@code DataIntegrityViolationException} 은 그대로 outer 로 propagate — outer 가 1회 retry.
+ */
+@Service
+@RequiredArgsConstructor
+public class GeocodeCacheUpserter {
+
+    private final GeocodeCacheRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GeocodeCache upsertMatch(String queryHash, String queryText, GeocodeCacheProvider provider,
+                                    KakaoLocalToGeocodeMapper.MatchedFields m) {
+        Optional<GeocodeCache> existing = repository.findByQueryHashAndProvider(queryHash, provider);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            return existing.get();
+        }
+        return repository.saveAndFlush(GeocodeCache.match(
+                queryHash, queryText, provider,
+                m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public GeocodeCache upsertMiss(String queryHash, String queryText, GeocodeCacheProvider provider) {
+        Optional<GeocodeCache> existing = repository.findByQueryHashAndProvider(queryHash, provider);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMiss(queryText);
+            return existing.get();
+        }
+        return repository.saveAndFlush(GeocodeCache.miss(queryHash, queryText, provider));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -85,8 +85,17 @@ public class GeocodeService {
             throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
         }
 
-        KakaoLocalToGeocodeMapper.MatchedFields m =
-                KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
+        KakaoLocalToGeocodeMapper.MatchedFields m;
+        try {
+            m = KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
+        } catch (NumberFormatException | NullPointerException e) {
+            // Kakao 가 x/y 를 빈 문자열/null/non-numeric 으로 반환 — 명세 §8.1 "외부 API 응답 이상"
+            // 분류로 502 매핑 (catch-all 500 으로 떨어지지 않게). miss 캐시는 안 함 — 일시적
+            // Kakao 응답 손상 가능성이라 다음 호출에서 정상 응답을 받을 기회 보존.
+            log.warn("Kakao Local 응답 매핑 실패 — x/y 비정상 query={}, cause={}",
+                    trimmed, e.getClass().getSimpleName(), e);
+            throw new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
+        }
         GeocodeCache saved = upsertMatch(hash, trimmed, m);
         return GeocodeResponse.from(saved);
     }

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -27,19 +27,13 @@ import java.util.Optional;
 /**
  * 명세 §8.1 — 주소/장소 지오코딩. Kakao Local 외부 호출 + {@code geocode_cache} TTL 30일.
  *
- * <p>흐름:
- * <ol>
- *   <li>{@code queryHash = SHA-256(query.trim())} — 명세 §8.1 v1.1.4 정규화 룰.</li>
- *   <li>TTL filter cache lookup (cached_at &gt; NOW - 30일). hit 면 즉시 응답.</li>
- *   <li>matched=false 캐시 hit → 404 GEOCODE_NO_MATCH (외부 API 호출 차단).</li>
- *   <li>miss → Kakao Local 호출. {@link ExternalApiException} 은 명세 §8.1 매핑표대로
- *       {@link BusinessException} 으로 변환 (401/403 → 503, timeout → 504, 그 외 → 502).</li>
- *   <li>documents 빈 배열 → miss row UPSERT + 404.</li>
- *   <li>매치 → match row UPSERT + 응답.</li>
- * </ol>
- *
- * <p>UPSERT race-safe: existing row 있으면 refresh, 없으면 save. {@link DataIntegrityViolationException}
- * (unique (query_hash, provider) 동시 INSERT 충돌) 은 catch 후 재조회 + refresh.
+ * <p>핵심 invariant:
+ * <ul>
+ *   <li>cache TTL filter — 명세 §8.1 30일. miss 캐시도 hit 처리해 외부 API quota 보호.</li>
+ *   <li>외부 호출 실패 → 명세 §8.1 매핑표 (401/403=503, 5xx=502, timeout=504).</li>
+ *   <li>UPSERT race 는 {@link GeocodeCacheUpserter} 의 {@code REQUIRES_NEW} 트랜잭션이 격리 처리 —
+ *       outer 의 read-only tx 가 inner 의 rollback-only 영향을 받지 않게 한다.</li>
+ * </ul>
  */
 @Service
 @RequiredArgsConstructor
@@ -52,17 +46,9 @@ public class GeocodeService {
     private static final int CACHE_TTL_DAYS = 30;
 
     private final GeocodeCacheRepository cacheRepository;
+    private final GeocodeCacheUpserter cacheUpserter;
     private final KakaoLocalClient kakaoLocalClient;
 
-    /**
-     * {@code noRollbackFor = BusinessException.class} — 의도된 응답 흐름(404 GEOCODE_NO_MATCH /
-     * 502/503/504 외부 API 매핑) 에서도 cache INSERT/refresh 부수효과를 보존하기 위함.
-     * miss 캐시는 명세 §8.1 의 의도 (반복 미스 query 의 외부 API 호출 차단). default rollback 이면
-     * GEOCODE_NO_MATCH 던지는 순간 miss row 가 함께 롤백되어 다음 호출 때 또 Kakao 를 부른다.
-     * 진짜 inconsistency 는 BusinessException 외 RuntimeException (DataAccessException 등) 으로 던져
-     * 자동 롤백.
-     */
-    @Transactional(noRollbackFor = BusinessException.class)
     public GeocodeResponse geocode(GeocodeRequest req) {
         String trimmed = req.query().trim();
         String hash = sha256Hex(trimmed);
@@ -81,7 +67,7 @@ public class GeocodeService {
         KakaoLocalSearchResponse raw = callKakao(trimmed);
 
         if (raw.documents() == null || raw.documents().isEmpty()) {
-            upsertMiss(hash, trimmed);
+            upsertWithRetry(() -> cacheUpserter.upsertMiss(hash, trimmed, PROVIDER), hash);
             throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
         }
 
@@ -90,13 +76,13 @@ public class GeocodeService {
             m = KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
         } catch (NumberFormatException | NullPointerException e) {
             // Kakao 가 x/y 를 빈 문자열/null/non-numeric 으로 반환 — 명세 §8.1 "외부 API 응답 이상"
-            // 분류로 502 매핑 (catch-all 500 으로 떨어지지 않게). miss 캐시는 안 함 — 일시적
-            // Kakao 응답 손상 가능성이라 다음 호출에서 정상 응답을 받을 기회 보존.
+            // 분류로 502 매핑 (catch-all 500 으로 떨어지지 않게).
             log.warn("Kakao Local 응답 매핑 실패 — x/y 비정상 query={}, cause={}",
                     trimmed, e.getClass().getSimpleName(), e);
             throw new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
         }
-        GeocodeCache saved = upsertMatch(hash, trimmed, m);
+        GeocodeCache saved = upsertWithRetry(
+                () -> cacheUpserter.upsertMatch(hash, trimmed, PROVIDER, m), hash);
         return GeocodeResponse.from(saved);
     }
 
@@ -115,43 +101,22 @@ public class GeocodeService {
         }
     }
 
-    private GeocodeCache upsertMatch(String hash, String queryText, KakaoLocalToGeocodeMapper.MatchedFields m) {
-        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
-        if (existing.isPresent()) {
-            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
-            return existing.get();
-        }
+    /**
+     * inner upserter 의 race 충돌은 1회 retry — race window 내 다른 호출이 먼저 INSERT 했다면
+     * findByQueryHashAndProvider 가 즉시 hit 한다. 두 번째 시도도 fail 이면 데이터 불일치 — 500.
+     */
+    private GeocodeCache upsertWithRetry(java.util.function.Supplier<GeocodeCache> action, String hash) {
         try {
-            return cacheRepository.saveAndFlush(
-                    GeocodeCache.match(hash, queryText, PROVIDER,
-                            m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+            return action.get();
         } catch (DataIntegrityViolationException e) {
-            // race: 동시 INSERT 충돌 — 재조회 후 refresh.
-            log.info("Geocode UPSERT match race — retrying via findByQueryHashAndProvider, cause={}",
-                    e.getMostSpecificCause().getClass().getSimpleName());
-            GeocodeCache row = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
-                    .orElseThrow(() -> {
-                        log.error("Geocode UPSERT inconsistency — DataIntegrityViolation but row not found", e);
-                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-                    });
-            row.refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
-            return row;
-        }
-    }
-
-    private void upsertMiss(String hash, String queryText) {
-        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
-        if (existing.isPresent()) {
-            existing.get().refreshAsMiss(queryText);
-            return;
-        }
-        try {
-            cacheRepository.saveAndFlush(GeocodeCache.miss(hash, queryText, PROVIDER));
-        } catch (DataIntegrityViolationException e) {
-            log.info("Geocode UPSERT miss race — retrying via findByQueryHashAndProvider, cause={}",
-                    e.getMostSpecificCause().getClass().getSimpleName());
-            cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
-                    .ifPresent(c -> c.refreshAsMiss(queryText));
+            log.info("Geocode UPSERT race detected — single retry, hash={}, cause={}",
+                    hash, e.getMostSpecificCause().getClass().getSimpleName());
+            try {
+                return action.get();
+            } catch (DataIntegrityViolationException retryEx) {
+                log.error("Geocode UPSERT inconsistency after retry — hash={}", hash, retryEx);
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         }
     }
 
@@ -162,7 +127,6 @@ public class GeocodeService {
                     .digest(input.getBytes(StandardCharsets.UTF_8));
             return HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
-            // SHA-256 은 JDK 표준 — 발생 불가. 발생 시 fail-fast.
             throw new IllegalStateException("SHA-256 not available", e);
         }
     }
@@ -176,7 +140,7 @@ public class GeocodeService {
         return status != null && (status == 401 || status == 403);
     }
 
-    /** 명세 §8.1 매핑표 — ExternalApiException → BusinessException. OdsayRouteService 패턴 미러. */
+    /** 명세 §8.1 매핑표 — ExternalApiException → BusinessException. {@link com.todayway.backend.route.OdsayRouteService} 패턴 미러. */
     private static BusinessException mapToBusinessException(ExternalApiException e) {
         if (isAuthError(e)) {
             return new BusinessException(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -54,7 +54,15 @@ public class GeocodeService {
     private final GeocodeCacheRepository cacheRepository;
     private final KakaoLocalClient kakaoLocalClient;
 
-    @Transactional
+    /**
+     * {@code noRollbackFor = BusinessException.class} — 의도된 응답 흐름(404 GEOCODE_NO_MATCH /
+     * 502/503/504 외부 API 매핑) 에서도 cache INSERT/refresh 부수효과를 보존하기 위함.
+     * miss 캐시는 명세 §8.1 의 의도 (반복 미스 query 의 외부 API 호출 차단). default rollback 이면
+     * GEOCODE_NO_MATCH 던지는 순간 miss row 가 함께 롤백되어 다음 호출 때 또 Kakao 를 부른다.
+     * 진짜 inconsistency 는 BusinessException 외 RuntimeException (DataAccessException 등) 으로 던져
+     * 자동 롤백.
+     */
+    @Transactional(noRollbackFor = BusinessException.class)
     public GeocodeResponse geocode(GeocodeRequest req) {
         String trimmed = req.query().trim();
         String hash = sha256Hex(trimmed);

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -7,6 +7,7 @@ import com.todayway.backend.external.kakao.KakaoLocalClient;
 import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
 import com.todayway.backend.geocode.domain.GeocodeCache;
 import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.domain.MatchedFields;
 import com.todayway.backend.geocode.dto.GeocodeRequest;
 import com.todayway.backend.geocode.dto.GeocodeResponse;
 import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
@@ -71,7 +72,7 @@ public class GeocodeService {
             throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
         }
 
-        KakaoLocalToGeocodeMapper.MatchedFields m;
+        MatchedFields m;
         try {
             m = KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
         } catch (NumberFormatException | NullPointerException e) {

--- a/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/GeocodeService.java
@@ -1,0 +1,173 @@
+package com.todayway.backend.geocode.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.kakao.KakaoLocalClient;
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import com.todayway.backend.geocode.domain.GeocodeCache;
+import com.todayway.backend.geocode.domain.GeocodeCacheProvider;
+import com.todayway.backend.geocode.dto.GeocodeRequest;
+import com.todayway.backend.geocode.dto.GeocodeResponse;
+import com.todayway.backend.geocode.repository.GeocodeCacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * 명세 §8.1 — 주소/장소 지오코딩. Kakao Local 외부 호출 + {@code geocode_cache} TTL 30일.
+ *
+ * <p>흐름:
+ * <ol>
+ *   <li>{@code queryHash = SHA-256(query.trim())} — 명세 §8.1 v1.1.4 정규화 룰.</li>
+ *   <li>TTL filter cache lookup (cached_at &gt; NOW - 30일). hit 면 즉시 응답.</li>
+ *   <li>matched=false 캐시 hit → 404 GEOCODE_NO_MATCH (외부 API 호출 차단).</li>
+ *   <li>miss → Kakao Local 호출. {@link ExternalApiException} 은 명세 §8.1 매핑표대로
+ *       {@link BusinessException} 으로 변환 (401/403 → 503, timeout → 504, 그 외 → 502).</li>
+ *   <li>documents 빈 배열 → miss row UPSERT + 404.</li>
+ *   <li>매치 → match row UPSERT + 응답.</li>
+ * </ol>
+ *
+ * <p>UPSERT race-safe: existing row 있으면 refresh, 없으면 save. {@link DataIntegrityViolationException}
+ * (unique (query_hash, provider) 동시 INSERT 충돌) 은 catch 후 재조회 + refresh.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class GeocodeService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final GeocodeCacheProvider PROVIDER = GeocodeCacheProvider.KAKAO_LOCAL;
+    private static final int CACHE_TTL_DAYS = 30;
+
+    private final GeocodeCacheRepository cacheRepository;
+    private final KakaoLocalClient kakaoLocalClient;
+
+    @Transactional
+    public GeocodeResponse geocode(GeocodeRequest req) {
+        String trimmed = req.query().trim();
+        String hash = sha256Hex(trimmed);
+        OffsetDateTime cutoff = OffsetDateTime.now(KST).minusDays(CACHE_TTL_DAYS);
+
+        Optional<GeocodeCache> fresh = cacheRepository
+                .findByQueryHashAndProviderAndCachedAtAfter(hash, PROVIDER, cutoff);
+        if (fresh.isPresent()) {
+            GeocodeCache c = fresh.get();
+            if (!c.isMatched()) {
+                throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
+            }
+            return GeocodeResponse.from(c);
+        }
+
+        KakaoLocalSearchResponse raw = callKakao(trimmed);
+
+        if (raw.documents() == null || raw.documents().isEmpty()) {
+            upsertMiss(hash, trimmed);
+            throw new BusinessException(ErrorCode.GEOCODE_NO_MATCH);
+        }
+
+        KakaoLocalToGeocodeMapper.MatchedFields m =
+                KakaoLocalToGeocodeMapper.toMatchedFields(raw.documents().get(0));
+        GeocodeCache saved = upsertMatch(hash, trimmed, m);
+        return GeocodeResponse.from(saved);
+    }
+
+    private KakaoLocalSearchResponse callKakao(String query) {
+        try {
+            return kakaoLocalClient.searchKeyword(query);
+        } catch (ExternalApiException e) {
+            if (isAuthError(e)) {
+                log.error("Kakao Local 401/403 (auth 미설정/만료, 운영자 alert) httpStatus={}",
+                        e.getHttpStatus(), e);
+            } else {
+                log.warn("Kakao Local 호출 실패 type={} httpStatus={}",
+                        e.getType(), e.getHttpStatus(), e);
+            }
+            throw mapToBusinessException(e);
+        }
+    }
+
+    private GeocodeCache upsertMatch(String hash, String queryText, KakaoLocalToGeocodeMapper.MatchedFields m) {
+        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            return existing.get();
+        }
+        try {
+            return cacheRepository.saveAndFlush(
+                    GeocodeCache.match(hash, queryText, PROVIDER,
+                            m.name(), m.address(), m.lat(), m.lng(), m.placeId()));
+        } catch (DataIntegrityViolationException e) {
+            // race: 동시 INSERT 충돌 — 재조회 후 refresh.
+            log.info("Geocode UPSERT match race — retrying via findByQueryHashAndProvider, cause={}",
+                    e.getMostSpecificCause().getClass().getSimpleName());
+            GeocodeCache row = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
+                    .orElseThrow(() -> {
+                        log.error("Geocode UPSERT inconsistency — DataIntegrityViolation but row not found", e);
+                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+                    });
+            row.refreshAsMatch(queryText, m.name(), m.address(), m.lat(), m.lng(), m.placeId());
+            return row;
+        }
+    }
+
+    private void upsertMiss(String hash, String queryText) {
+        Optional<GeocodeCache> existing = cacheRepository.findByQueryHashAndProvider(hash, PROVIDER);
+        if (existing.isPresent()) {
+            existing.get().refreshAsMiss(queryText);
+            return;
+        }
+        try {
+            cacheRepository.saveAndFlush(GeocodeCache.miss(hash, queryText, PROVIDER));
+        } catch (DataIntegrityViolationException e) {
+            log.info("Geocode UPSERT miss race — retrying via findByQueryHashAndProvider, cause={}",
+                    e.getMostSpecificCause().getClass().getSimpleName());
+            cacheRepository.findByQueryHashAndProvider(hash, PROVIDER)
+                    .ifPresent(c -> c.refreshAsMiss(queryText));
+        }
+    }
+
+    /** 명세 §8.1 v1.1.4 — query_hash = SHA-256(query.trim()). hex 64자 (CHAR(64) 정합). */
+    private static String sha256Hex(String input) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 은 JDK 표준 — 발생 불가. 발생 시 fail-fast.
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    /** 401/403 — Kakao API 키 미설정/만료. 운영자 alert. */
+    private static boolean isAuthError(ExternalApiException e) {
+        if (e.getType() != ExternalApiException.Type.CLIENT_ERROR) {
+            return false;
+        }
+        Integer status = e.getHttpStatus();
+        return status != null && (status == 401 || status == 403);
+    }
+
+    /** 명세 §8.1 매핑표 — ExternalApiException → BusinessException. OdsayRouteService 패턴 미러. */
+    private static BusinessException mapToBusinessException(ExternalApiException e) {
+        if (isAuthError(e)) {
+            return new BusinessException(ErrorCode.EXTERNAL_AUTH_MISCONFIGURED);
+        }
+        return switch (e.getType()) {
+            case TIMEOUT -> new BusinessException(ErrorCode.EXTERNAL_TIMEOUT);
+            case CLIENT_ERROR, SERVER_ERROR, NETWORK ->
+                    new BusinessException(ErrorCode.EXTERNAL_ROUTE_API_FAILED);
+        };
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.geocode.service;
+
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+
+import java.math.BigDecimal;
+
+/**
+ * 명세 §8.1 v1.1.4 — Kakao Local 응답 → 캐시 entity / 명세 응답 필드 변환 규칙.
+ *
+ * <p>매핑표:
+ * <ul>
+ *   <li>{@code name} ← {@code documents[0].place_name}</li>
+ *   <li>{@code address} ← {@code documents[0].road_address_name} (빈값이면 {@code address_name} fallback)</li>
+ *   <li>{@code lat} ← {@code Double.parseDouble(documents[0].y)} (Kakao 는 string 반환)</li>
+ *   <li>{@code lng} ← {@code Double.parseDouble(documents[0].x)}</li>
+ *   <li>{@code placeId} ← {@code documents[0].id}</li>
+ * </ul>
+ *
+ * <p>{@code matched} / {@code provider} / cache 라이프사이클 결정은 caller 책임 (GeocodeService).
+ */
+final class KakaoLocalToGeocodeMapper {
+
+    private KakaoLocalToGeocodeMapper() {
+    }
+
+    /**
+     * Kakao document → 캐시 INSERT/refresh 에 필요한 매칭 결과 record. lat/lng 는 {@code BigDecimal}
+     * (DB DECIMAL(10,7) 정밀도 보존).
+     */
+    static MatchedFields toMatchedFields(KakaoLocalSearchResponse.Document doc) {
+        return new MatchedFields(
+                doc.placeName(),
+                preferRoadAddress(doc),
+                new BigDecimal(doc.y()),
+                new BigDecimal(doc.x()),
+                doc.id()
+        );
+    }
+
+    private static String preferRoadAddress(KakaoLocalSearchResponse.Document doc) {
+        String road = doc.roadAddressName();
+        if (road != null && !road.isBlank()) {
+            return road;
+        }
+        return doc.addressName();
+    }
+
+    record MatchedFields(String name, String address, BigDecimal lat, BigDecimal lng, String placeId) {
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
+++ b/backend/src/main/java/com/todayway/backend/geocode/service/KakaoLocalToGeocodeMapper.java
@@ -1,18 +1,19 @@
 package com.todayway.backend.geocode.service;
 
 import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import com.todayway.backend.geocode.domain.MatchedFields;
 
 import java.math.BigDecimal;
 
 /**
- * 명세 §8.1 v1.1.4 — Kakao Local 응답 → 캐시 entity / 명세 응답 필드 변환 규칙.
+ * 명세 §8.1 v1.1.4 — Kakao Local 응답 → {@link MatchedFields} 변환 규칙.
  *
  * <p>매핑표:
  * <ul>
  *   <li>{@code name} ← {@code documents[0].place_name}</li>
  *   <li>{@code address} ← {@code documents[0].road_address_name} (빈값이면 {@code address_name} fallback)</li>
- *   <li>{@code lat} ← {@code Double.parseDouble(documents[0].y)} (Kakao 는 string 반환)</li>
- *   <li>{@code lng} ← {@code Double.parseDouble(documents[0].x)}</li>
+ *   <li>{@code lat} ← {@code BigDecimal(documents[0].y)} (Kakao 는 string 반환, DB DECIMAL(10,7) 정밀도 보존)</li>
+ *   <li>{@code lng} ← {@code BigDecimal(documents[0].x)}</li>
  *   <li>{@code placeId} ← {@code documents[0].id}</li>
  * </ul>
  *
@@ -23,10 +24,6 @@ final class KakaoLocalToGeocodeMapper {
     private KakaoLocalToGeocodeMapper() {
     }
 
-    /**
-     * Kakao document → 캐시 INSERT/refresh 에 필요한 매칭 결과 record. lat/lng 는 {@code BigDecimal}
-     * (DB DECIMAL(10,7) 정밀도 보존).
-     */
     static MatchedFields toMatchedFields(KakaoLocalSearchResponse.Document doc) {
         return new MatchedFields(
                 doc.placeName(),
@@ -43,8 +40,5 @@ final class KakaoLocalToGeocodeMapper {
             return road;
         }
         return doc.addressName();
-    }
-
-    record MatchedFields(String name, String address, BigDecimal lat, BigDecimal lng, String placeId) {
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
+++ b/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
@@ -1,0 +1,50 @@
+package com.todayway.backend.map.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 명세 §4.2 — {@code GET /map/config} 정적 응답 source.
+ * {@code application.yml} {@code map.*} 키에서 주입. 운영 환경에서 환경변수 override 허용.
+ *
+ * <p>설정값 자체가 부적합하면 {@code @Validated} 로 ApplicationContext 시작 시점에 fail —
+ * 런타임 503 케이스가 도달하지 않도록 fail-fast.
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "map")
+public class MapConfigProperties {
+
+    /** 클라이언트 지도 SDK 식별자. 명세 §4.2 예시 {@code "NAVER"}. */
+    @NotBlank
+    private String provider;
+
+    /** 초기 줌 레벨. 일반 지도 SDK 범위 (0=세계, 20=상세). */
+    @Min(0)
+    @Max(20)
+    private int defaultZoom;
+
+    /** 위치 정보 부재 시 지도 초기 중심 좌표. */
+    @Valid
+    @NotNull
+    private DefaultCenter defaultCenter;
+
+    /** 타일 스타일 식별자 (예: {@code "basic"}). 클라이언트가 SDK 에 그대로 전달. */
+    @NotBlank
+    private String tileStyle;
+
+    @Getter
+    @Setter
+    public static class DefaultCenter {
+        private double lat;
+        private double lng;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
+++ b/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -16,42 +14,21 @@ import org.springframework.validation.annotation.Validated;
  * 명세 §4.2 — {@code GET /map/config} 정적 응답 source.
  * {@code application.yml} {@code map.*} 키에서 주입. 운영 환경에서 환경변수 override 허용.
  *
- * <p>설정값 자체가 부적합하면 {@code @Validated} 로 ApplicationContext 시작 시점에 fail —
- * 런타임 503 케이스가 도달하지 않도록 fail-fast.
+ * <p>Spring Boot 3 record {@code @ConfigurationProperties} — 불변 + setter 노출 X.
+ * {@code @Validated} 가 ApplicationContext 시작 시점에 fail-fast.
  */
-@Getter
-@Setter
 @Validated
 @ConfigurationProperties(prefix = "map")
-public class MapConfigProperties {
+public record MapConfigProperties(
+        @NotBlank String provider,
+        @Min(0) @Max(20) int defaultZoom,
+        @Valid @NotNull DefaultCenter defaultCenter,
+        @NotBlank String tileStyle
+) {
 
-    /** 클라이언트 지도 SDK 식별자. 명세 §4.2 예시 {@code "NAVER"}. */
-    @NotBlank
-    private String provider;
-
-    /** 초기 줌 레벨. 일반 지도 SDK 범위 (0=세계, 20=상세). */
-    @Min(0)
-    @Max(20)
-    private int defaultZoom;
-
-    /** 위치 정보 부재 시 지도 초기 중심 좌표. */
-    @Valid
-    @NotNull
-    private DefaultCenter defaultCenter;
-
-    /** 타일 스타일 식별자 (예: {@code "basic"}). 클라이언트가 SDK 에 그대로 전달. */
-    @NotBlank
-    private String tileStyle;
-
-    @Getter
-    @Setter
-    public static class DefaultCenter {
-        @DecimalMin("-90.0")
-        @DecimalMax("90.0")
-        private double lat;
-
-        @DecimalMin("-180.0")
-        @DecimalMax("180.0")
-        private double lng;
+    public record DefaultCenter(
+            @DecimalMin("-90.0") @DecimalMax("90.0") double lat,
+            @DecimalMin("-180.0") @DecimalMax("180.0") double lng
+    ) {
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
+++ b/backend/src/main/java/com/todayway/backend/map/config/MapConfigProperties.java
@@ -1,6 +1,8 @@
 package com.todayway.backend.map.config;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -44,7 +46,12 @@ public class MapConfigProperties {
     @Getter
     @Setter
     public static class DefaultCenter {
+        @DecimalMin("-90.0")
+        @DecimalMax("90.0")
         private double lat;
+
+        @DecimalMin("-180.0")
+        @DecimalMax("180.0")
         private double lng;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
+++ b/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 명세 §4 — 메인/지도 (display, settings).
- * <p>{@code GET /main} 게스트 허용 + {@code GET /map/config} 인증 불필요.
- * SecurityConfig.permitAll 에 두 경로 모두 사전 등록되어 있다.
+ * <p>{@code GET /main} 은 명세 §4.1 게스트 허용 ({@code @CurrentMember(required=false)}),
+ * {@code GET /map/config} 는 인증 불필요. 두 경로 모두 통합 테스트가 401 회귀 가드 담당.
  */
 @RestController
 @RequestMapping("/api/v1")

--- a/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
+++ b/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
@@ -1,0 +1,28 @@
+package com.todayway.backend.map.controller;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.map.dto.MapConfigResponse;
+import com.todayway.backend.map.service.MapConfigService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 명세 §4 — 메인/지도 (display, settings).
+ * <p>{@code GET /main} 게스트 허용 + {@code GET /map/config} 인증 불필요.
+ * SecurityConfig.permitAll 에 두 경로 모두 사전 등록되어 있다.
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class MapController {
+
+    private final MapConfigService mapConfigService;
+
+    @GetMapping("/map/config")
+    public ResponseEntity<ApiResponse<MapConfigResponse>> getMapConfig() {
+        return ResponseEntity.ok(ApiResponse.of(mapConfigService.getConfig()));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
+++ b/backend/src/main/java/com/todayway/backend/map/controller/MapController.java
@@ -1,12 +1,16 @@
 package com.todayway.backend.map.controller;
 
 import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.map.dto.MainResponse;
 import com.todayway.backend.map.dto.MapConfigResponse;
+import com.todayway.backend.map.service.MainService;
 import com.todayway.backend.map.service.MapConfigService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -19,7 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MapController {
 
+    private final MainService mainService;
     private final MapConfigService mapConfigService;
+
+    @GetMapping("/main")
+    public ResponseEntity<ApiResponse<MainResponse>> getMain(
+            @CurrentMember(required = false) String memberUid,
+            @RequestParam(required = false) Double lat,
+            @RequestParam(required = false) Double lng) {
+        return ResponseEntity.ok(ApiResponse.of(mainService.compose(memberUid, lat, lng)));
+    }
 
     @GetMapping("/map/config")
     public ResponseEntity<ApiResponse<MapConfigResponse>> getMapConfig() {

--- a/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
@@ -1,11 +1,11 @@
 package com.todayway.backend.map.dto;
 
 /**
- * 명세 §4 응답에 등장하는 위경도 좌표 (예: {@code mapCenter}, {@code defaultCenter}).
+ * 명세 §4 응답의 위경도 좌표 ({@code mapCenter}, {@code defaultCenter}).
  *
- * <p>compact constructor 가 NaN/Infinity/range 를 거부 — {@code Coordinate(0,0)} 같은 silent
- * "Null Island" 좌표는 명세상 valid 범위 안이라 통과시키되, 그 외 비정상 값은 즉시 차단해
- * 클라이언트가 의도한 좌표를 보내지 않은 케이스가 silent corruption 으로 흘러가지 않도록 한다.
+ * <p>compact constructor 가 NaN/Infinity/range 를 거부 — query 파라미터의 비정상 값이 silent 로
+ * 흘러가지 않게 한다. {@code (0, 0)} 은 valid 범위 안이라 통과되지만 운영 측면에선 "Null Island"
+ * 사고 신호일 수 있다 (호출자가 좌표를 셋업 안 한 채 호출).
  */
 public record Coordinate(double lat, double lng) {
 

--- a/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
@@ -2,7 +2,19 @@ package com.todayway.backend.map.dto;
 
 /**
  * 명세 §4 응답에 등장하는 위경도 좌표 (예: {@code mapCenter}, {@code defaultCenter}).
- * 직렬화는 {@code {"lat": ..., "lng": ...}} 형태.
+ *
+ * <p>compact constructor 가 NaN/Infinity/range 를 거부 — {@code Coordinate(0,0)} 같은 silent
+ * "Null Island" 좌표는 명세상 valid 범위 안이라 통과시키되, 그 외 비정상 값은 즉시 차단해
+ * 클라이언트가 의도한 좌표를 보내지 않은 케이스가 silent corruption 으로 흘러가지 않도록 한다.
  */
 public record Coordinate(double lat, double lng) {
+
+    public Coordinate {
+        if (Double.isNaN(lat) || Double.isInfinite(lat) || lat < -90 || lat > 90) {
+            throw new IllegalArgumentException("lat 은 [-90, 90] 범위의 유한 값이어야 함: " + lat);
+        }
+        if (Double.isNaN(lng) || Double.isInfinite(lng) || lng < -180 || lng > 180) {
+            throw new IllegalArgumentException("lng 은 [-180, 180] 범위의 유한 값이어야 함: " + lng);
+        }
+    }
 }

--- a/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/Coordinate.java
@@ -1,0 +1,8 @@
+package com.todayway.backend.map.dto;
+
+/**
+ * 명세 §4 응답에 등장하는 위경도 좌표 (예: {@code mapCenter}, {@code defaultCenter}).
+ * 직렬화는 {@code {"lat": ..., "lng": ...}} 형태.
+ */
+public record Coordinate(double lat, double lng) {
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MainPlaceDto.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MainPlaceDto.java
@@ -1,0 +1,8 @@
+package com.todayway.backend.map.dto;
+
+/**
+ * 명세 §4.1 — {@code nearestSchedule.origin / destination} 의 응답 형태.
+ * 명세 §11.1 {@code Place} 의 sub-shape (name + 좌표만 노출).
+ */
+public record MainPlaceDto(String name, double lat, double lng) {
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
@@ -1,17 +1,14 @@
 package com.todayway.backend.map.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 /**
  * 명세 §4.1 — {@code GET /main} 응답.
  *
- * <p>{@code nearestSchedule} 은 미인증 / 미래 일정 없을 시 {@code null}. Jackson 의
- * {@code @JsonInclude(NON_NULL)} 로 직렬화에서 키 자체가 사라지지 않도록 record 레벨에는 적용하지
- * 않고 그대로 둔다 — 명세 §4.1 응답 예시에 {@code nearestSchedule} 키가 항상 등장하기 때문.
- * 다만 mapCenter 는 항상 채워진다.
+ * <p>{@code nearestSchedule} 은 미인증 / 미래 일정 없을 시 {@code null} 로 직렬화되어 명세 응답 예시의
+ * {@code "nearestSchedule": null} 과 정합. {@code application.yml} 에 global non-null 설정이 없고
+ * Jackson 의 디폴트가 {@code Include.ALWAYS} 라 별도 어노테이션 불필요. {@code mapCenter} 는 항상 채워진다.
  */
 public record MainResponse(
-        @JsonInclude NearestScheduleDto nearestSchedule,
+        NearestScheduleDto nearestSchedule,
         Coordinate mapCenter
 ) {
 }

--- a/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MainResponse.java
@@ -1,0 +1,17 @@
+package com.todayway.backend.map.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * 명세 §4.1 — {@code GET /main} 응답.
+ *
+ * <p>{@code nearestSchedule} 은 미인증 / 미래 일정 없을 시 {@code null}. Jackson 의
+ * {@code @JsonInclude(NON_NULL)} 로 직렬화에서 키 자체가 사라지지 않도록 record 레벨에는 적용하지
+ * 않고 그대로 둔다 — 명세 §4.1 응답 예시에 {@code nearestSchedule} 키가 항상 등장하기 때문.
+ * 다만 mapCenter 는 항상 채워진다.
+ */
+public record MainResponse(
+        @JsonInclude NearestScheduleDto nearestSchedule,
+        Coordinate mapCenter
+) {
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
@@ -1,0 +1,23 @@
+package com.todayway.backend.map.dto;
+
+import com.todayway.backend.map.config.MapConfigProperties;
+
+/**
+ * 명세 §4.2 — {@code GET /map/config} 응답. 클라이언트 API 키는 포함하지 않는다 (프론트 빌드시 주입).
+ */
+public record MapConfigResponse(
+        String provider,
+        int defaultZoom,
+        Coordinate defaultCenter,
+        String tileStyle
+) {
+
+    public static MapConfigResponse from(MapConfigProperties p) {
+        return new MapConfigResponse(
+                p.getProvider(),
+                p.getDefaultZoom(),
+                new Coordinate(p.getDefaultCenter().getLat(), p.getDefaultCenter().getLng()),
+                p.getTileStyle()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/MapConfigResponse.java
@@ -14,10 +14,10 @@ public record MapConfigResponse(
 
     public static MapConfigResponse from(MapConfigProperties p) {
         return new MapConfigResponse(
-                p.getProvider(),
-                p.getDefaultZoom(),
-                new Coordinate(p.getDefaultCenter().getLat(), p.getDefaultCenter().getLng()),
-                p.getTileStyle()
+                p.provider(),
+                p.defaultZoom(),
+                new Coordinate(p.defaultCenter().lat(), p.defaultCenter().lng()),
+                p.tileStyle()
         );
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
@@ -1,0 +1,39 @@
+package com.todayway.backend.map.dto;
+
+import com.todayway.backend.common.web.IdPrefixes;
+import com.todayway.backend.schedule.domain.Schedule;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 명세 §4.1 {@code data.nearestSchedule} 응답. 시간상 가장 가까운 미래 일정 한 건.
+ * 미인증 또는 일정 없을 시 응답에서 {@code null}.
+ *
+ * <p>{@code hasCalculatedRoute} 는 명세 §4.1 비고대로 {@code route_summary_json IS NOT NULL} 여부.
+ */
+public record NearestScheduleDto(
+        String scheduleId,
+        String title,
+        OffsetDateTime arrivalTime,
+        MainPlaceDto origin,
+        MainPlaceDto destination,
+        boolean hasCalculatedRoute,
+        OffsetDateTime recommendedDepartureTime,
+        OffsetDateTime reminderAt
+) {
+
+    public static NearestScheduleDto from(Schedule s) {
+        return new NearestScheduleDto(
+                IdPrefixes.SCHEDULE + s.getScheduleUid(),
+                s.getTitle(),
+                s.getArrivalTime(),
+                new MainPlaceDto(s.getOriginName(),
+                        s.getOriginLat().doubleValue(), s.getOriginLng().doubleValue()),
+                new MainPlaceDto(s.getDestinationName(),
+                        s.getDestinationLat().doubleValue(), s.getDestinationLng().doubleValue()),
+                s.getRouteSummaryJson() != null,
+                s.getRecommendedDepartureTime(),
+                s.getReminderAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
+++ b/backend/src/main/java/com/todayway/backend/map/dto/NearestScheduleDto.java
@@ -23,6 +23,11 @@ public record NearestScheduleDto(
 ) {
 
     public static NearestScheduleDto from(Schedule s) {
+        // V1 schema 는 origin/destination lat/lng 를 NOT NULL 로 강제하지만 JPA field 는 BigDecimal
+        // (JVM-nullable). DB 마이그레이션 / 직접 SQL 우회 등으로 null 이 흘러들어오면 NPE → 500 generic
+        // 으로 떨어지므로 명시 가드 + scheduleUid 를 메시지에 박아 운영 진단 가능하게 한다.
+        requireCoord(s.getOriginLat(), s.getOriginLng(), "origin", s.getScheduleUid());
+        requireCoord(s.getDestinationLat(), s.getDestinationLng(), "destination", s.getScheduleUid());
         return new NearestScheduleDto(
                 IdPrefixes.SCHEDULE + s.getScheduleUid(),
                 s.getTitle(),
@@ -35,5 +40,13 @@ public record NearestScheduleDto(
                 s.getRecommendedDepartureTime(),
                 s.getReminderAt()
         );
+    }
+
+    private static void requireCoord(java.math.BigDecimal lat, java.math.BigDecimal lng,
+                                     String label, String scheduleUid) {
+        if (lat == null || lng == null) {
+            throw new IllegalStateException(
+                    "Schedule " + scheduleUid + " has null " + label + " coordinate (data corruption)");
+        }
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/service/MainService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MainService.java
@@ -74,7 +74,7 @@ public class MainService {
         if (nearest != null) {
             return new Coordinate(nearest.origin().lat(), nearest.origin().lng());
         }
-        MapConfigProperties.DefaultCenter dc = mapConfigProperties.getDefaultCenter();
-        return new Coordinate(dc.getLat(), dc.getLng());
+        MapConfigProperties.DefaultCenter dc = mapConfigProperties.defaultCenter();
+        return new Coordinate(dc.lat(), dc.lng());
     }
 }

--- a/backend/src/main/java/com/todayway/backend/map/service/MainService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MainService.java
@@ -8,6 +8,7 @@ import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.repository.MemberRepository;
 import com.todayway.backend.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,7 @@ import java.time.ZoneId;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class MainService {
 
@@ -50,11 +52,17 @@ public class MainService {
         }
         // 탈퇴 회원의 토큰이 살아있는 경우 — 명세 §1.7 / §3.3 정합으로 nearestSchedule = null
         // (UNAUTHORIZED 던지지 않고 graceful 게스트 처리. 로그인 필요 흐름은 다른 endpoint 가 담당).
-        return memberRepository.findByMemberUid(memberUid)
+        // 단 silent 처리는 token-revocation 파이프라인 고장을 가리므로 WARN 로깅으로 신호 보존.
+        Long memberId = memberRepository.findByMemberUid(memberUid)
                 .map(Member::getId)
-                .flatMap(memberId -> scheduleRepository
-                        .findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(
-                                memberId, OffsetDateTime.now(KST)))
+                .orElse(null);
+        if (memberId == null) {
+            log.warn("Authenticated /main with valid JWT but member not found — graceful guest fallback. memberUid={}",
+                    memberUid);
+            return null;
+        }
+        return scheduleRepository
+                .findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(memberId, OffsetDateTime.now(KST))
                 .map(NearestScheduleDto::from)
                 .orElse(null);
     }

--- a/backend/src/main/java/com/todayway/backend/map/service/MainService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MainService.java
@@ -1,0 +1,72 @@
+package com.todayway.backend.map.service;
+
+import com.todayway.backend.map.config.MapConfigProperties;
+import com.todayway.backend.map.dto.Coordinate;
+import com.todayway.backend.map.dto.MainResponse;
+import com.todayway.backend.map.dto.NearestScheduleDto;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+/**
+ * 명세 §4.1 — {@code GET /main} 메인 화면 데이터 조회 (게스트 허용).
+ *
+ * <p>{@code memberUid} 가 {@code null} 인 게스트 호출은 nearestSchedule=null 로 응답.
+ * 인증된 호출은 시간상 가장 가까운 미래 일정 한 건을 노출.
+ *
+ * <p>mapCenter 결정 우선순위 (명세 §4.1 비고):
+ * <ol>
+ *   <li>query lat/lng</li>
+ *   <li>nearestSchedule.origin</li>
+ *   <li>{@link MapConfigProperties} default-center (예: 서울시청)</li>
+ * </ol>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MainService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final MapConfigProperties mapConfigProperties;
+
+    public MainResponse compose(String memberUid, Double lat, Double lng) {
+        NearestScheduleDto nearest = resolveNearest(memberUid);
+        Coordinate mapCenter = decideMapCenter(lat, lng, nearest);
+        return new MainResponse(nearest, mapCenter);
+    }
+
+    private NearestScheduleDto resolveNearest(String memberUid) {
+        if (memberUid == null) {
+            return null;
+        }
+        // 탈퇴 회원의 토큰이 살아있는 경우 — 명세 §1.7 / §3.3 정합으로 nearestSchedule = null
+        // (UNAUTHORIZED 던지지 않고 graceful 게스트 처리. 로그인 필요 흐름은 다른 endpoint 가 담당).
+        return memberRepository.findByMemberUid(memberUid)
+                .map(Member::getId)
+                .flatMap(memberId -> scheduleRepository
+                        .findFirstByMemberIdAndArrivalTimeAfterOrderByArrivalTimeAsc(
+                                memberId, OffsetDateTime.now(KST)))
+                .map(NearestScheduleDto::from)
+                .orElse(null);
+    }
+
+    private Coordinate decideMapCenter(Double lat, Double lng, NearestScheduleDto nearest) {
+        if (lat != null && lng != null) {
+            return new Coordinate(lat, lng);
+        }
+        if (nearest != null) {
+            return new Coordinate(nearest.origin().lat(), nearest.origin().lng());
+        }
+        MapConfigProperties.DefaultCenter dc = mapConfigProperties.getDefaultCenter();
+        return new Coordinate(dc.getLat(), dc.getLng());
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
@@ -1,0 +1,24 @@
+package com.todayway.backend.map.service;
+
+import com.todayway.backend.map.config.MapConfigProperties;
+import com.todayway.backend.map.dto.MapConfigResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 명세 §4.2 — 지도 SDK 설정 정적 응답. DB 미사용.
+ *
+ * <p>설정값 자체가 부적합하면 {@link MapConfigProperties} 의 {@code @Validated} 가 ApplicationContext
+ * 시작 시점에 fail 시키므로 본 service 는 단순 변환만 수행. 명세에 박힌 503 MAP_PROVIDER_UNAVAILABLE 은
+ * 정적 설정 흐름에서는 도달 불가 (P1 — 외부 SDK 헬스체크 도입 시 발화 예정).
+ */
+@Service
+@RequiredArgsConstructor
+public class MapConfigService {
+
+    private final MapConfigProperties properties;
+
+    public MapConfigResponse getConfig() {
+        return MapConfigResponse.from(properties);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
+++ b/backend/src/main/java/com/todayway/backend/map/service/MapConfigService.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
  * 명세 §4.2 — 지도 SDK 설정 정적 응답. DB 미사용.
  *
  * <p>설정값 자체가 부적합하면 {@link MapConfigProperties} 의 {@code @Validated} 가 ApplicationContext
- * 시작 시점에 fail 시키므로 본 service 는 단순 변환만 수행. 명세에 박힌 503 MAP_PROVIDER_UNAVAILABLE 은
- * 정적 설정 흐름에서는 도달 불가 (P1 — 외부 SDK 헬스체크 도입 시 발화 예정).
+ * 시작 시점에 fail 시키므로 본 service 는 단순 변환만 수행. 명세 §4.2 의 503 MAP_PROVIDER_UNAVAILABLE
+ * 은 정적 설정 흐름에선 도달 불가 — 외부 SDK 헬스체크가 추가될 때 발화 경로가 생긴다.
  */
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
@@ -57,11 +57,7 @@ public class MemberService {
 
     @Transactional
     public void softDelete(String memberUid) {
-        // 의사결정 4 (가-1) cascade — Step 5 + Step 7 진입으로 모두 충족 (Issue #8 + #9):
-        //   ✅ Member.deleted_at (자체)
-        //   ✅ refresh_token.revoked_at 일괄
-        //   ✅ schedule.deleted_at 일괄 (β PR + Step 5 — closes #8)
-        //   ✅ push_subscription.revoked_at 일괄 (이상진 Step 7 — closes #9)
+        // soft-delete cascade 는 코드 레벨에서만 보장 — DB FK CASCADE 는 hard-delete 시에만 동작.
         Member m = memberRepository.findByMemberUid(memberUid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
         m.softDelete();

--- a/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/todayway/backend/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.todayway.backend.member.domain.Member;
 import com.todayway.backend.member.dto.MemberResponse;
 import com.todayway.backend.member.dto.MemberUpdateRequest;
 import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
 import com.todayway.backend.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final ScheduleRepository scheduleRepository;
+    private final PushSubscriptionRepository pushSubscriptionRepository;
     private final PasswordEncoder passwordEncoder;
 
     public MemberResponse getMe(String memberUid) {
@@ -55,18 +57,19 @@ public class MemberService {
 
     @Transactional
     public void softDelete(String memberUid) {
-        // 의사결정 4 (가-1) cascade — Step 5 진입으로 schedule 추가 (Issue #8):
+        // 의사결정 4 (가-1) cascade — Step 5 + Step 7 진입으로 모두 충족 (Issue #8 + #9):
         //   ✅ Member.deleted_at (자체)
         //   ✅ refresh_token.revoked_at 일괄
         //   ✅ schedule.deleted_at 일괄 (β PR + Step 5 — closes #8)
-        //   ⏳ push_subscription.revoked_at — 이상진 Step 7 진입 시 추가 (#9)
+        //   ✅ push_subscription.revoked_at 일괄 (이상진 Step 7 — closes #9)
         Member m = memberRepository.findByMemberUid(memberUid)
                 .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
         m.softDelete();
         OffsetDateTime now = OffsetDateTime.now(KST);
-        int revoked = refreshTokenRepository.revokeAllActiveByMemberId(m.getId(), now);
+        int revokedTokens = refreshTokenRepository.revokeAllActiveByMemberId(m.getId(), now);
         int deletedSchedules = scheduleRepository.softDeleteByMemberId(m.getId(), now);
-        log.info("revoked {} active refresh tokens, soft-deleted {} schedules for memberId={} (member soft delete)",
-                revoked, deletedSchedules, m.getId());
+        int revokedSubscriptions = pushSubscriptionRepository.revokeAllByMemberId(m.getId(), now);
+        log.info("member soft delete cascade — memberId={} : refresh tokens={}, schedules={}, push subscriptions={}",
+                m.getId(), revokedTokens, deletedSchedules, revokedSubscriptions);
     }
 }

--- a/backend/src/main/java/com/todayway/backend/push/controller/PushController.java
+++ b/backend/src/main/java/com/todayway/backend/push/controller/PushController.java
@@ -1,0 +1,59 @@
+package com.todayway.backend.push.controller;
+
+import com.todayway.backend.common.response.ApiResponse;
+import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.push.dto.PushSubscribeRequest;
+import com.todayway.backend.push.dto.PushSubscribeResponse;
+import com.todayway.backend.push.service.PushService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 명세 §7.1 / §7.2 — Web Push 구독 등록/해제.
+ * <p>인증/인가 검증은 {@link PushService} 가 담당. 본 controller 는 HTTP 레이어 변환만 —
+ * {@code sub_} prefix strip + {@link ApiResponse} 래핑 + 명세 응답 코드 (201 Created / 204 No Content).
+ */
+@RestController
+@RequestMapping("/api/v1/push")
+@RequiredArgsConstructor
+public class PushController {
+
+    private static final String SUBSCRIPTION_ID_PREFIX = "sub_";
+
+    private final PushService pushService;
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<ApiResponse<PushSubscribeResponse>> subscribe(
+            @CurrentMember String memberUid,
+            @Valid @RequestBody PushSubscribeRequest request,
+            @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) String userAgent) {
+        PushSubscribeResponse resp = pushService.subscribe(memberUid, request, userAgent);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(resp));
+    }
+
+    @DeleteMapping("/subscribe/{subscriptionId}")
+    public ResponseEntity<Void> unsubscribe(
+            @CurrentMember String memberUid,
+            @PathVariable String subscriptionId) {
+        pushService.unsubscribe(memberUid, stripPrefix(subscriptionId));
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 명세 §1.7 — 외부 노출 ID는 {@code sub_} prefix. 내부 ULID로 변환. */
+    private static String stripPrefix(String subscriptionId) {
+        if (subscriptionId != null && subscriptionId.startsWith(SUBSCRIPTION_ID_PREFIX)) {
+            return subscriptionId.substring(SUBSCRIPTION_ID_PREFIX.length());
+        }
+        return subscriptionId;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/controller/PushController.java
+++ b/backend/src/main/java/com/todayway/backend/push/controller/PushController.java
@@ -2,6 +2,7 @@ package com.todayway.backend.push.controller;
 
 import com.todayway.backend.common.response.ApiResponse;
 import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.common.web.IdPrefixes;
 import com.todayway.backend.push.dto.PushSubscribeRequest;
 import com.todayway.backend.push.dto.PushSubscribeResponse;
 import com.todayway.backend.push.service.PushService;
@@ -21,14 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 명세 §7.1 / §7.2 — Web Push 구독 등록/해제.
  * <p>인증/인가 검증은 {@link PushService} 가 담당. 본 controller 는 HTTP 레이어 변환만 —
- * {@code sub_} prefix strip + {@link ApiResponse} 래핑 + 명세 응답 코드 (201 Created / 204 No Content).
+ * {@link IdPrefixes#SUBSCRIPTION} prefix strip + {@link ApiResponse} 래핑 + 명세 응답 코드.
  */
 @RestController
 @RequestMapping("/api/v1/push")
 @RequiredArgsConstructor
 public class PushController {
-
-    private static final String SUBSCRIPTION_ID_PREFIX = "sub_";
 
     private final PushService pushService;
 
@@ -45,15 +44,7 @@ public class PushController {
     public ResponseEntity<Void> unsubscribe(
             @CurrentMember String memberUid,
             @PathVariable String subscriptionId) {
-        pushService.unsubscribe(memberUid, stripPrefix(subscriptionId));
+        pushService.unsubscribe(memberUid, IdPrefixes.strip(subscriptionId, IdPrefixes.SUBSCRIPTION));
         return ResponseEntity.noContent().build();
-    }
-
-    /** 명세 §1.7 — 외부 노출 ID는 {@code sub_} prefix. 내부 ULID로 변환. */
-    private static String stripPrefix(String subscriptionId) {
-        if (subscriptionId != null && subscriptionId.startsWith(SUBSCRIPTION_ID_PREFIX)) {
-            return subscriptionId.substring(SUBSCRIPTION_ID_PREFIX.length());
-        }
-        return subscriptionId;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushLog.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushLog.java
@@ -1,0 +1,86 @@
+package com.todayway.backend.push.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+/**
+ * 푸시 발송 이력 (append-only). 명세 §9.1 / V1__init.sql {@code push_log}.
+ *
+ * <p>변경 메서드가 없는 immutable record-like entity. 발송 직후 한 번 INSERT 되고
+ * 이후 어떤 변경도 일어나지 않는다 — BaseEntity 미상속, {@code sent_at} 만 PrePersist.
+ *
+ * <p>{@code subscription_id} FK CASCADE — 구독 row가 hard-delete 되면 로그도 함께 사라짐.
+ * 그래서 {@link PushSubscription} 은 {@link PushSubscription#revoke()} (soft) 만 사용.
+ */
+@Getter
+@Entity
+@Table(name = "push_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PushLog {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "subscription_id", nullable = false, updatable = false)
+    private Long subscriptionId;
+
+    @Column(name = "schedule_id", updatable = false)
+    private Long scheduleId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "push_type", nullable = false, updatable = false,
+            columnDefinition = "ENUM('REMINDER')")
+    private PushType pushType;
+
+    @Column(name = "payload_json", updatable = false, columnDefinition = "JSON")
+    private String payloadJson;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, updatable = false,
+            columnDefinition = "ENUM('SENT','FAILED','EXPIRED')")
+    private PushStatus status;
+
+    @Column(name = "http_status", updatable = false)
+    private Integer httpStatus;
+
+    @Column(name = "sent_at", nullable = false, updatable = false)
+    private OffsetDateTime sentAt;
+
+    private PushLog(Long subscriptionId, Long scheduleId, PushType pushType,
+                    PushStatus status, Integer httpStatus, String payloadJson) {
+        this.subscriptionId = subscriptionId;
+        this.scheduleId = scheduleId;
+        this.pushType = pushType;
+        this.status = status;
+        this.httpStatus = httpStatus;
+        this.payloadJson = payloadJson;
+    }
+
+    public static PushLog record(Long subscriptionId, Long scheduleId, PushType pushType,
+                                 PushStatus status, Integer httpStatus, String payloadJson) {
+        return new PushLog(subscriptionId, scheduleId, pushType, status, httpStatus, payloadJson);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (sentAt == null) {
+            sentAt = OffsetDateTime.now(KST);
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushStatus.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushStatus.java
@@ -1,0 +1,16 @@
+package com.todayway.backend.push.domain;
+
+/**
+ * 명세 §9.1 + DB-SQL.txt {@code push_log.status} ENUM.
+ *
+ * <ul>
+ *   <li>{@link #SENT} — Web Push 서버 응답 200/201 (정상 발송)</li>
+ *   <li>{@link #EXPIRED} — 응답 410 Gone (브라우저 구독 만료, 자동 revoke 트리거)</li>
+ *   <li>{@link #FAILED} — 그 외 모든 실패 (네트워크/타임아웃/4xx-5xx)</li>
+ * </ul>
+ */
+public enum PushStatus {
+    SENT,
+    FAILED,
+    EXPIRED
+}

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushSubscription.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushSubscription.java
@@ -68,13 +68,18 @@ public class PushSubscription {
     private OffsetDateTime revokedAt;
 
     private PushSubscription(Long memberId, String endpoint, String p256dhKey, String authKey, String userAgent) {
-        this.memberId = Objects.requireNonNull(memberId, "memberId");
-        this.endpoint = requireNonBlank(endpoint, "endpoint");
-        this.p256dhKey = requireNonBlank(p256dhKey, "p256dhKey");
-        this.authKey = requireNonBlank(authKey, "authKey");
+        this.memberId = memberId;
+        this.endpoint = endpoint;
+        this.p256dhKey = p256dhKey;
+        this.authKey = authKey;
         this.userAgent = userAgent;
     }
 
+    /**
+     * 입력 검증은 호출자(DTO {@code @NotBlank} / Service)의 책임. 본 entity 는 검증 X —
+     * IllegalArgumentException 으로 entity 검증을 추가하면 GlobalExceptionHandler 에 해당 핸들러가
+     * 없어 silent 500 으로 떨어진다. 컬럼 제약(NOT NULL / UNIQUE / VARCHAR length) 으로 DB 레벨 가드.
+     */
     public static PushSubscription create(Long memberId, String endpoint, String p256dhKey, String authKey,
                                           String userAgent) {
         return new PushSubscription(memberId, endpoint, p256dhKey, authKey, userAgent);
@@ -100,10 +105,11 @@ public class PushSubscription {
 
     /**
      * 명세 §7.1 — 브라우저가 키 회전한 케이스 반영 (재구독 시 키/UA 갱신, {@code revoked_at} 해제).
+     * 입력 검증은 호출자 책임 (DTO {@code @NotBlank}).
      */
     public void reactivate(String p256dhKey, String authKey, String userAgent) {
-        this.p256dhKey = requireNonBlank(p256dhKey, "p256dhKey");
-        this.authKey = requireNonBlank(authKey, "authKey");
+        this.p256dhKey = p256dhKey;
+        this.authKey = authKey;
         this.userAgent = userAgent;
         this.revokedAt = null;
     }
@@ -115,12 +121,5 @@ public class PushSubscription {
         if (revokedAt == null) {
             revokedAt = OffsetDateTime.now(KST);
         }
-    }
-
-    private static String requireNonBlank(String value, String name) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException(name + " must not be blank");
-        }
-        return value;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushSubscription.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushSubscription.java
@@ -1,0 +1,115 @@
+package com.todayway.backend.push.domain;
+
+import com.todayway.backend.common.ulid.UlidGenerator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+/**
+ * Web Push 구독 (사용자 1명 = 기기당 1행). 명세 §7 / V1__init.sql {@code push_subscription} 정합.
+ *
+ * <p>row 자체는 hard-delete 하지 않고 {@code revoked_at} 으로 활성/비활성을 구분한다 —
+ * push_log FK가 ON DELETE CASCADE라 row 삭제 시 발송 이력까지 사라지기 때문.
+ * 따라서 BaseEntity 미상속 ({@code updated_at} 컬럼 없음, {@code created_at} 만 PrePersist).
+ *
+ * <p>활성 구독 조회는 항상 {@code revoked_at IS NULL} 조건을 붙여야 한다 (Repository 메서드에 명시).
+ * {@code @SQLRestriction} 사용 X — soft-delete 의미가 다름 (revoke는 사용자 의도, deleted는 삭제).
+ */
+@Getter
+@Entity
+@Table(name = "push_subscription")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PushSubscription {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "subscription_uid", nullable = false, updatable = false, unique = true,
+            columnDefinition = "CHAR(26)")
+    private String subscriptionUid;
+
+    @Column(name = "member_id", nullable = false, updatable = false)
+    private Long memberId;
+
+    @Column(name = "endpoint", nullable = false, unique = true, length = 500)
+    private String endpoint;
+
+    @Column(name = "p256dh_key", nullable = false, length = 255)
+    private String p256dhKey;
+
+    @Column(name = "auth_key", nullable = false, length = 255)
+    private String authKey;
+
+    @Column(name = "user_agent", length = 255)
+    private String userAgent;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "revoked_at")
+    private OffsetDateTime revokedAt;
+
+    private PushSubscription(Long memberId, String endpoint, String p256dhKey, String authKey, String userAgent) {
+        this.memberId = memberId;
+        this.endpoint = endpoint;
+        this.p256dhKey = p256dhKey;
+        this.authKey = authKey;
+        this.userAgent = userAgent;
+    }
+
+    public static PushSubscription create(Long memberId, String endpoint, String p256dhKey, String authKey,
+                                          String userAgent) {
+        return new PushSubscription(memberId, endpoint, p256dhKey, authKey, userAgent);
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (subscriptionUid == null) {
+            subscriptionUid = UlidGenerator.generate();
+        }
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(KST);
+        }
+    }
+
+    public boolean isActive() {
+        return revokedAt == null;
+    }
+
+    public boolean belongsTo(Long memberId) {
+        return this.memberId.equals(memberId);
+    }
+
+    /**
+     * 명세 §7.1 — 동일 endpoint 재구독 시 호출. {@code revoked_at} 을 {@code NULL} 로 되돌리고
+     * 키/UA 갱신 (브라우저가 키 회전했을 가능성 반영).
+     */
+    public void reactivate(String p256dhKey, String authKey, String userAgent) {
+        this.p256dhKey = p256dhKey;
+        this.authKey = authKey;
+        this.userAgent = userAgent;
+        this.revokedAt = null;
+    }
+
+    /**
+     * 명세 §7.2 — soft revoke. 멱등 (이미 revoked면 시각 보존).
+     */
+    public void revoke() {
+        if (revokedAt == null) {
+            revokedAt = OffsetDateTime.now(KST);
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushSubscription.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushSubscription.java
@@ -14,16 +14,21 @@ import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Objects;
 
 /**
  * Web Push 구독 (사용자 1명 = 기기당 1행). 명세 §7 / V1__init.sql {@code push_subscription} 정합.
  *
  * <p>row 자체는 hard-delete 하지 않고 {@code revoked_at} 으로 활성/비활성을 구분한다 —
- * push_log FK가 ON DELETE CASCADE라 row 삭제 시 발송 이력까지 사라지기 때문.
+ * push_log FK 가 ON DELETE CASCADE 라 row 삭제 시 발송 이력까지 사라지기 때문.
  * 따라서 BaseEntity 미상속 ({@code updated_at} 컬럼 없음, {@code created_at} 만 PrePersist).
  *
  * <p>활성 구독 조회는 항상 {@code revoked_at IS NULL} 조건을 붙여야 한다 (Repository 메서드에 명시).
- * {@code @SQLRestriction} 사용 X — soft-delete 의미가 다름 (revoke는 사용자 의도, deleted는 삭제).
+ * {@code @SQLRestriction} 사용 X — soft-delete 의미가 다름 (revoke 는 사용자 의도, deleted 는 삭제).
+ *
+ * <p>{@code endpoint} 와 {@code member_id} 모두 {@code updatable=false} — UPSERT 의 row 식별자
+ * (endpoint UNIQUE) 와 소유자(member_id) 모두 INSERT 후 변경 X. 변경 시 silent identity drift
+ * 위험이라 컬럼 레벨에서 차단.
  */
 @Getter
 @Entity
@@ -44,7 +49,7 @@ public class PushSubscription {
     @Column(name = "member_id", nullable = false, updatable = false)
     private Long memberId;
 
-    @Column(name = "endpoint", nullable = false, unique = true, length = 500)
+    @Column(name = "endpoint", nullable = false, updatable = false, unique = true, length = 500)
     private String endpoint;
 
     @Column(name = "p256dh_key", nullable = false, length = 255)
@@ -63,10 +68,10 @@ public class PushSubscription {
     private OffsetDateTime revokedAt;
 
     private PushSubscription(Long memberId, String endpoint, String p256dhKey, String authKey, String userAgent) {
-        this.memberId = memberId;
-        this.endpoint = endpoint;
-        this.p256dhKey = p256dhKey;
-        this.authKey = authKey;
+        this.memberId = Objects.requireNonNull(memberId, "memberId");
+        this.endpoint = requireNonBlank(endpoint, "endpoint");
+        this.p256dhKey = requireNonBlank(p256dhKey, "p256dhKey");
+        this.authKey = requireNonBlank(authKey, "authKey");
         this.userAgent = userAgent;
     }
 
@@ -90,26 +95,32 @@ public class PushSubscription {
     }
 
     public boolean belongsTo(Long memberId) {
-        return this.memberId.equals(memberId);
+        return Objects.equals(this.memberId, memberId);
     }
 
     /**
-     * 명세 §7.1 — 동일 endpoint 재구독 시 호출. {@code revoked_at} 을 {@code NULL} 로 되돌리고
-     * 키/UA 갱신 (브라우저가 키 회전했을 가능성 반영).
+     * 명세 §7.1 — 브라우저가 키 회전한 케이스 반영 (재구독 시 키/UA 갱신, {@code revoked_at} 해제).
      */
     public void reactivate(String p256dhKey, String authKey, String userAgent) {
-        this.p256dhKey = p256dhKey;
-        this.authKey = authKey;
+        this.p256dhKey = requireNonBlank(p256dhKey, "p256dhKey");
+        this.authKey = requireNonBlank(authKey, "authKey");
         this.userAgent = userAgent;
         this.revokedAt = null;
     }
 
     /**
-     * 명세 §7.2 — soft revoke. 멱등 (이미 revoked면 시각 보존).
+     * 명세 §7.2 — soft revoke. 멱등 (이미 revoked 면 시각 보존).
      */
     public void revoke() {
         if (revokedAt == null) {
             revokedAt = OffsetDateTime.now(KST);
         }
+    }
+
+    private static String requireNonBlank(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushType.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushType.java
@@ -1,8 +1,7 @@
 package com.todayway.backend.push.domain;
 
 /**
- * 명세 §V1 + DB-SQL.txt {@code push_log.push_type} ENUM. MVP는 REMINDER만.
- * 신규 타입 추가 시 V2 마이그레이션으로 컬럼 ENUM 확장 필요.
+ * {@code push_log.push_type} 컬럼 ENUM. MVP 는 REMINDER 단일 변종.
  */
 public enum PushType {
     REMINDER

--- a/backend/src/main/java/com/todayway/backend/push/domain/PushType.java
+++ b/backend/src/main/java/com/todayway/backend/push/domain/PushType.java
@@ -1,0 +1,9 @@
+package com.todayway.backend.push.domain;
+
+/**
+ * 명세 §V1 + DB-SQL.txt {@code push_log.push_type} ENUM. MVP는 REMINDER만.
+ * 신규 타입 추가 시 V2 마이그레이션으로 컬럼 ENUM 확장 필요.
+ */
+public enum PushType {
+    REMINDER
+}

--- a/backend/src/main/java/com/todayway/backend/push/dto/PushSubscribeRequest.java
+++ b/backend/src/main/java/com/todayway/backend/push/dto/PushSubscribeRequest.java
@@ -1,0 +1,41 @@
+package com.todayway.backend.push.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 명세 §7.1 — Web Push 표준 PushSubscription JSON 그대로 받는다.
+ *
+ * <pre>{@code
+ * {
+ *   "endpoint": "https://fcm.googleapis.com/fcm/send/...",
+ *   "keys": { "p256dh": "BNc...", "auth": "tBHI..." }
+ * }
+ * }</pre>
+ *
+ * <p>{@code @Size}는 V1__init.sql의 컬럼 길이 ({@code endpoint VARCHAR(500)},
+ * {@code p256dh_key/auth_key VARCHAR(255)}) 와 동기. 초과 시 SQL truncation 500 회피용
+ * 1차 가드 (명세 §1.6 정합).
+ */
+public record PushSubscribeRequest(
+        @NotBlank
+        @Size(max = 500)
+        String endpoint,
+
+        @NotNull
+        @Valid
+        Keys keys
+) {
+    public record Keys(
+            @NotBlank
+            @Size(max = 255)
+            String p256dh,
+
+            @NotBlank
+            @Size(max = 255)
+            String auth
+    ) {
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/dto/PushSubscribeResponse.java
+++ b/backend/src/main/java/com/todayway/backend/push/dto/PushSubscribeResponse.java
@@ -1,15 +1,15 @@
 package com.todayway.backend.push.dto;
 
+import com.todayway.backend.common.web.IdPrefixes;
 import com.todayway.backend.push.domain.PushSubscription;
 
 /**
- * 명세 §7.1 응답 — {@code subscriptionId} 외부 노출 ID는 명세 §1.7 규약대로 {@code sub_} prefix 부착.
+ * 명세 §7.1 응답 — {@code subscriptionId} 외부 노출 ID 는 명세 §1.7 규약대로
+ * {@link IdPrefixes#SUBSCRIPTION} prefix 부착.
  */
 public record PushSubscribeResponse(String subscriptionId) {
 
-    private static final String SUBSCRIPTION_ID_PREFIX = "sub_";
-
     public static PushSubscribeResponse from(PushSubscription s) {
-        return new PushSubscribeResponse(SUBSCRIPTION_ID_PREFIX + s.getSubscriptionUid());
+        return new PushSubscribeResponse(IdPrefixes.SUBSCRIPTION + s.getSubscriptionUid());
     }
 }

--- a/backend/src/main/java/com/todayway/backend/push/dto/PushSubscribeResponse.java
+++ b/backend/src/main/java/com/todayway/backend/push/dto/PushSubscribeResponse.java
@@ -1,0 +1,15 @@
+package com.todayway.backend.push.dto;
+
+import com.todayway.backend.push.domain.PushSubscription;
+
+/**
+ * 명세 §7.1 응답 — {@code subscriptionId} 외부 노출 ID는 명세 §1.7 규약대로 {@code sub_} prefix 부착.
+ */
+public record PushSubscribeResponse(String subscriptionId) {
+
+    private static final String SUBSCRIPTION_ID_PREFIX = "sub_";
+
+    public static PushSubscribeResponse from(PushSubscription s) {
+        return new PushSubscribeResponse(SUBSCRIPTION_ID_PREFIX + s.getSubscriptionUid());
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/repository/PushLogRepository.java
+++ b/backend/src/main/java/com/todayway/backend/push/repository/PushLogRepository.java
@@ -3,9 +3,17 @@ package com.todayway.backend.push.repository;
 import com.todayway.backend.push.domain.PushLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * 명세 §9.1 — 푸시 발송 이력. append-only.
- * 별도 도메인 쿼리는 P1 (재시도 정책/관측성). MVP는 INSERT 만.
+ * 별도 도메인 쿼리는 P1 (재시도 정책/관측성). MVP는 INSERT + 통합 테스트 필터링용 조회만.
  */
 public interface PushLogRepository extends JpaRepository<PushLog, Long> {
+
+    /**
+     * 통합 테스트에서 자기 케이스의 발송 이력만 격리해 검증하기 위한 derived query.
+     * 운영 코드에서는 사용하지 않는다.
+     */
+    List<PushLog> findBySubscriptionId(Long subscriptionId);
 }

--- a/backend/src/main/java/com/todayway/backend/push/repository/PushLogRepository.java
+++ b/backend/src/main/java/com/todayway/backend/push/repository/PushLogRepository.java
@@ -1,0 +1,11 @@
+package com.todayway.backend.push.repository;
+
+import com.todayway.backend.push.domain.PushLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 명세 §9.1 — 푸시 발송 이력. append-only.
+ * 별도 도메인 쿼리는 P1 (재시도 정책/관측성). MVP는 INSERT 만.
+ */
+public interface PushLogRepository extends JpaRepository<PushLog, Long> {
+}

--- a/backend/src/main/java/com/todayway/backend/push/repository/PushSubscriptionRepository.java
+++ b/backend/src/main/java/com/todayway/backend/push/repository/PushSubscriptionRepository.java
@@ -1,0 +1,38 @@
+package com.todayway.backend.push.repository;
+
+import com.todayway.backend.push.domain.PushSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
+
+    /** 명세 §7.1 — UPSERT 분기 (신규 INSERT vs 기존 row 재활성화). endpoint UNIQUE 제약. */
+    Optional<PushSubscription> findByEndpoint(String endpoint);
+
+    /** 명세 §7.2 — DELETE /push/subscribe/{subscriptionId} 단건 조회. */
+    Optional<PushSubscription> findBySubscriptionUid(String subscriptionUid);
+
+    /**
+     * 명세 §9.1 — PushScheduler 발송 대상 조회. 활성 구독만 ({@code revoked_at IS NULL}).
+     * 다중 기기 시나리오: 한 회원의 모든 활성 구독에 동일 페이로드 발송.
+     */
+    @Query("SELECT s FROM PushSubscription s WHERE s.memberId = :memberId AND s.revokedAt IS NULL")
+    List<PushSubscription> findActiveByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * 회원 탈퇴 cascade — issue #9. 활성 구독 일괄 soft-revoke.
+     * 영속성 컨텍스트와의 일관성을 위해 {@code clearAutomatically/flushAutomatically} 활성화
+     * (다른 cascade 메서드와 동일 패턴, ScheduleRepository.softDeleteByMemberId 참조).
+     *
+     * @return 영향받은 활성 구독 수
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE PushSubscription s SET s.revokedAt = :now WHERE s.memberId = :memberId AND s.revokedAt IS NULL")
+    int revokeAllByMemberId(@Param("memberId") Long memberId, @Param("now") OffsetDateTime now);
+}

--- a/backend/src/main/java/com/todayway/backend/push/sender/PushSendResult.java
+++ b/backend/src/main/java/com/todayway/backend/push/sender/PushSendResult.java
@@ -1,0 +1,34 @@
+package com.todayway.backend.push.sender;
+
+import com.todayway.backend.push.domain.PushStatus;
+
+/**
+ * {@link PushSender#send} 결과. {@link com.todayway.backend.push.domain.PushLog} INSERT 시
+ * {@code status} / {@code http_status} 컬럼에 그대로 매핑.
+ *
+ * @param status     SENT / FAILED / EXPIRED 분류
+ * @param httpStatus 푸시 서버 응답 코드 — 네트워크 오류로 응답 자체가 없으면 {@code null}
+ */
+public record PushSendResult(PushStatus status, Integer httpStatus) {
+
+    public static PushSendResult sent(int httpStatus) {
+        return new PushSendResult(PushStatus.SENT, httpStatus);
+    }
+
+    /** 푸시 서버 410 Gone — 브라우저 구독 만료 → 호출자가 {@link com.todayway.backend.push.domain.PushSubscription#revoke} 트리거. */
+    public static PushSendResult expired() {
+        return new PushSendResult(PushStatus.EXPIRED, 410);
+    }
+
+    public static PushSendResult failed(Integer httpStatus) {
+        return new PushSendResult(PushStatus.FAILED, httpStatus);
+    }
+
+    public boolean isExpired() {
+        return status == PushStatus.EXPIRED;
+    }
+
+    public boolean isSent() {
+        return status == PushStatus.SENT;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/sender/PushSendResult.java
+++ b/backend/src/main/java/com/todayway/backend/push/sender/PushSendResult.java
@@ -11,6 +11,18 @@ import com.todayway.backend.push.domain.PushStatus;
  */
 public record PushSendResult(PushStatus status, Integer httpStatus) {
 
+    public PushSendResult {
+        if (status == null) {
+            throw new IllegalArgumentException("status must not be null");
+        }
+        if (status == PushStatus.SENT && (httpStatus == null || httpStatus < 200 || httpStatus >= 300)) {
+            throw new IllegalArgumentException("SENT requires 2xx httpStatus, got " + httpStatus);
+        }
+        if (status == PushStatus.EXPIRED && (httpStatus == null || httpStatus != 410)) {
+            throw new IllegalArgumentException("EXPIRED requires 410 httpStatus, got " + httpStatus);
+        }
+    }
+
     public static PushSendResult sent(int httpStatus) {
         return new PushSendResult(PushStatus.SENT, httpStatus);
     }

--- a/backend/src/main/java/com/todayway/backend/push/sender/PushSender.java
+++ b/backend/src/main/java/com/todayway/backend/push/sender/PushSender.java
@@ -19,11 +19,11 @@ import java.security.Security;
  * <ul>
  *   <li>BouncyCastle Provider 1회 등록 (클래스 로드 시 static init — Spring lifecycle 이전)</li>
  *   <li>{@link VapidProperties} 기반 {@code PushService} lazy 초기화 (publicKey/privateKey 미설정 시 {@link IllegalStateException})</li>
- *   <li>HTTP 응답 코드 → {@link PushSendResult} 매핑 (200/201/202 = SENT, 410 = EXPIRED, 그 외 + 예외 = FAILED)</li>
+ *   <li>HTTP 응답 코드 → {@link PushSendResult} 매핑 (2xx = SENT, 410 = EXPIRED, 그 외 + 예외 = FAILED)</li>
  *   <li>checked exception 다수 래핑 (라이브러리가 IOException/GeneralSecurityException/JoseException/InterruptedException 등 던짐)</li>
  * </ul>
  *
- * <p>410 Gone 처리는 호출자({@link com.todayway.backend.push.service.PushScheduler}) 책임 —
+ * <p>410 Gone 처리는 호출자({@link com.todayway.backend.push.service.PushReminderDispatcher}) 책임 —
  * 결과의 {@link PushSendResult#isExpired()} 보고 {@link PushSubscription#revoke()} 호출.
  * 본 클래스는 IO만 담당하고 도메인 상태 변경 X.
  */

--- a/backend/src/main/java/com/todayway/backend/push/sender/PushSender.java
+++ b/backend/src/main/java/com/todayway/backend/push/sender/PushSender.java
@@ -1,0 +1,111 @@
+package com.todayway.backend.push.sender;
+
+import com.todayway.backend.push.domain.PushSubscription;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.apache.http.HttpResponse;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.security.GeneralSecurityException;
+import java.security.Security;
+
+/**
+ * Web Push 전송 어댑터. {@code nl.martijndwars:web-push:5.1.x} (동기 {@link PushService}) 래퍼.
+ *
+ * <p>책임:
+ * <ul>
+ *   <li>BouncyCastle Provider 1회 등록 (클래스 로드 시 static init — Spring lifecycle 이전)</li>
+ *   <li>{@link VapidProperties} 기반 {@code PushService} lazy 초기화 (publicKey/privateKey 미설정 시 {@link IllegalStateException})</li>
+ *   <li>HTTP 응답 코드 → {@link PushSendResult} 매핑 (200/201/202 = SENT, 410 = EXPIRED, 그 외 + 예외 = FAILED)</li>
+ *   <li>checked exception 다수 래핑 (라이브러리가 IOException/GeneralSecurityException/JoseException/InterruptedException 등 던짐)</li>
+ * </ul>
+ *
+ * <p>410 Gone 처리는 호출자({@link com.todayway.backend.push.service.PushScheduler}) 책임 —
+ * 결과의 {@link PushSendResult#isExpired()} 보고 {@link PushSubscription#revoke()} 호출.
+ * 본 클래스는 IO만 담당하고 도메인 상태 변경 X.
+ */
+@Component
+public class PushSender {
+
+    private static final Logger log = LoggerFactory.getLogger(PushSender.class);
+
+    static {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private final VapidProperties vapidProperties;
+    private volatile PushService pushService;
+
+    public PushSender(VapidProperties vapidProperties) {
+        this.vapidProperties = vapidProperties;
+    }
+
+    /**
+     * 동기 발송. 내부에서 모든 라이브러리 예외를 잡아 {@link PushSendResult#failed(Integer)} 로 변환.
+     * 호출자는 예외 catch 불필요 (단, {@link IllegalStateException} 은 키 미설정 시 propagation —
+     * 운영 단계에서 즉시 발견되어야 할 설정 누락이라 graceful 처리 X).
+     */
+    public PushSendResult send(PushSubscription subscription, String payloadJson) {
+        PushService ps = getOrCreatePushService();
+        try {
+            Notification notification = new Notification(
+                    subscription.getEndpoint(),
+                    subscription.getP256dhKey(),
+                    subscription.getAuthKey(),
+                    payloadJson
+            );
+            HttpResponse response = ps.send(notification);
+            int code = response.getStatusLine().getStatusCode();
+
+            if (code == 410) {
+                log.info("Push 410 Gone — endpoint expired: subscriptionUid={}", subscription.getSubscriptionUid());
+                return PushSendResult.expired();
+            }
+            if (code >= 200 && code < 300) {
+                return PushSendResult.sent(code);
+            }
+            log.warn("Push HTTP {} — endpoint={}, subscriptionUid={}",
+                    code, subscription.getEndpoint(), subscription.getSubscriptionUid());
+            return PushSendResult.failed(code);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Push send interrupted: subscriptionUid={}", subscription.getSubscriptionUid());
+            return PushSendResult.failed(null);
+        } catch (Exception e) {
+            // 보안: cause는 endpoint/payload 일부 포함 가능 → 메시지에 클래스명만 남김 (KakaoLocalClient 패턴 미러).
+            log.warn("Push send failed: subscriptionUid={}, cause={}",
+                    subscription.getSubscriptionUid(), e.getClass().getSimpleName());
+            return PushSendResult.failed(null);
+        }
+    }
+
+    private PushService getOrCreatePushService() {
+        PushService cached = this.pushService;
+        if (cached != null) {
+            return cached;
+        }
+        if (!vapidProperties.isConfigured()) {
+            throw new IllegalStateException(
+                    "VAPID keys 미설정 — vapid.public-key / vapid.private-key 환경변수를 확인하세요.");
+        }
+        synchronized (this) {
+            if (this.pushService == null) {
+                try {
+                    this.pushService = new PushService(
+                            vapidProperties.getPublicKey(),
+                            vapidProperties.getPrivateKey(),
+                            vapidProperties.getSubject()
+                    );
+                } catch (GeneralSecurityException e) {
+                    throw new IllegalStateException("VAPID PushService 초기화 실패: " + e.getClass().getSimpleName(), e);
+                }
+            }
+            return this.pushService;
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/sender/VapidProperties.java
+++ b/backend/src/main/java/com/todayway/backend/push/sender/VapidProperties.java
@@ -1,0 +1,35 @@
+package com.todayway.backend.push.sender;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * VAPID 키페어 설정 ({@code application.yml} {@code vapid.*}).
+ *
+ * <p>{@link #publicKey} / {@link #privateKey} 는 {@code @NotBlank} 미부착 — {@code OdsayProperties}
+ * 패턴과 동일하게 다른 도메인(member/schedule/route) 작업자가 VAPID 키 없이 백엔드를 부팅할 수
+ * 있어야 한다. 비어있는 채 PushSender 가 send 호출 시 {@link IllegalStateException} 으로 발견되어
+ * push 흐름만 graceful 차단된다.
+ *
+ * <p>{@link #subject} 는 RFC 8292 §2.1 권장 ({@code mailto:} 또는 https URL). 운영자가
+ * 잘못 설정 시 푸시 서버가 401 반환 가능하므로 {@code @NotBlank} 강제.
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "vapid")
+public class VapidProperties {
+    private String publicKey;
+    private String privateKey;
+
+    @NotBlank
+    private String subject;
+
+    public boolean isConfigured() {
+        return publicKey != null && !publicKey.isBlank()
+                && privateKey != null && !privateKey.isBlank();
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
@@ -30,7 +30,7 @@ import java.util.Map;
 /**
  * 한 일정의 알림 발송 처리 (트랜잭션 boundary). 명세 §9.1 흐름 정합:
  * <ol>
- *   <li>ODsay 재호출 — {@link PushSchedulerProperties#getOdsayMaxAttempts()} 회 시도, 실패 시 폴백 모드.</li>
+ *   <li>ODsay 재조회 — 총 {@link PushSchedulerProperties#getOdsayMaxAttempts()} 회 시도 (첫 호출 포함), 실패 시 폴백 모드.</li>
  *   <li>페이로드 빌드 — 명세 §9.1 형식. 폴백 시 {@code data.fallback=true} + {@code fallbackReason}.</li>
  *   <li>회원 활성 구독 모두에 발송 + {@link PushLog} 기록. 410 Gone → {@link PushSubscription#revoke()}.</li>
  *   <li>다음 occurrence — ONCE/null → {@link Schedule#clearReminderAt()},

--- a/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
@@ -1,0 +1,186 @@
+package com.todayway.backend.push.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.push.domain.PushLog;
+import com.todayway.backend.push.domain.PushSubscription;
+import com.todayway.backend.push.domain.PushType;
+import com.todayway.backend.push.repository.PushLogRepository;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
+import com.todayway.backend.push.sender.PushSendResult;
+import com.todayway.backend.push.sender.PushSender;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.RoutineCalculator;
+import com.todayway.backend.schedule.domain.RoutineType;
+import com.todayway.backend.schedule.domain.Schedule;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 한 일정의 알림 발송 처리 (트랜잭션 boundary). 명세 §9.1 흐름 정합:
+ * <ol>
+ *   <li>ODsay 재호출 — {@link PushSchedulerProperties#getOdsayMaxAttempts()} 회 시도, 실패 시 폴백 모드.</li>
+ *   <li>페이로드 빌드 — 명세 §9.1 형식. 폴백 시 {@code data.fallback=true} + {@code fallbackReason}.</li>
+ *   <li>회원 활성 구독 모두에 발송 + {@link PushLog} 기록. 410 Gone → {@link PushSubscription#revoke()}.</li>
+ *   <li>다음 occurrence — ONCE/null → {@link Schedule#clearReminderAt()},
+ *       루틴 → {@link RoutineCalculator}로 next, 없으면 종결.</li>
+ * </ol>
+ *
+ * <p>{@link PushScheduler} 가 per-iteration {@code try/catch} 로 본 메서드를 감싸서 한 일정 실패가
+ * 다른 일정 처리에 전파되지 않게 한다. 트랜잭션 boundary는 본 클래스 — {@link PushScheduler} 는 X.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PushReminderDispatcher {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter HHMM = DateTimeFormatter.ofPattern("H:mm");
+    private static final String FALLBACK_REASON_ODSAY = "EXTERNAL_ROUTE_API_FAILED";
+    private static final String SCHEDULE_ID_PREFIX = "sch_";
+    private static final String SCHEDULE_URL_PREFIX = "/schedules/";
+    private static final String PUSH_TYPE_REMINDER = "REMINDER";
+
+    private final ScheduleRepository scheduleRepository;
+    private final PushSubscriptionRepository subscriptionRepository;
+    private final PushLogRepository pushLogRepository;
+    private final RouteService routeService;
+    private final RoutineCalculator routineCalculator;
+    private final PushSender pushSender;
+    private final PushSchedulerProperties properties;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 단일 일정의 알림 발송. 본 트랜잭션 안에서 ODsay 재호출 + 발송 + 다음 occurrence 갱신을 모두 수행.
+     *
+     * <p>{@link Schedule} 은 다시 fetch — {@link PushScheduler} 가 트랜잭션 밖에서 ID만 추출했기 때문.
+     * fetch 시 {@code @SQLRestriction("deleted_at IS NULL")} 로 soft-deleted 자동 제외.
+     * race window (다른 인스턴스가 이미 처리/취소) 방어로 fetch 후 {@code reminderAt} 재확인.
+     */
+    @Transactional
+    public void process(Long scheduleId) {
+        Schedule s = scheduleRepository.findById(scheduleId).orElse(null);
+        if (s == null || s.getReminderAt() == null) {
+            log.debug("Push reminder skip — already processed or deleted: scheduleId={}", scheduleId);
+            return;
+        }
+
+        boolean refreshOk = refreshOdsayWithRetry(s);
+        String payloadJson = buildPayloadJson(s, refreshOk);
+
+        List<PushSubscription> activeSubs = subscriptionRepository.findActiveByMemberId(s.getMemberId());
+        if (activeSubs.isEmpty()) {
+            log.info("Push reminder no active subscription: scheduleId={}, memberId={}",
+                    s.getId(), s.getMemberId());
+        }
+        for (PushSubscription sub : activeSubs) {
+            PushSendResult result = pushSender.send(sub, payloadJson);
+            pushLogRepository.save(PushLog.record(
+                    sub.getId(), s.getId(), PushType.REMINDER,
+                    result.status(), result.httpStatus(), payloadJson));
+            if (result.isExpired()) {
+                sub.revoke();
+            }
+        }
+
+        advanceOrTerminate(s);
+    }
+
+    private boolean refreshOdsayWithRetry(Schedule s) {
+        int max = properties.getOdsayMaxAttempts();
+        for (int attempt = 1; attempt <= max; attempt++) {
+            if (attempt > 1) {
+                try {
+                    Thread.sleep(properties.getOdsayRetryIntervalMs());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Push reminder ODsay retry interrupted: scheduleId={}", s.getId());
+                    return false;
+                }
+            }
+            try {
+                if (routeService.refreshRouteSync(s)) {
+                    return true;
+                }
+                log.debug("ODsay refresh returned false: scheduleId={}, attempt={}/{}",
+                        s.getId(), attempt, max);
+            } catch (Exception e) {
+                // RouteService 자체는 graceful 설계지만 방어적 catch — 한 일정 ODsay 실패가
+                // 다른 일정 처리를 막지 않게 한다.
+                log.warn("ODsay refresh threw exception: scheduleId={}, attempt={}/{}, cause={}",
+                        s.getId(), attempt, max, e.getClass().getSimpleName());
+            }
+        }
+        return false;
+    }
+
+    private String buildPayloadJson(Schedule s, boolean refreshOk) {
+        String externalScheduleId = SCHEDULE_ID_PREFIX + s.getScheduleUid();
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("scheduleId", externalScheduleId);
+        data.put("type", PUSH_TYPE_REMINDER);
+        data.put("url", SCHEDULE_URL_PREFIX + externalScheduleId);
+        if (s.getRecommendedDepartureTime() != null) {
+            data.put("recommendedDepartureTime", s.getRecommendedDepartureTime().toString());
+        }
+        if (s.getEstimatedDurationMinutes() != null) {
+            data.put("estimatedDurationMinutes", s.getEstimatedDurationMinutes());
+        }
+        data.put("fallback", !refreshOk);
+        if (!refreshOk) {
+            data.put("fallbackReason", FALLBACK_REASON_ODSAY);
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("title", s.getTitle());
+        payload.put("body", buildBody(s));
+        payload.put("data", data);
+
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            // 본 메서드가 만든 in-memory Map 만 직렬화하므로 정상 흐름엔 발생 X.
+            // 발생 시 fail-fast — config 또는 ObjectMapper 손상 시그널.
+            throw new IllegalStateException("Push payload 직렬화 실패", e);
+        }
+    }
+
+    /** 명세 §9.1 body 예시: "5분 뒤 출발하세요 (8:25, 예상 소요시간 35분)". */
+    private static String buildBody(Schedule s) {
+        Integer offsetMin = s.getReminderOffsetMinutes();
+        OffsetDateTime depart = s.getRecommendedDepartureTime();
+        Integer duration = s.getEstimatedDurationMinutes();
+
+        String hhmm = depart != null ? depart.atZoneSameInstant(KST).toLocalTime().format(HHMM) : "?";
+        String durationStr = duration != null ? duration + "분" : "계산 중";
+        String offsetStr = offsetMin != null ? offsetMin + "분 뒤" : "곧";
+        return String.format("%s 출발하세요 (%s, 예상 소요시간 %s)", offsetStr, hhmm, durationStr);
+    }
+
+    private void advanceOrTerminate(Schedule s) {
+        RoutineType type = s.getRoutineType();
+        if (type == null || type == RoutineType.ONCE) {
+            s.clearReminderAt();
+            return;
+        }
+        OffsetDateTime nextArrival = routineCalculator.calculateNextOccurrence(s);
+        if (nextArrival == null) {
+            log.warn("Routine next occurrence not found — terminating reminder: scheduleId={}, type={}",
+                    s.getId(), type);
+            s.clearReminderAt();
+            return;
+        }
+        s.advanceToNextOccurrence(nextArrival);
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
@@ -46,6 +46,8 @@ public class PushReminderDispatcher {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter HHMM = DateTimeFormatter.ofPattern("H:mm");
+    /** 명세 §9.1 페이로드 예시 ("2026-04-21T08:25:00+09:00") 정합 — seconds=0 도 명시 출력. */
+    private static final DateTimeFormatter ISO_OFFSET_SECONDS = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
     private static final String FALLBACK_REASON_ODSAY = "EXTERNAL_ROUTE_API_FAILED";
     private static final String SCHEDULE_ID_PREFIX = "sch_";
     private static final String SCHEDULE_URL_PREFIX = "/schedules/";
@@ -132,7 +134,7 @@ public class PushReminderDispatcher {
         data.put("type", PUSH_TYPE_REMINDER);
         data.put("url", SCHEDULE_URL_PREFIX + externalScheduleId);
         if (s.getRecommendedDepartureTime() != null) {
-            data.put("recommendedDepartureTime", s.getRecommendedDepartureTime().toString());
+            data.put("recommendedDepartureTime", s.getRecommendedDepartureTime().format(ISO_OFFSET_SECONDS));
         }
         if (s.getEstimatedDurationMinutes() != null) {
             data.put("estimatedDurationMinutes", s.getEstimatedDurationMinutes());

--- a/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
@@ -67,13 +67,21 @@ public class PushReminderDispatcher {
      *
      * <p>{@link Schedule} 은 다시 fetch — {@link PushScheduler} 가 트랜잭션 밖에서 ID만 추출했기 때문.
      * fetch 시 {@code @SQLRestriction("deleted_at IS NULL")} 로 soft-deleted 자동 제외.
-     * race window (다른 인스턴스가 이미 처리/취소) 방어로 fetch 후 {@code reminderAt} 재확인.
+     * fetch 와 트랜잭션 시작 사이에 일정이 삭제·갱신되었을 수 있어 {@code reminderAt} 재확인.
      */
     @Transactional
     public void process(Long scheduleId) {
         Schedule s = scheduleRepository.findById(scheduleId).orElse(null);
-        if (s == null || s.getReminderAt() == null) {
-            log.debug("Push reminder skip — already processed or deleted: scheduleId={}", scheduleId);
+        if (s == null) {
+            // soft-delete 만 사용하는 codebase 에서 row 가 사라지는 것은 비정상 — 명시적 WARN.
+            log.warn("Push reminder skip — Schedule disappeared between scan and dispatch: scheduleId={}",
+                    scheduleId);
+            return;
+        }
+        if (s.getReminderAt() == null) {
+            // 동시 PATCH/dispatch 또는 직전 advance 로 reminderAt 이 이미 정리됨 — 정상 race.
+            log.debug("Push reminder skip — reminderAt cleared (race or already processed): scheduleId={}",
+                    scheduleId);
             return;
         }
 
@@ -91,6 +99,10 @@ public class PushReminderDispatcher {
                     sub.getId(), s.getId(), PushType.REMINDER,
                     result.status(), result.httpStatus(), payloadJson));
             if (result.isExpired()) {
+                // 410 Gone 자동 cleanup — 운영 관측성을 위해 dispatcher 레벨에서도 INFO 로깅
+                // (PushSender 에서 같은 이벤트를 INFO 로 남기지만 cause 가 다른 호출자 추적에 유용).
+                log.info("Push subscription auto-revoked due to 410 Gone: subscriptionUid={}",
+                        sub.getSubscriptionUid());
                 sub.revoke();
             }
         }
@@ -117,10 +129,10 @@ public class PushReminderDispatcher {
                 log.debug("ODsay refresh returned false: scheduleId={}, attempt={}/{}",
                         s.getId(), attempt, max);
             } catch (Exception e) {
-                // RouteService 자체는 graceful 설계지만 방어적 catch — 한 일정 ODsay 실패가
-                // 다른 일정 처리를 막지 않게 한다.
-                log.warn("ODsay refresh threw exception: scheduleId={}, attempt={}/{}, cause={}",
-                        s.getId(), attempt, max, e.getClass().getSimpleName());
+                // RouteService 가 unchecked 던져도 폴백 페이로드로 발송이 진행되도록 흡수.
+                // scheduleId 만 입력이라 stack trace 노출 안전.
+                log.warn("ODsay refresh threw exception: scheduleId={}, attempt={}/{}",
+                        s.getId(), attempt, max, e);
             }
         }
         return false;

--- a/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushReminderDispatcher.java
@@ -2,6 +2,7 @@ package com.todayway.backend.push.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.common.web.IdPrefixes;
 import com.todayway.backend.push.domain.PushLog;
 import com.todayway.backend.push.domain.PushSubscription;
 import com.todayway.backend.push.domain.PushType;
@@ -16,7 +17,7 @@ import com.todayway.backend.schedule.domain.Schedule;
 import com.todayway.backend.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -39,7 +40,7 @@ import java.util.Map;
  * <p>{@link PushScheduler} 가 per-iteration {@code try/catch} 로 본 메서드를 감싸서 한 일정 실패가
  * 다른 일정 처리에 전파되지 않게 한다. 트랜잭션 boundary는 본 클래스 — {@link PushScheduler} 는 X.
  */
-@Component
+@Service
 @RequiredArgsConstructor
 @Slf4j
 public class PushReminderDispatcher {
@@ -49,7 +50,6 @@ public class PushReminderDispatcher {
     /** 명세 §9.1 페이로드 예시 ("2026-04-21T08:25:00+09:00") 정합 — seconds=0 도 명시 출력. */
     private static final DateTimeFormatter ISO_OFFSET_SECONDS = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
     private static final String FALLBACK_REASON_ODSAY = "EXTERNAL_ROUTE_API_FAILED";
-    private static final String SCHEDULE_ID_PREFIX = "sch_";
     private static final String SCHEDULE_URL_PREFIX = "/schedules/";
     private static final String PUSH_TYPE_REMINDER = "REMINDER";
 
@@ -139,7 +139,7 @@ public class PushReminderDispatcher {
     }
 
     private String buildPayloadJson(Schedule s, boolean refreshOk) {
-        String externalScheduleId = SCHEDULE_ID_PREFIX + s.getScheduleUid();
+        String externalScheduleId = IdPrefixes.SCHEDULE + s.getScheduleUid();
 
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("scheduleId", externalScheduleId);

--- a/backend/src/main/java/com/todayway/backend/push/service/PushScheduler.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushScheduler.java
@@ -52,9 +52,10 @@ public class PushScheduler {
             try {
                 dispatcher.process(id);
             } catch (Exception e) {
-                // dispatcher 트랜잭션 rollback 후 다음 일정 처리 계속.
-                log.warn("Push reminder dispatch failed: scheduleId={}, cause={}",
-                        id, e.getClass().getSimpleName());
+                // dispatcher 트랜잭션 rollback 후 다음 일정 처리 계속. 입력은 internal scheduleId 뿐이라
+                // payload/endpoint leak 우려 없음 → e 를 last vararg 로 넘겨 stack trace 출력
+                // (OdsayRouteService 패턴 미러 — 운영 root-cause analysis 가능).
+                log.warn("Push reminder dispatch failed: scheduleId={}", id, e);
             }
         }
     }

--- a/backend/src/main/java/com/todayway/backend/push/service/PushScheduler.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushScheduler.java
@@ -1,0 +1,61 @@
+package com.todayway.backend.push.service;
+
+import com.todayway.backend.schedule.domain.Schedule;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * 명세 §9.1 — {@code @Scheduled(fixedDelay)} 트리거. 5분 누락 방지 윈도우 안의 due reminder 를
+ * 모아 ID 만 추출 후 {@link PushReminderDispatcher#process} 에 위임.
+ *
+ * <p>per-iteration {@code try/catch} — 한 일정 처리 실패가 다른 일정 처리를 막지 않게 한다.
+ * 트랜잭션 boundary 는 dispatcher 안. 본 클래스는 트랜잭션 X (read-only repository 호출만).
+ *
+ * <p>활성화는 {@link PushSchedulingConfig} 의 {@code @ConditionalOnProperty} 로 제어 —
+ * {@code @EnableScheduling} 자체가 미적용되면 본 빈은 등록되어도 {@code @Scheduled} 트리거 X.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PushScheduler {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final ScheduleRepository scheduleRepository;
+    private final PushReminderDispatcher dispatcher;
+    private final PushSchedulerProperties properties;
+
+    @Scheduled(fixedDelayString = "${push.scheduler.fixed-delay-ms:30000}")
+    public void dispatchDueReminders() {
+        OffsetDateTime now = OffsetDateTime.now(KST);
+        OffsetDateTime windowStart = now.minus(Duration.ofMinutes(properties.getWindowMinutes()));
+
+        List<Long> scheduleIds = scheduleRepository.findDueReminders(now, windowStart)
+                .stream()
+                .map(Schedule::getId)
+                .toList();
+
+        if (scheduleIds.isEmpty()) {
+            return;
+        }
+        log.info("Push reminder due: count={}", scheduleIds.size());
+
+        for (Long id : scheduleIds) {
+            try {
+                dispatcher.process(id);
+            } catch (Exception e) {
+                // dispatcher 트랜잭션 rollback 후 다음 일정 처리 계속.
+                log.warn("Push reminder dispatch failed: scheduleId={}, cause={}",
+                        id, e.getClass().getSimpleName());
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/service/PushSchedulerProperties.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushSchedulerProperties.java
@@ -1,0 +1,38 @@
+package com.todayway.backend.push.service;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * {@link PushScheduler} 운영 튜닝값. {@code application.yml} {@code push.scheduler.*}.
+ *
+ * <p>기본값은 명세 §9.1 정확히 정합 — 운영 환경에서만 환경변수로 override (명세 동작 변경 X).
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "push.scheduler")
+public class PushSchedulerProperties {
+
+    /** 스케줄러 자체 on/off. 테스트/dev 환경에서 끄기 위한 토글. */
+    private boolean enabled = true;
+
+    /** 명세 §9.1 — fixedDelay 30초 (밀리초). */
+    @Min(1000)
+    private long fixedDelayMs = 30_000;
+
+    /** 명세 §9.1 — 누락 방지 윈도우 5분. {@code reminder_at > NOW() - INTERVAL window MINUTE}. */
+    @Min(1)
+    private int windowMinutes = 5;
+
+    /** 명세 §9.1 — ODsay 재호출 총 시도 횟수 (첫 호출 포함). 명세 "최대 2회 시도" → 2. */
+    @Min(1)
+    private int odsayMaxAttempts = 2;
+
+    /** 명세 §9.1 — 시도 간 sleep 간격 (밀리초). 첫 시도 후부터 적용. */
+    @Min(0)
+    private long odsayRetryIntervalMs = 1000;
+}

--- a/backend/src/main/java/com/todayway/backend/push/service/PushSchedulingConfig.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushSchedulingConfig.java
@@ -1,0 +1,18 @@
+package com.todayway.backend.push.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * 명세 §9.1 — {@link PushScheduler} 활성화. {@code @ConditionalOnProperty} 로 통합 테스트/dev 환경에서
+ * {@code push.scheduler.enabled=false} 설정 시 {@code @EnableScheduling} 자체가 미적용 →
+ * {@code @Scheduled} 빈도 등록 X.
+ *
+ * <p>기본값 {@code true} (matchIfMissing) — 운영 환경은 별도 설정 없이 동작.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableScheduling
+@ConditionalOnProperty(prefix = "push.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class PushSchedulingConfig {
+}

--- a/backend/src/main/java/com/todayway/backend/push/service/PushService.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushService.java
@@ -1,0 +1,88 @@
+package com.todayway.backend.push.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.member.domain.Member;
+import com.todayway.backend.member.repository.MemberRepository;
+import com.todayway.backend.push.domain.PushSubscription;
+import com.todayway.backend.push.dto.PushSubscribeRequest;
+import com.todayway.backend.push.dto.PushSubscribeResponse;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 명세 §7 — Web Push 구독 도메인 서비스. UPSERT(by endpoint) + soft revoke.
+ *
+ * <p>{@link #subscribe} 의 race condition 정책:
+ * <ul>
+ *   <li>endpoint UNIQUE 제약으로 동시 INSERT 시 두 번째가 {@link DataIntegrityViolationException}.
+ *       catch 후 재조회 → reactivate.</li>
+ *   <li>{@code saveAndFlush} 로 commit 미루지 않고 즉시 발견 — silent late-commit 충돌 방지.</li>
+ * </ul>
+ *
+ * <p>다른 회원이 동일 endpoint 재구독 시도: 명세 미정의 영역이라 안전하게 {@code 403 FORBIDDEN_RESOURCE}
+ * reject. push provider 가 endpoint 를 device-bound 로 발급하므로 실제 발생 빈도 매우 낮으며,
+ * "디바이스 소유자 이전" 정책은 P1 보류.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PushService {
+
+    private final MemberRepository memberRepository;
+    private final PushSubscriptionRepository subscriptionRepository;
+
+    @Transactional
+    public PushSubscribeResponse subscribe(String memberUid, PushSubscribeRequest req, String userAgent) {
+        Long memberId = resolveMemberId(memberUid);
+        PushSubscription saved = upsertByEndpoint(memberId, req, userAgent);
+        return PushSubscribeResponse.from(saved);
+    }
+
+    @Transactional
+    public void unsubscribe(String memberUid, String subscriptionUid) {
+        Long memberId = resolveMemberId(memberUid);
+        PushSubscription s = subscriptionRepository.findBySubscriptionUid(subscriptionUid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+        if (!s.belongsTo(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
+        s.revoke();
+    }
+
+    private PushSubscription upsertByEndpoint(Long memberId, PushSubscribeRequest req, String userAgent) {
+        try {
+            return subscriptionRepository.findByEndpoint(req.endpoint())
+                    .map(existing -> reactivateOwned(existing, memberId, req, userAgent))
+                    .orElseGet(() -> subscriptionRepository.saveAndFlush(
+                            PushSubscription.create(memberId, req.endpoint(),
+                                    req.keys().p256dh(), req.keys().auth(), userAgent)));
+        } catch (DataIntegrityViolationException e) {
+            // race: 동시 INSERT 충돌 — 두 번째 요청이 unique 위반. 재조회 후 reactivate.
+            log.info("Push subscribe UPSERT race — retrying via findByEndpoint");
+            PushSubscription existing = subscriptionRepository.findByEndpoint(req.endpoint())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+            return reactivateOwned(existing, memberId, req, userAgent);
+        }
+    }
+
+    private PushSubscription reactivateOwned(PushSubscription existing, Long memberId,
+                                             PushSubscribeRequest req, String userAgent) {
+        if (!existing.belongsTo(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
+        existing.reactivate(req.keys().p256dh(), req.keys().auth(), userAgent);
+        return existing;
+    }
+
+    private Long resolveMemberId(String memberUid) {
+        return memberRepository.findByMemberUid(memberUid)
+                .map(Member::getId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/push/service/PushService.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushService.java
@@ -25,8 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
  * </ul>
  *
  * <p>다른 회원이 동일 endpoint 재구독 시도: 명세 미정의 영역이라 안전하게 {@code 403 FORBIDDEN_RESOURCE}
- * reject. push provider 가 endpoint 를 device-bound 로 발급하므로 실제 발생 빈도 매우 낮으며,
- * "디바이스 소유자 이전" 정책은 P1 보류.
+ * reject. push provider 가 endpoint 를 device-bound 로 발급하므로 실제 발생 빈도 매우 낮음.
  */
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/todayway/backend/push/service/PushService.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushService.java
@@ -64,9 +64,16 @@ public class PushService {
                                     req.keys().p256dh(), req.keys().auth(), userAgent)));
         } catch (DataIntegrityViolationException e) {
             // race: 동시 INSERT 충돌 — 두 번째 요청이 unique 위반. 재조회 후 reactivate.
-            log.info("Push subscribe UPSERT race — retrying via findByEndpoint");
+            // cause 클래스명 함께 로깅 — endpoint 이외 제약(member_id FK 등) 위반 시 진단 가능.
+            log.info("Push subscribe UPSERT race — retrying via findByEndpoint, cause={}",
+                    e.getMostSpecificCause().getClass().getSimpleName());
             PushSubscription existing = subscriptionRepository.findByEndpoint(req.endpoint())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
+                    .orElseThrow(() -> {
+                        // unique 위반 났는데 endpoint 가 안 나오면 다른 제약 위반 — 원인 보존 후 500.
+                        log.error("Push subscribe UPSERT inconsistency — DataIntegrityViolation but endpoint not found",
+                                e);
+                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+                    });
             return reactivateOwned(existing, memberId, req, userAgent);
         }
     }

--- a/backend/src/main/java/com/todayway/backend/push/service/PushService.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushService.java
@@ -15,17 +15,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 명세 §7 — Web Push 구독 도메인 서비스. UPSERT(by endpoint) + soft revoke.
+ * 명세 §7 — Web Push 구독 도메인 서비스. UPSERT (by endpoint) + soft revoke.
  *
- * <p>{@link #subscribe} 의 race condition 정책:
- * <ul>
- *   <li>endpoint UNIQUE 제약으로 동시 INSERT 시 두 번째가 {@link DataIntegrityViolationException}.
- *       catch 후 재조회 → reactivate.</li>
- *   <li>{@code saveAndFlush} 로 commit 미루지 않고 즉시 발견 — silent late-commit 충돌 방지.</li>
- * </ul>
+ * <p>UPSERT 의 race 처리는 {@link PushSubscriptionUpserter} 의 {@code REQUIRES_NEW} 트랜잭션이
+ * 격리한다. 본 서비스의 outer transaction 은 read-only — inner 의 rollback-only 가 outer commit 에
+ * 영향을 주지 않게 해 race 가 silent 500 으로 떨어지지 않게 한다.
  *
- * <p>다른 회원이 동일 endpoint 재구독 시도: 명세 미정의 영역이라 안전하게 {@code 403 FORBIDDEN_RESOURCE}
- * reject. push provider 가 endpoint 를 device-bound 로 발급하므로 실제 발생 빈도 매우 낮음.
+ * <p>다른 회원이 동일 endpoint 재구독 시도: 명세 §7.1 미정의 영역이라 {@link PushSubscriptionUpserter}
+ * 안에서 안전하게 {@code 403 FORBIDDEN_RESOURCE} reject. push provider 가 endpoint 를 device-bound
+ * 로 발급하므로 실제 발생 빈도 매우 낮음.
  */
 @Service
 @RequiredArgsConstructor
@@ -35,11 +33,11 @@ public class PushService {
 
     private final MemberRepository memberRepository;
     private final PushSubscriptionRepository subscriptionRepository;
+    private final PushSubscriptionUpserter upserter;
 
-    @Transactional
     public PushSubscribeResponse subscribe(String memberUid, PushSubscribeRequest req, String userAgent) {
         Long memberId = resolveMemberId(memberUid);
-        PushSubscription saved = upsertByEndpoint(memberId, req, userAgent);
+        PushSubscription saved = upsertWithRetry(memberId, req, userAgent);
         return PushSubscribeResponse.from(saved);
     }
 
@@ -54,36 +52,23 @@ public class PushService {
         s.revoke();
     }
 
-    private PushSubscription upsertByEndpoint(Long memberId, PushSubscribeRequest req, String userAgent) {
+    /**
+     * inner upserter race 충돌은 1회 retry — race window 내 다른 호출이 먼저 INSERT 했다면
+     * findByEndpoint 가 즉시 hit. 두 번째 시도도 fail 이면 데이터 불일치 — 500.
+     */
+    private PushSubscription upsertWithRetry(Long memberId, PushSubscribeRequest req, String userAgent) {
         try {
-            return subscriptionRepository.findByEndpoint(req.endpoint())
-                    .map(existing -> reactivateOwned(existing, memberId, req, userAgent))
-                    .orElseGet(() -> subscriptionRepository.saveAndFlush(
-                            PushSubscription.create(memberId, req.endpoint(),
-                                    req.keys().p256dh(), req.keys().auth(), userAgent)));
+            return upserter.upsert(memberId, req, userAgent);
         } catch (DataIntegrityViolationException e) {
-            // race: 동시 INSERT 충돌 — 두 번째 요청이 unique 위반. 재조회 후 reactivate.
-            // cause 클래스명 함께 로깅 — endpoint 이외 제약(member_id FK 등) 위반 시 진단 가능.
-            log.info("Push subscribe UPSERT race — retrying via findByEndpoint, cause={}",
+            log.info("Push subscribe UPSERT race detected — single retry, cause={}",
                     e.getMostSpecificCause().getClass().getSimpleName());
-            PushSubscription existing = subscriptionRepository.findByEndpoint(req.endpoint())
-                    .orElseThrow(() -> {
-                        // unique 위반 났는데 endpoint 가 안 나오면 다른 제약 위반 — 원인 보존 후 500.
-                        log.error("Push subscribe UPSERT inconsistency — DataIntegrityViolation but endpoint not found",
-                                e);
-                        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-                    });
-            return reactivateOwned(existing, memberId, req, userAgent);
+            try {
+                return upserter.upsert(memberId, req, userAgent);
+            } catch (DataIntegrityViolationException retryEx) {
+                log.error("Push subscribe UPSERT inconsistency after retry", retryEx);
+                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         }
-    }
-
-    private PushSubscription reactivateOwned(PushSubscription existing, Long memberId,
-                                             PushSubscribeRequest req, String userAgent) {
-        if (!existing.belongsTo(memberId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
-        }
-        existing.reactivate(req.keys().p256dh(), req.keys().auth(), userAgent);
-        return existing;
     }
 
     private Long resolveMemberId(String memberUid) {

--- a/backend/src/main/java/com/todayway/backend/push/service/PushSubscriptionUpserter.java
+++ b/backend/src/main/java/com/todayway/backend/push/service/PushSubscriptionUpserter.java
@@ -1,0 +1,54 @@
+package com.todayway.backend.push.service;
+
+import com.todayway.backend.common.exception.BusinessException;
+import com.todayway.backend.common.exception.ErrorCode;
+import com.todayway.backend.push.domain.PushSubscription;
+import com.todayway.backend.push.dto.PushSubscribeRequest;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 명세 §7.1 — UPSERT (by endpoint) 의 race-safe 처리. {@link PushService} 의 outer 트랜잭션과 분리된
+ * {@code REQUIRES_NEW} 트랜잭션 안에서 INSERT/UPDATE 수행.
+ *
+ * <p>{@code saveAndFlush} 후 {@link DataIntegrityViolationException} 이 발생하면 Hibernate session 의
+ * 트랜잭션이 rollback-only 로 마킹된다. 같은 트랜잭션 안에서 catch + dirty mutate 는 commit 시점에
+ * {@link org.springframework.transaction.UnexpectedRollbackException} → silent 500 위험. 별도
+ * {@code REQUIRES_NEW} 메서드로 분리해 충돌이 inner tx 안에서 끝나게 한다.
+ *
+ * <p>다른 회원이 동일 endpoint 재구독 시도는 명세 §7.1 미정의 영역이므로 안전하게 {@code 403
+ * FORBIDDEN_RESOURCE} reject — 본 메서드 내부에서 처리.
+ *
+ * <p>{@code DataIntegrityViolationException} 은 outer 로 propagate — outer 가 1회 retry.
+ */
+@Service
+@RequiredArgsConstructor
+public class PushSubscriptionUpserter {
+
+    private final PushSubscriptionRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PushSubscription upsert(Long memberId, PushSubscribeRequest req, String userAgent) {
+        Optional<PushSubscription> existing = repository.findByEndpoint(req.endpoint());
+        if (existing.isPresent()) {
+            return reactivateOwned(existing.get(), memberId, req, userAgent);
+        }
+        return repository.saveAndFlush(PushSubscription.create(
+                memberId, req.endpoint(), req.keys().p256dh(), req.keys().auth(), userAgent));
+    }
+
+    private PushSubscription reactivateOwned(PushSubscription existing, Long memberId,
+                                             PushSubscribeRequest req, String userAgent) {
+        if (!existing.belongsTo(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_RESOURCE);
+        }
+        existing.reactivate(req.keys().p256dh(), req.keys().auth(), userAgent);
+        return existing;
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/route/RouteController.java
+++ b/backend/src/main/java/com/todayway/backend/route/RouteController.java
@@ -2,6 +2,7 @@ package com.todayway.backend.route;
 
 import com.todayway.backend.common.response.ApiResponse;
 import com.todayway.backend.common.web.CurrentMember;
+import com.todayway.backend.common.web.IdPrefixes;
 import com.todayway.backend.schedule.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,15 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 명세 §6.1 — 일정 경로 조회 (단일).
- * <p>인증 + 인가 검증은 {@link ScheduleService#getRouteForOwned}가 담당 (단일 트랜잭션 facade).
- * 본 controller는 HTTP 레이어 변환만 — sch_ prefix strip + ApiResponse 래핑.
+ * <p>인증 + 인가 검증은 {@link ScheduleService#getRouteForOwned} 가 담당 (단일 트랜잭션 facade).
+ * 본 controller 는 HTTP 레이어 변환만 — {@link IdPrefixes#SCHEDULE} strip + {@link ApiResponse} 래핑.
  */
 @RestController
 @RequestMapping("/api/v1/schedules")
 @RequiredArgsConstructor
 public class RouteController {
-
-    private static final String SCHEDULE_ID_PREFIX = "sch_";
 
     private final ScheduleService scheduleService;
 
@@ -31,15 +30,7 @@ public class RouteController {
             @PathVariable String scheduleId,
             @RequestParam(defaultValue = "false") boolean forceRefresh) {
         RouteResponse resp = scheduleService.getRouteForOwned(
-                memberUid, stripPrefix(scheduleId), forceRefresh);
+                memberUid, IdPrefixes.strip(scheduleId, IdPrefixes.SCHEDULE), forceRefresh);
         return ResponseEntity.ok(ApiResponse.of(resp));
-    }
-
-    /** 명세 §1.7 — 외부 노출 ID는 {@code sch_} prefix. 내부 ULID로 변환. */
-    private static String stripPrefix(String scheduleId) {
-        if (scheduleId != null && scheduleId.startsWith(SCHEDULE_ID_PREFIX)) {
-            return scheduleId.substring(SCHEDULE_ID_PREFIX.length());
-        }
-        return scheduleId;
     }
 }

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/PlaceProvider.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/PlaceProvider.java
@@ -1,8 +1,11 @@
 package com.todayway.backend.schedule.domain;
 
 /**
- * 장소 정보의 출처 (origin_provider / destination_provider).
- * DB ENUM과 정합 (V1__init.sql).
+ * 장소 정보의 출처 (origin_provider / destination_provider). 명세 §11.1 / V1__init.sql 정합.
+ *
+ * <p>본 ENUM 은 도메인 추상화 — schedule 도메인에서만 사용. 명세 §8.1 v1.1.4 변환표에 따라 geocode
+ * 응답의 {@link com.todayway.backend.geocode.domain.GeocodeCacheProvider#KAKAO_LOCAL} 는 schedule
+ * 저장 시 {@link #KAKAO} 로 변환되어 들어온다 (변환 책임은 frontend).
  */
 public enum PlaceProvider {
     NAVER, KAKAO, ODSAY, MANUAL

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
@@ -330,9 +330,12 @@ public class Schedule extends BaseEntity {
     }
 
     /**
-     * 명세 §9.1 — ONCE 일정의 알림 발송 직후 호출. {@code reminder_at = NULL} 로 재발송 방지. 멱등.
+     * 명세 §9.1 — ONCE 일정 발송 직후 호출. {@code reminder_at = NULL} 로 재발송 방지. 멱등.
      */
     public void clearReminderAt() {
+        if (deletedAt != null) {
+            throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
+        }
         this.reminderAt = null;
     }
 
@@ -340,24 +343,34 @@ public class Schedule extends BaseEntity {
      * 명세 §9.2 — 루틴 일정 다음 occurrence 로 갱신. ODsay 재호출 X
      * ({@code estimatedDurationMinutes} 마지막 호출값 그대로 사용).
      *
-     * <p>{@code arrival_time} 갱신 → {@code recommendedDepartureTime} = arrival - duration →
-     * {@code recalculateDepartureAdvice / recalculateReminderAt} 으로 파생값 동기화.
+     * <p>{@code userDepartureTime} delta shift (v1.1.13): {@code arrivalTime} 변화량과 동일하게
+     * 사용자 출발 의도 시각도 이동. 미동기화 시 {@code recalculateDepartureAdvice} 가 24h+ 차이로
+     * 항상 {@code EARLIER} 가 되어 silent corruption 발생 → §6.1/§5.4 응답이 무의미해진다.
      *
-     * <p>{@code userDepartureTime} 은 명세 silent — 본 메서드에서 변경 X (P1 보충 후보).
-     * 알림 페이로드는 {@code recommendedDepartureTime} 만 사용하므로 push 동작에 영향 없음.
+     * <p>{@code estimatedDurationMinutes} 부재 시 fallback (v1.1.13): 등록 시 ODsay graceful 실패로
+     * duration 이 NULL 인 routine 의 경우, {@code reminder_at = arrival - reminder_offset} 으로 직접
+     * 추정해 routine 이 silent disable 되지 않도록 보장. 다음 dispatch 의 ODsay 재호출이 성공하면
+     * 정확한 값으로 자동 갱신된다.
      */
     public void advanceToNextOccurrence(OffsetDateTime nextArrival) {
         if (deletedAt != null) {
             throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
         }
-        this.arrivalTime = nextArrival;
-        if (estimatedDurationMinutes != null) {
-            this.recommendedDepartureTime = nextArrival.minusMinutes(estimatedDurationMinutes);
-        } else {
-            this.recommendedDepartureTime = null;
+        if (userDepartureTime != null && this.arrivalTime != null) {
+            Duration delta = Duration.between(this.arrivalTime, nextArrival);
+            this.userDepartureTime = this.userDepartureTime.plus(delta);
         }
+        this.arrivalTime = nextArrival;
+        this.recommendedDepartureTime = (estimatedDurationMinutes != null)
+                ? nextArrival.minusMinutes(estimatedDurationMinutes)
+                : null;
         recalculateDepartureAdvice();
         recalculateReminderAt();
+        // estimatedDurationMinutes == null 로 reminderAt 이 null 이 되는 경우 fallback —
+        // 다음 dispatch 의 ODsay 재호출이 estimatedDurationMinutes 를 채워 정상화될 기회 확보.
+        if (reminderAt == null && reminderOffsetMinutes != null) {
+            this.reminderAt = nextArrival.minusMinutes(reminderOffsetMinutes);
+        }
     }
 
     /** PATCH 부분 업데이트용 입력 DTO — 출/도착지 묶음. */

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
@@ -329,6 +329,37 @@ public class Schedule extends BaseEntity {
         }
     }
 
+    /**
+     * 명세 §9.1 — ONCE 일정의 알림 발송 직후 호출. {@code reminder_at = NULL} 로 재발송 방지. 멱등.
+     */
+    public void clearReminderAt() {
+        this.reminderAt = null;
+    }
+
+    /**
+     * 명세 §9.2 — 루틴 일정 다음 occurrence 로 갱신. ODsay 재호출 X
+     * ({@code estimatedDurationMinutes} 마지막 호출값 그대로 사용).
+     *
+     * <p>{@code arrival_time} 갱신 → {@code recommendedDepartureTime} = arrival - duration →
+     * {@code recalculateDepartureAdvice / recalculateReminderAt} 으로 파생값 동기화.
+     *
+     * <p>{@code userDepartureTime} 은 명세 silent — 본 메서드에서 변경 X (P1 보충 후보).
+     * 알림 페이로드는 {@code recommendedDepartureTime} 만 사용하므로 push 동작에 영향 없음.
+     */
+    public void advanceToNextOccurrence(OffsetDateTime nextArrival) {
+        if (deletedAt != null) {
+            throw new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND);
+        }
+        this.arrivalTime = nextArrival;
+        if (estimatedDurationMinutes != null) {
+            this.recommendedDepartureTime = nextArrival.minusMinutes(estimatedDurationMinutes);
+        } else {
+            this.recommendedDepartureTime = null;
+        }
+        recalculateDepartureAdvice();
+        recalculateReminderAt();
+    }
+
     /** PATCH 부분 업데이트용 입력 DTO — 출/도착지 묶음. */
     public record PlaceUpdate(
             String name,

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
@@ -217,10 +217,9 @@ public class Schedule extends BaseEntity {
     }
 
     /**
-     * 부분 업데이트. 출/도착지 또는 arrivalTime 변경 시 true 반환 (ODsay 재호출 분기 trigger).
-     * 명세 §5.4 정합. D8: deleted invariant 가드.
+     * 명세 §5.4 부분 업데이트. {@code deletedAt != null} 시 SCHEDULE_NOT_FOUND — 유령 변경 차단.
      *
-     * @return placeOrArrivalChanged — 출/도착지 또는 arrivalTime 변경 여부
+     * @return placeOrArrivalChanged — 출/도착지 또는 arrivalTime 변경 시 true (ODsay 재호출 trigger)
      */
     public boolean applyUpdate(String title,
                                PlaceUpdate origin,
@@ -278,9 +277,8 @@ public class Schedule extends BaseEntity {
     }
 
     /**
-     * RouteService가 ODsay 호출 후 결과 반영. departureAdvice / reminderAt 자동 재계산.
-     * Step 6 OdsayRouteService와의 ON_TIME_WINDOW_MINUTES silent drift 차단
-     * (claude.ai PR #10 P2 — invariant 통합으로 컴파일 강제 일관성).
+     * RouteService 가 ODsay 호출 후 결과 반영. departureAdvice / reminderAt 자동 재계산.
+     * {@code ON_TIME_WINDOW_MINUTES} 를 본 클래스 단독 소유 — 외부에서 임계값 재정의 시 silent drift.
      */
     public void updateRouteInfo(Integer estimatedDurationMinutes,
                                 OffsetDateTime recommendedDepartureTime,

--- a/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/domain/Schedule.java
@@ -344,11 +344,6 @@ public class Schedule extends BaseEntity {
      * <p>{@code userDepartureTime} delta shift (v1.1.13): {@code arrivalTime} 변화량과 동일하게
      * 사용자 출발 의도 시각도 이동. 미동기화 시 {@code recalculateDepartureAdvice} 가 24h+ 차이로
      * 항상 {@code EARLIER} 가 되어 silent corruption 발생 → §6.1/§5.4 응답이 무의미해진다.
-     *
-     * <p>{@code estimatedDurationMinutes} 부재 시 fallback (v1.1.13): 등록 시 ODsay graceful 실패로
-     * duration 이 NULL 인 routine 의 경우, {@code reminder_at = arrival - reminder_offset} 으로 직접
-     * 추정해 routine 이 silent disable 되지 않도록 보장. 다음 dispatch 의 ODsay 재호출이 성공하면
-     * 정확한 값으로 자동 갱신된다.
      */
     public void advanceToNextOccurrence(OffsetDateTime nextArrival) {
         if (deletedAt != null) {
@@ -359,16 +354,14 @@ public class Schedule extends BaseEntity {
             this.userDepartureTime = this.userDepartureTime.plus(delta);
         }
         this.arrivalTime = nextArrival;
-        this.recommendedDepartureTime = (estimatedDurationMinutes != null)
-                ? nextArrival.minusMinutes(estimatedDurationMinutes)
-                : null;
+        // estimatedDurationMinutes 는 OdsayRouteService.applyToSchedule 가 항상 non-null 로 호출하므로
+        // reminderAt 이 박힌 dispatch 가능 schedule 은 항상 estimatedDurationMinutes 도 non-null. 다만 NPE
+        // 방어 차원에서 가드만 둔다 (defensive).
+        if (estimatedDurationMinutes != null) {
+            this.recommendedDepartureTime = nextArrival.minusMinutes(estimatedDurationMinutes);
+        }
         recalculateDepartureAdvice();
         recalculateReminderAt();
-        // estimatedDurationMinutes == null 로 reminderAt 이 null 이 되는 경우 fallback —
-        // 다음 dispatch 의 ODsay 재호출이 estimatedDurationMinutes 를 채워 정상화될 기회 확보.
-        if (reminderAt == null && reminderOffsetMinutes != null) {
-            this.reminderAt = nextArrival.minusMinutes(reminderOffsetMinutes);
-        }
     }
 
     /** PATCH 부분 업데이트용 입력 DTO — 출/도착지 묶음. */

--- a/backend/src/main/java/com/todayway/backend/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/repository/ScheduleRepository.java
@@ -45,14 +45,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             Long memberId, OffsetDateTime now);
 
     /**
-     * 이상진 Step 7 PushScheduler용 — 알림 시각 도래한 일정 조회.
-     * ⚠️ JPQL `deletedAt IS NULL` 명시 필수.
+     * 명세 §9.1 — PushScheduler 알림 시각 도래 일정 조회. {@code reminder_at > NOW()-5min AND <= NOW()}
+     * 누락 방지 윈도우 + soft-delete 필터.
+     *
+     * <p>{@code MemberService.softDelete} cascade 가 schedule 도 일괄 soft-delete 하므로 회원 deleted
+     * 시 자동으로 본 쿼리에서 제외되지만, 명세 §9.1 SQL 본문이 {@code m.deleted_at IS NULL} 도 명시하므로
+     * defense-in-depth 로 Member subquery 추가 (cascade 부분 실패 / 데이터 마이그레이션 시 안전망).
      */
     @Query("""
             SELECT s FROM Schedule s
             WHERE s.reminderAt > :windowStart
               AND s.reminderAt <= :now
               AND s.deletedAt IS NULL
+              AND s.memberId IN (SELECT m.id FROM Member m WHERE m.deletedAt IS NULL)
             """)
     List<Schedule> findDueReminders(@Param("now") OffsetDateTime now,
                                     @Param("windowStart") OffsetDateTime windowStart);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -66,3 +66,11 @@ push:
     window-minutes: 5                          # 명세 §9.1 — 누락 방지 윈도우
     odsay-max-attempts: 2                      # 명세 §9.1 — 최대 2회 시도
     odsay-retry-interval-ms: 1000              # 명세 §9.1 — 1초 간격
+
+map:                                            # 명세 §4.2 GET /map/config 정적 응답
+  provider: ${MAP_PROVIDER:NAVER}
+  default-zoom: ${MAP_DEFAULT_ZOOM:15}
+  default-center:
+    lat: ${MAP_DEFAULT_CENTER_LAT:37.5665}     # 서울시청 (명세 예시 디폴트)
+    lng: ${MAP_DEFAULT_CENTER_LNG:126.9780}
+  tile-style: ${MAP_TILE_STYLE:basic}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -58,3 +58,11 @@ vapid:
   public-key: ${VAPID_PUBLIC_KEY:}
   private-key: ${VAPID_PRIVATE_KEY:}
   subject: mailto:contact@todayway.example
+
+push:
+  scheduler:
+    enabled: ${PUSH_SCHEDULER_ENABLED:true}   # 테스트/dev에서 false 로 끔
+    fixed-delay-ms: 30000                      # 명세 §9.1 — 30초 주기
+    window-minutes: 5                          # 명세 §9.1 — 누락 방지 윈도우
+    odsay-max-attempts: 2                      # 명세 §9.1 — 최대 2회 시도
+    odsay-retry-interval-ms: 1000              # 명세 §9.1 — 1초 간격

--- a/backend/src/test/java/com/todayway/backend/common/jwt/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/jwt/JwtAuthenticationFilterTest.java
@@ -91,4 +91,23 @@ class JwtAuthenticationFilterTest {
         assertThat(response.getStatus()).isEqualTo(200);
         verify(chain, times(1)).doFilter(request, response);
     }
+
+    @Test
+    void 만료된_토큰이지만_permitAll_path_GET_main이면_401_차단_X_체인_진행_명세_4_1_게스트_허용() throws Exception {
+        // Step 8 self-review F-F — 만료 토큰 + permitAll endpoint = 게스트 흐름. 인증 필요 endpoint 만 401.
+        JwtProvider expiredProvider = new JwtProvider(new JwtProperties(TEST_SECRET, 0, 0, ISSUER));
+        String expiredToken = expiredProvider.issueAccessToken(MEMBER_UID);
+        Thread.sleep(50);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/main");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain, times(1)).doFilter(request, response);
+    }
 }

--- a/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
@@ -15,11 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Resolver 단위 테스트.
- * SecurityFilterChain 의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
- *
- * <p>{@code MethodParameter} 는 더미 메서드 시그니처에서 추출 — production 환경에서는 Spring 이
- * controller 메서드의 파라미터로부터 항상 valid {@code MethodParameter} 를 전달한다.
+ * Resolver 단위 테스트. SecurityFilterChain 의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
  */
 class CurrentMemberArgumentResolverTest {
 

--- a/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/web/CurrentMemberArgumentResolverTest.java
@@ -4,21 +4,45 @@ import com.todayway.backend.common.exception.BusinessException;
 import com.todayway.backend.common.exception.ErrorCode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Resolver 단위 테스트 (claude.ai PR #7 리뷰 P2 흡수).
- * SecurityFilterChain의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
+ * Resolver 단위 테스트.
+ * SecurityFilterChain 의 인증 보장과 별도로 Resolver 자체의 안전망 검증.
+ *
+ * <p>{@code MethodParameter} 는 더미 메서드 시그니처에서 추출 — production 환경에서는 Spring 이
+ * controller 메서드의 파라미터로부터 항상 valid {@code MethodParameter} 를 전달한다.
  */
 class CurrentMemberArgumentResolverTest {
 
     private final CurrentMemberArgumentResolver resolver = new CurrentMemberArgumentResolver();
+
+    @SuppressWarnings("unused")
+    private static class TargetMethods {
+        void requiredMethod(@CurrentMember String memberUid) {
+        }
+
+        void optionalMethod(@CurrentMember(required = false) String memberUid) {
+        }
+    }
+
+    private static MethodParameter requiredParam() throws NoSuchMethodException {
+        Method m = TargetMethods.class.getDeclaredMethod("requiredMethod", String.class);
+        return new MethodParameter(m, 0);
+    }
+
+    private static MethodParameter optionalParam() throws NoSuchMethodException {
+        Method m = TargetMethods.class.getDeclaredMethod("optionalMethod", String.class);
+        return new MethodParameter(m, 0);
+    }
 
     @AfterEach
     void clearSecurityContext() {
@@ -26,29 +50,32 @@ class CurrentMemberArgumentResolverTest {
     }
 
     @Test
-    void resolveArgument_whenAuthenticationNull_throwsUnauthorized() {
+    void resolveArgument_whenAuthenticationNull_throwsUnauthorized() throws Exception {
         SecurityContextHolder.clearContext();
-        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+        MethodParameter param = requiredParam();
+        assertThatThrownBy(() -> resolver.resolveArgument(param, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.UNAUTHORIZED);
     }
 
     @Test
-    void resolveArgument_whenPrincipalNotString_throwsUnauthorized() {
+    void resolveArgument_whenPrincipalNotString_throwsUnauthorized() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(new Object(), null, List.of()));
-        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+        MethodParameter param = requiredParam();
+        assertThatThrownBy(() -> resolver.resolveArgument(param, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.UNAUTHORIZED);
     }
 
     @Test
-    void resolveArgument_whenMemberUidBlank_throwsUnauthorized() {
+    void resolveArgument_whenMemberUidBlank_throwsUnauthorized() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("   ", null, List.of()));
-        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+        MethodParameter param = requiredParam();
+        assertThatThrownBy(() -> resolver.resolveArgument(param, null, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.UNAUTHORIZED);
@@ -58,7 +85,26 @@ class CurrentMemberArgumentResolverTest {
     void resolveArgument_whenValidPrincipal_returnsMemberUid() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("01HAA0123456789ABCDEFGHJK", null, List.of()));
-        Object result = resolver.resolveArgument(null, null, null, null);
+        MethodParameter param = requiredParam();
+        Object result = resolver.resolveArgument(param, null, null, null);
+        assertThat(result).isEqualTo("01HAA0123456789ABCDEFGHJK");
+    }
+
+    @Test
+    void resolveArgument_whenOptional_andUnauthenticated_returnsNull() throws Exception {
+        // 명세 §4.1 — GET /main 게스트 허용. @CurrentMember(required=false) 면 null 주입.
+        SecurityContextHolder.clearContext();
+        MethodParameter param = optionalParam();
+        Object result = resolver.resolveArgument(param, null, null, null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void resolveArgument_whenOptional_andAuthenticated_returnsMemberUid() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("01HAA0123456789ABCDEFGHJK", null, List.of()));
+        MethodParameter param = optionalParam();
+        Object result = resolver.resolveArgument(param, null, null, null);
         assertThat(result).isEqualTo("01HAA0123456789ABCDEFGHJK");
     }
 }

--- a/backend/src/test/java/com/todayway/backend/geocode/controller/GeocodeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/geocode/controller/GeocodeControllerIntegrationTest.java
@@ -1,0 +1,260 @@
+package com.todayway.backend.geocode.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.kakao.KakaoLocalClient;
+import com.todayway.backend.external.kakao.dto.KakaoLocalSearchResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §8.1 — POST /geocode 통합 테스트.
+ *
+ * <p>{@link KakaoLocalClient} 는 {@code @MockitoBean} — 외부 호출 격리, 매핑/캐시 흐름만 검증.
+ *
+ * <p>회귀 가드 매트릭스:
+ * <ul>
+ *   <li>정상 매치 / 캐시 hit (Kakao 호출 1회)</li>
+ *   <li>미스 → 404 / 미스 캐시 hit</li>
+ *   <li>401 → 503 / 5xx → 502 / timeout → 504 (명세 §8.1 매핑표)</li>
+ *   <li>인증 401 / query blank → 400</li>
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class GeocodeControllerIntegrationTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean KakaoLocalClient kakaoLocalClient;
+
+    @Test
+    void 정상_매치_200_GeocodeResponse_v1_1_4_매핑표_정합() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(matchedResponse());
+
+        String token = signupAndGetToken("geo01", "정상");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"국민대학교 geo01\" }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.matched").value(true))
+                .andExpect(jsonPath("$.data.name").value("국민대학교"))
+                // road_address_name 우선 (명세 §8.1 v1.1.4)
+                .andExpect(jsonPath("$.data.address").value("서울 성북구 정릉로 77"))
+                .andExpect(jsonPath("$.data.lat").value(37.6103))
+                .andExpect(jsonPath("$.data.lng").value(126.9969))
+                .andExpect(jsonPath("$.data.placeId").value("1234567"))
+                .andExpect(jsonPath("$.data.provider").value("KAKAO_LOCAL"));
+    }
+
+    @Test
+    void 캐시_hit_같은_query_두번째_호출시_Kakao_X_verify_times_1() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(matchedResponse());
+        String token = signupAndGetToken("geocache01", "캐시");
+
+        // 1차 호출 — Kakao 호출 + 캐시 INSERT
+        callGeocode(token, "국민대학교 cache01");
+        // 2차 호출 — TTL 안 → cache hit, Kakao 호출 X
+        callGeocode(token, "국민대학교 cache01");
+
+        verify(kakaoLocalClient, times(1)).searchKeyword(any());
+    }
+
+    @Test
+    void road_address_빈값이면_address_name_fallback() throws Exception {
+        // 명세 §8.1 v1.1.4 — road_address_name 빈값이면 address_name fallback.
+        KakaoLocalSearchResponse.Document doc = new KakaoLocalSearchResponse.Document(
+                "9876", "어떤장소", "서울 성북구 정릉동 100", "", "", "127.001", "37.600");
+        KakaoLocalSearchResponse resp = new KakaoLocalSearchResponse(
+                new KakaoLocalSearchResponse.Meta(1, 1, true), List.of(doc));
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(resp);
+
+        String token = signupAndGetToken("geofallback01", "fallback");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"어떤장소 fb01\" }"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.address").value("서울 성북구 정릉동 100"));
+    }
+
+    @Test
+    void documents_빈배열_404_GEOCODE_NO_MATCH() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(emptyResponse());
+
+        String token = signupAndGetToken("geomiss01", "미스");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"asdfasdfasdf miss01\" }"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("GEOCODE_NO_MATCH"));
+    }
+
+    @Test
+    void 미스_캐시_hit_두번째_호출시_Kakao_X_verify_times_1() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenReturn(emptyResponse());
+        String token = signupAndGetToken("geomisscache01", "미스캐시");
+
+        // 1차 — Kakao 호출 + miss row INSERT + 404
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"asdf misscache01\" }"))
+                .andExpect(status().isNotFound());
+        // 2차 — cache hit (matched=false) → 404, Kakao 호출 X
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"asdf misscache01\" }"))
+                .andExpect(status().isNotFound());
+
+        verify(kakaoLocalClient, times(1)).searchKeyword(any());
+    }
+
+    @Test
+    void Kakao_401_503_EXTERNAL_AUTH_MISCONFIGURED() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenThrow(new ExternalApiException(
+                ExternalApiException.Source.KAKAO_LOCAL,
+                ExternalApiException.Type.CLIENT_ERROR, 401, "401", null));
+        String token = signupAndGetToken("geo401", "auth");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"q401\" }"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_AUTH_MISCONFIGURED"));
+    }
+
+    @Test
+    void Kakao_5xx_502_EXTERNAL_ROUTE_API_FAILED() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenThrow(new ExternalApiException(
+                ExternalApiException.Source.KAKAO_LOCAL,
+                ExternalApiException.Type.SERVER_ERROR, 502, "502", null));
+        String token = signupAndGetToken("geo502", "5xx");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"q502\" }"))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_ROUTE_API_FAILED"));
+    }
+
+    @Test
+    void Kakao_timeout_504_EXTERNAL_TIMEOUT() throws Exception {
+        when(kakaoLocalClient.searchKeyword(any())).thenThrow(new ExternalApiException(
+                ExternalApiException.Source.KAKAO_LOCAL,
+                ExternalApiException.Type.TIMEOUT, null, "timeout", null));
+        String token = signupAndGetToken("geotimeout", "timeout");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"qtimeout\" }"))
+                .andExpect(status().isGatewayTimeout())
+                .andExpect(jsonPath("$.error.code").value("EXTERNAL_TIMEOUT"));
+    }
+
+    @Test
+    void 인증_없이_geocode_401() throws Exception {
+        mockMvc.perform(post("/api/v1/geocode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"국민대\" }"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void query_blank이면_400_VALIDATION_ERROR() throws Exception {
+        String token = signupAndGetToken("geoval", "검증");
+
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"\" }"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    // ───── helpers ─────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private void callGeocode(String token, String query) throws Exception {
+        mockMvc.perform(post("/api/v1/geocode")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"query\": \"" + query + "\" }"))
+                .andExpect(status().isOk());
+    }
+
+    private static KakaoLocalSearchResponse matchedResponse() {
+        KakaoLocalSearchResponse.Document doc = new KakaoLocalSearchResponse.Document(
+                "1234567",
+                "국민대학교",
+                "서울 성북구 정릉동 861-1",
+                "서울 성북구 정릉로 77",
+                "SC4",
+                "126.9969",   // x = lng (Kakao string)
+                "37.6103"     // y = lat
+        );
+        return new KakaoLocalSearchResponse(
+                new KakaoLocalSearchResponse.Meta(1, 1, true), List.of(doc));
+    }
+
+    private static KakaoLocalSearchResponse emptyResponse() {
+        return new KakaoLocalSearchResponse(
+                new KakaoLocalSearchResponse.Meta(0, 0, true), List.of());
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -85,7 +86,7 @@ class MapControllerIntegrationTest {
     void main_게스트_토큰없이_200_nearestSchedule_null_mapCenter_default() throws Exception {
         mockMvc.perform(get("/api/v1/main"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.nearestSchedule").value(nullValue()))
                 .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665))
                 .andExpect(jsonPath("$.data.mapCenter.lng").value(126.9780));
     }
@@ -94,7 +95,7 @@ class MapControllerIntegrationTest {
     void main_게스트_query_lat_lng_제공시_mapCenter_query() throws Exception {
         mockMvc.perform(get("/api/v1/main?lat=37.66&lng=127.01"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.nearestSchedule").value(nullValue()))
                 .andExpect(jsonPath("$.data.mapCenter.lat").value(37.66))
                 .andExpect(jsonPath("$.data.mapCenter.lng").value(127.01));
     }
@@ -105,7 +106,7 @@ class MapControllerIntegrationTest {
 
         mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.nearestSchedule").value(nullValue()))
                 .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665));
     }
 

--- a/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/map/controller/MapControllerIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.todayway.backend.map.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.Schedule;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §4.1 (GET /main) + §4.2 (GET /map/config) 통합 테스트.
+ *
+ * <p>{@link RouteService} 는 {@code @MockitoBean} — schedule 등록 흐름의 ODsay 호출 격리.
+ * push.scheduler.enabled=false 로 통합 테스트 중 자동 트리거 차단.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MapControllerIntegrationTest {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean RouteService routeService;
+
+    // ─────────── §4.2 GET /map/config ───────────
+
+    @Test
+    void mapConfig_정상_200_명세_4_2_정적_응답() throws Exception {
+        mockMvc.perform(get("/api/v1/map/config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.provider").value("NAVER"))
+                .andExpect(jsonPath("$.data.defaultZoom").value(15))
+                .andExpect(jsonPath("$.data.defaultCenter.lat").value(37.5665))
+                .andExpect(jsonPath("$.data.defaultCenter.lng").value(126.9780))
+                .andExpect(jsonPath("$.data.tileStyle").value("basic"));
+    }
+
+    @Test
+    void mapConfig_인증_없이도_200_permitAll() throws Exception {
+        // /map/config 는 SecurityConfig.permitAll 등록 — Authorization 헤더 없음에도 200.
+        mockMvc.perform(get("/api/v1/map/config"))
+                .andExpect(status().isOk());
+    }
+
+    // ─────────── §4.1 GET /main ───────────
+
+    @Test
+    void main_게스트_토큰없이_200_nearestSchedule_null_mapCenter_default() throws Exception {
+        mockMvc.perform(get("/api/v1/main"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(126.9780));
+    }
+
+    @Test
+    void main_게스트_query_lat_lng_제공시_mapCenter_query() throws Exception {
+        mockMvc.perform(get("/api/v1/main?lat=37.66&lng=127.01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.66))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(127.01));
+    }
+
+    @Test
+    void main_인증_일정없음_nearestSchedule_null_mapCenter_default() throws Exception {
+        String token = signupAndGetToken("mainnoschd01", "일정없음");
+
+        mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule").doesNotExist())
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.5665));
+    }
+
+    @Test
+    void main_인증_일정있음_nearestSchedule_채워지고_mapCenter_origin() throws Exception {
+        // refresh 실패 stub (graceful) — schedule 등록은 성공, hasCalculatedRoute=false
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String token = signupAndGetToken("mainwithschd01", "일정있음");
+        String externalScheduleId = createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule.scheduleId").value(externalScheduleId))
+                .andExpect(jsonPath("$.data.nearestSchedule.title").value("메인테스트"))
+                .andExpect(jsonPath("$.data.nearestSchedule.origin.name").value("우이동"))
+                .andExpect(jsonPath("$.data.nearestSchedule.origin.lat").value(37.6612))
+                .andExpect(jsonPath("$.data.nearestSchedule.origin.lng").value(127.0124))
+                .andExpect(jsonPath("$.data.nearestSchedule.destination.name").value("국민대"))
+                .andExpect(jsonPath("$.data.nearestSchedule.hasCalculatedRoute").value(false))
+                // mapCenter 우선순위 ② nearestSchedule.origin (query lat/lng 없음)
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.6612))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(127.0124));
+    }
+
+    @Test
+    void main_인증_일정있고_query_제공시_mapCenter_query_우선() throws Exception {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        String token = signupAndGetToken("mainquery01", "쿼리우선");
+        createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/main?lat=37.50&lng=127.30")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                // ① query 가 ② origin 보다 우선
+                .andExpect(jsonPath("$.data.mapCenter.lat").value(37.50))
+                .andExpect(jsonPath("$.data.mapCenter.lng").value(127.30));
+    }
+
+    @Test
+    void main_인증_일정있고_route_계산완료시_hasCalculatedRoute_true() throws Exception {
+        // refreshRouteSync 가 schedule.updateRouteInfo 를 호출해 routeSummaryJson 채움 → hasCalculatedRoute=true
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            s.updateRouteInfo(34, s.getArrivalTime().minusMinutes(34),
+                    "{\"path\":{},\"lane\":null}", OffsetDateTime.now(KST));
+            return true;
+        });
+        String token = signupAndGetToken("mainroute01", "경로있음");
+        createSchedule(token);
+
+        mockMvc.perform(get("/api/v1/main").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nearestSchedule.hasCalculatedRoute").value(true))
+                .andExpect(jsonPath("$.data.nearestSchedule.recommendedDepartureTime").exists());
+    }
+
+    // ─────────── helpers ───────────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private String createSchedule(String token) throws Exception {
+        OffsetDateTime arrival = OffsetDateTime.now(KST).plusMinutes(60);
+        OffsetDateTime depart = arrival.minusMinutes(30);
+        String body = """
+                {
+                  "title": "메인테스트",
+                  "origin": {"name":"우이동","lat":37.6612,"lng":127.0124},
+                  "destination": {"name":"국민대","lat":37.6103,"lng":126.9969},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s",
+                  "reminderOffsetMinutes": 5
+                }
+                """.formatted(depart, arrival);
+        String resp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("scheduleId").asText();
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/push/MemberSoftDeleteCascadeTest.java
+++ b/backend/src/test/java/com/todayway/backend/push/MemberSoftDeleteCascadeTest.java
@@ -1,0 +1,113 @@
+package com.todayway.backend.push;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.push.domain.PushSubscription;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #9 회귀 가드 — {@code MemberService.softDelete} cascade 가
+ * {@code push_subscription.revoked_at} 을 일괄 갱신하는지 검증.
+ *
+ * <p>시나리오 (이슈 #9 본문 그대로):
+ * <ol>
+ *   <li>회원가입 → access token</li>
+ *   <li>push 구독 등록 (다중 디바이스 시나리오 — 2건)</li>
+ *   <li>회원 탈퇴 ({@code DELETE /api/v1/members/me})</li>
+ *   <li>DB에서 모든 활성 구독이 {@code revoked_at IS NOT NULL} 인지 검증</li>
+ * </ol>
+ *
+ * <p>이 테스트는 코드가 cascade를 실수로 빼먹어도 (DB FK CASCADE 는 hard-delete 에서만 동작 —
+ * soft-delete 환경에선 코드가 유일한 보호선) 즉시 실패해 silent 회귀를 차단한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MemberSoftDeleteCascadeTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired PushSubscriptionRepository subscriptionRepository;
+
+    @Test
+    void 회원_탈퇴시_모든_활성_push_subscription_revoke_cascade() throws Exception {
+        // 1) 가입
+        String token = signupAndGetToken("cascade01", "탈퇴자");
+
+        // 2) 다중 디바이스 시뮬레이션 — 2건 구독
+        subscribe(token, "https://fcm.googleapis.com/fcm/send/cascade-pc");
+        subscribe(token, "https://fcm.googleapis.com/fcm/send/cascade-mobile");
+
+        long activeBefore = subscriptionRepository.findAll().stream()
+                .filter(PushSubscription::isActive)
+                .count();
+        assertEquals(2L, activeBefore, "탈퇴 전 2건 활성");
+
+        // 3) 회원 탈퇴
+        mockMvc.perform(delete("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        // 4) cascade 검증 — 모든 row 의 revoked_at non-null
+        for (PushSubscription sub : subscriptionRepository.findAll()) {
+            assertFalse(sub.isActive(),
+                    "회원 탈퇴 cascade — subscriptionUid=" + sub.getSubscriptionUid()
+                            + " 가 revoke 되어야 함 (issue #9)");
+            assertNotNull(sub.getRevokedAt(), "revoked_at 시각이 박혀야 함");
+        }
+    }
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private void subscribe(String token, String endpoint) throws Exception {
+        String body = """
+                { "endpoint": "%s", "keys": { "p256dh": "BNc-cascade", "auth": "auth-cascade" } }
+                """.formatted(endpoint);
+        mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/push/controller/PushControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/push/controller/PushControllerIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * <p>회귀 가드: 인증/인가/sub_ prefix/UPSERT(reactivate)/타인 endpoint 403/없는 sub 404/
  * validation(@NotBlank endpoint, keys.p256dh, keys.auth).
  *
- * <p>{@code push.scheduler.enabled=false} — 통합 테스트 중 30초 cycle 자동 발사 차단.
+ * <p>{@code push.scheduler.enabled=false} — 통합 테스트 중 스케줄러 자동 트리거 차단.
  */
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/backend/src/test/java/com/todayway/backend/push/controller/PushControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/push/controller/PushControllerIntegrationTest.java
@@ -1,0 +1,192 @@
+package com.todayway.backend.push.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §7.1 / §7.2 — Push 구독 등록·해제 통합 테스트.
+ *
+ * <p>회귀 가드: 인증/인가/sub_ prefix/UPSERT(reactivate)/타인 endpoint 403/없는 sub 404/
+ * validation(@NotBlank endpoint, keys.p256dh, keys.auth).
+ *
+ * <p>{@code push.scheduler.enabled=false} — 통합 테스트 중 30초 cycle 자동 발사 차단.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PushControllerIntegrationTest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @Test
+    void 정상_subscribe_201_sub_prefix_subscriptionId_반환() throws Exception {
+        String token = signupAndGetToken("pushsub01", "구독자");
+
+        mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + token)
+                        .header("User-Agent", "Mozilla/5.0 (Test)")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subscribeBody("https://fcm.googleapis.com/fcm/send/test001",
+                                "BNc-test-p256dh-key-1", "tBHI-auth-1")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.subscriptionId").value(org.hamcrest.Matchers.startsWith("sub_")));
+    }
+
+    @Test
+    void 동일_endpoint_재구독시_같은_subscriptionId_반환_revoked_at_재활성화() throws Exception {
+        String token = signupAndGetToken("pushrearm01", "재활성화");
+        String endpoint = "https://fcm.googleapis.com/fcm/send/rearm001";
+
+        // 1차 구독
+        String first = subscribe(token, endpoint, "BNc-key-1", "auth-1");
+
+        // 2차 구독 (키 회전 시뮬레이션) — 같은 endpoint 재사용
+        String second = subscribe(token, endpoint, "BNc-key-2", "auth-2");
+
+        // 명세 §7.1 비고 — 동일 endpoint 재구독은 row 갱신, subscriptionId 보존
+        org.junit.jupiter.api.Assertions.assertEquals(first, second);
+    }
+
+    @Test
+    void 다른_회원이_동일_endpoint_재구독시_403_FORBIDDEN_RESOURCE() throws Exception {
+        String tokenA = signupAndGetToken("pushown01", "원소유자");
+        String endpoint = "https://fcm.googleapis.com/fcm/send/conflict001";
+        subscribe(tokenA, endpoint, "BNc-A", "auth-A");
+
+        String tokenB = signupAndGetToken("pushint01", "침입자");
+        mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + tokenB)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subscribeBody(endpoint, "BNc-B", "auth-B")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN_RESOURCE"));
+    }
+
+    @Test
+    void 정상_unsubscribe_204_NoContent() throws Exception {
+        String token = signupAndGetToken("pushrm01", "해제자");
+        String subscriptionId = subscribe(token, "https://fcm.googleapis.com/fcm/send/rm001", "BNc", "auth");
+
+        mockMvc.perform(delete("/api/v1/push/subscribe/" + subscriptionId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void 다른_사용자의_subscriptionId_해제시도_403() throws Exception {
+        String ownerToken = signupAndGetToken("pushrmown01", "구독소유자");
+        String subscriptionId = subscribe(ownerToken,
+                "https://fcm.googleapis.com/fcm/send/rmperm001", "BNc", "auth");
+
+        String otherToken = signupAndGetToken("pushrmoth01", "다른사용자");
+        mockMvc.perform(delete("/api/v1/push/subscribe/" + subscriptionId)
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN_RESOURCE"));
+    }
+
+    @Test
+    void 존재하지_않는_subscriptionId_해제시_404_SUBSCRIPTION_NOT_FOUND() throws Exception {
+        String token = signupAndGetToken("pushrm404", "없는구독");
+
+        mockMvc.perform(delete("/api/v1/push/subscribe/sub_01HXX0000NOEXIST123456ABCDE")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("SUBSCRIPTION_NOT_FOUND"));
+    }
+
+    @Test
+    void 인증_없이_subscribe_401() throws Exception {
+        mockMvc.perform(post("/api/v1/push/subscribe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subscribeBody("https://fcm.googleapis.com/fcm/send/noauth", "BNc", "auth")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void endpoint_blank이면_400_VALIDATION_ERROR() throws Exception {
+        String token = signupAndGetToken("pushval01", "검증");
+
+        mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subscribeBody("", "BNc", "auth")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void keys_p256dh_blank이면_400_VALIDATION_ERROR() throws Exception {
+        String token = signupAndGetToken("pushval02", "키검증");
+
+        mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subscribeBody("https://fcm.googleapis.com/fcm/send/val02", "", "auth")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    // ───── helpers ─────
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(resp).path("data");
+        return node.path("accessToken").asText();
+    }
+
+    private String subscribe(String token, String endpoint, String p256dh, String auth) throws Exception {
+        String resp = mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(subscribeBody(endpoint, p256dh, auth)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("subscriptionId").asText();
+    }
+
+    private static String subscribeBody(String endpoint, String p256dh, String auth) {
+        return """
+                {
+                  "endpoint": "%s",
+                  "keys": { "p256dh": "%s", "auth": "%s" }
+                }
+                """.formatted(endpoint, p256dh, auth);
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/push/service/PushReminderDispatcherIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/push/service/PushReminderDispatcherIntegrationTest.java
@@ -1,0 +1,271 @@
+package com.todayway.backend.push.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.auth.dto.SignupRequest;
+import com.todayway.backend.push.domain.PushLog;
+import com.todayway.backend.push.domain.PushStatus;
+import com.todayway.backend.push.domain.PushSubscription;
+import com.todayway.backend.push.repository.PushLogRepository;
+import com.todayway.backend.push.repository.PushSubscriptionRepository;
+import com.todayway.backend.push.sender.PushSendResult;
+import com.todayway.backend.push.sender.PushSender;
+import com.todayway.backend.route.RouteService;
+import com.todayway.backend.schedule.domain.Schedule;
+import com.todayway.backend.schedule.repository.ScheduleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 명세 §9.1 / §9.2 — PushReminderDispatcher 통합 테스트.
+ *
+ * <p>{@code RouteService} / {@code PushSender} 는 {@code @MockitoBean} 으로 대체 — 외부 호출 없이
+ * 흐름 분기만 검증. push.scheduler.enabled=false 로 자동 트리거 차단, dispatcher 직접 호출.
+ *
+ * <p>회귀 가드: 정상 SENT + ONCE 종료 / ODsay 실패 폴백 / 410 EXPIRED + revoke / 루틴 advance.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PushReminderDispatcherIntegrationTest {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+    private static final String SCH_PREFIX = "sch_";
+    private static final String SUB_PREFIX = "sub_";
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("routine_commute");
+
+    @DynamicPropertySource
+    static void mysqlProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("jwt.secret", () -> "dGVzdC1zZWNyZXQtYmFzZTY0LXBhZGRlZC0zMmJ5dGVzLWxvbmc9PQ==");
+        registry.add("push.scheduler.enabled", () -> "false");
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired PushReminderDispatcher dispatcher;
+    @Autowired ScheduleRepository scheduleRepository;
+    @Autowired PushSubscriptionRepository subscriptionRepository;
+    @Autowired PushLogRepository pushLogRepository;
+
+    @MockitoBean RouteService routeService;
+    @MockitoBean PushSender pushSender;
+
+    @Test
+    void 정상_ODsay성공_PushSender_SENT_ONCE_일정_reminderAt_NULL() throws Exception {
+        stubRouteRefreshSuccess(34);
+        when(pushSender.send(any(PushSubscription.class), any(String.class)))
+                .thenReturn(PushSendResult.sent(201));
+
+        String token = signupAndGetToken("disp01", "정상발송");
+        String externalSubId = subscribe(token, "https://fcm.googleapis.com/fcm/send/disp01");
+        String externalScheduleId = createOnceSchedule(token);
+
+        Long scheduleDbId = schId(externalScheduleId);
+        dispatcher.process(scheduleDbId);
+
+        Schedule s = scheduleRepository.findById(scheduleDbId).orElseThrow();
+        assertNull(s.getReminderAt(), "ONCE 일정 발송 후 reminder_at 은 NULL (재발송 방지)");
+        assertNotNull(s.getRouteCalculatedAt(), "ODsay 갱신 결과 반영");
+
+        List<PushLog> logs = pushLogRepository.findAll();
+        assertEquals(1, logs.size());
+        assertEquals(PushStatus.SENT, logs.get(0).getStatus());
+        assertEquals(201, logs.get(0).getHttpStatus());
+
+        Long subDbId = subId(externalSubId);
+        PushSubscription sub = subscriptionRepository.findById(subDbId).orElseThrow();
+        assertTrue(sub.isActive(), "정상 발송에선 구독 유지");
+    }
+
+    @Test
+    void ODsay_재시도_모두_실패_폴백_페이로드_fallback_true_SENT() throws Exception {
+        // 등록 시는 정상 (reminder_at 박힘). dispatch 시점에는 false.
+        stubRouteRefreshSuccess(40);
+        String token = signupAndGetToken("disp02", "폴백");
+        String externalSubId = subscribe(token, "https://fcm.googleapis.com/fcm/send/disp02");
+        String externalScheduleId = createOnceSchedule(token);
+
+        // 등록 끝났으니 이후 dispatch 시점에는 ODsay 실패
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+        when(pushSender.send(any(PushSubscription.class), any(String.class)))
+                .thenReturn(PushSendResult.sent(201));
+
+        Long scheduleDbId = schId(externalScheduleId);
+        dispatcher.process(scheduleDbId);
+
+        // odsayMaxAttempts=2 — 폴백 진입 시 총 2회 호출됨 (등록 시 1회 + dispatch 시 추가 2회 = 3회 호출 누적)
+        verify(routeService, times(3)).refreshRouteSync(any(Schedule.class));
+
+        List<PushLog> logs = pushLogRepository.findAll();
+        assertEquals(1, logs.size());
+        assertEquals(PushStatus.SENT, logs.get(0).getStatus());
+
+        JsonNode payload = objectMapper.readTree(logs.get(0).getPayloadJson());
+        assertTrue(payload.path("data").path("fallback").asBoolean(),
+                "ODsay 실패 시 data.fallback=true (명세 §9.1)");
+        assertEquals("EXTERNAL_ROUTE_API_FAILED",
+                payload.path("data").path("fallbackReason").asText());
+
+        // 사용 안 함 경고 차단 — externalSubId 검증 (구독 보존)
+        Long subDbId = subId(externalSubId);
+        assertTrue(subscriptionRepository.findById(subDbId).orElseThrow().isActive());
+    }
+
+    @Test
+    void PushSender_410_Gone_응답시_push_log_EXPIRED_subscription_revoke() throws Exception {
+        stubRouteRefreshSuccess(34);
+        when(pushSender.send(any(PushSubscription.class), any(String.class)))
+                .thenReturn(PushSendResult.expired());
+
+        String token = signupAndGetToken("disp03", "만료");
+        String externalSubId = subscribe(token, "https://fcm.googleapis.com/fcm/send/disp03");
+        String externalScheduleId = createOnceSchedule(token);
+
+        Long scheduleDbId = schId(externalScheduleId);
+        dispatcher.process(scheduleDbId);
+
+        List<PushLog> logs = pushLogRepository.findAll();
+        assertEquals(1, logs.size());
+        assertEquals(PushStatus.EXPIRED, logs.get(0).getStatus());
+        assertEquals(410, logs.get(0).getHttpStatus());
+
+        Long subDbId = subId(externalSubId);
+        PushSubscription sub = subscriptionRepository.findById(subDbId).orElseThrow();
+        assertEquals(false, sub.isActive(), "410 Gone 시 자동 revoke (명세 §12.6)");
+    }
+
+    @Test
+    void DAILY_루틴_일정_advance_to_next_occurrence_reminderAt_미래_갱신() throws Exception {
+        stubRouteRefreshSuccess(30);
+        when(pushSender.send(any(PushSubscription.class), any(String.class)))
+                .thenReturn(PushSendResult.sent(201));
+
+        String token = signupAndGetToken("disp04", "루틴");
+        subscribe(token, "https://fcm.googleapis.com/fcm/send/disp04");
+
+        OffsetDateTime origArrival = OffsetDateTime.now(KST).plusMinutes(60);
+        String externalScheduleId = createDailySchedule(token, origArrival);
+
+        Long scheduleDbId = schId(externalScheduleId);
+        dispatcher.process(scheduleDbId);
+
+        Schedule s = scheduleRepository.findById(scheduleDbId).orElseThrow();
+        assertTrue(s.getArrivalTime().isAfter(origArrival.plusHours(23)),
+                "DAILY 루틴은 다음 날로 advance (명세 §9.2)");
+        assertNotNull(s.getReminderAt(), "advance 후 reminderAt 재계산 (NULL 아님)");
+        assertTrue(s.getReminderAt().isAfter(OffsetDateTime.now(KST)),
+                "advance 후 reminderAt 은 미래 시각");
+    }
+
+    // ───── helpers ─────
+
+    private void stubRouteRefreshSuccess(int durationMinutes) {
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenAnswer(inv -> {
+            Schedule s = inv.getArgument(0);
+            s.updateRouteInfo(durationMinutes,
+                    s.getArrivalTime().minusMinutes(durationMinutes),
+                    "{\"path\":{},\"lane\":null}",
+                    OffsetDateTime.now(KST));
+            return true;
+        });
+    }
+
+    private String signupAndGetToken(String loginId, String nickname) throws Exception {
+        SignupRequest req = new SignupRequest(loginId, "P@ssw0rd!", nickname);
+        String resp = mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("accessToken").asText();
+    }
+
+    private String subscribe(String token, String endpoint) throws Exception {
+        String body = """
+                { "endpoint": "%s", "keys": { "p256dh": "BNc-test", "auth": "auth-test" } }
+                """.formatted(endpoint);
+        String resp = mockMvc.perform(post("/api/v1/push/subscribe")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("subscriptionId").asText();
+    }
+
+    private String createOnceSchedule(String token) throws Exception {
+        OffsetDateTime arrival = OffsetDateTime.now(KST).plusMinutes(60);
+        return createSchedule(token, arrival, null);
+    }
+
+    private String createDailySchedule(String token, OffsetDateTime arrival) throws Exception {
+        return createSchedule(token, arrival, "\"routineRule\": { \"type\": \"DAILY\" },");
+    }
+
+    private String createSchedule(String token, OffsetDateTime arrival, String routineRuleJsonField)
+            throws Exception {
+        OffsetDateTime depart = arrival.minusMinutes(30);
+        String routinePart = routineRuleJsonField != null ? routineRuleJsonField : "";
+        String body = """
+                {
+                  "title": "통합테스트",
+                  "origin": {"name":"우이동","lat":37.6612,"lng":127.0124},
+                  "destination": {"name":"국민대","lat":37.6103,"lng":126.9969},
+                  "userDepartureTime": "%s",
+                  "arrivalTime": "%s",
+                  %s
+                  "reminderOffsetMinutes": 5
+                }
+                """.formatted(depart, arrival, routinePart);
+        String resp = mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(resp).path("data").path("scheduleId").asText();
+    }
+
+    private Long schId(String externalScheduleId) {
+        String uid = externalScheduleId.startsWith(SCH_PREFIX)
+                ? externalScheduleId.substring(SCH_PREFIX.length()) : externalScheduleId;
+        return scheduleRepository.findByScheduleUid(uid).orElseThrow().getId();
+    }
+
+    private Long subId(String externalSubId) {
+        String uid = externalSubId.startsWith(SUB_PREFIX)
+                ? externalSubId.substring(SUB_PREFIX.length()) : externalSubId;
+        return subscriptionRepository.findBySubscriptionUid(uid).orElseThrow().getId();
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/push/service/PushReminderDispatcherIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/push/service/PushReminderDispatcherIntegrationTest.java
@@ -98,7 +98,7 @@ class PushReminderDispatcherIntegrationTest {
         assertNull(s.getReminderAt(), "ONCE 일정 발송 후 reminder_at 은 NULL (재발송 방지)");
         assertNotNull(s.getRouteCalculatedAt(), "ODsay 갱신 결과 반영");
 
-        List<PushLog> logs = pushLogRepository.findAll();
+        List<PushLog> logs = pushLogRepository.findBySubscriptionId(subId(externalSubId));
         assertEquals(1, logs.size());
         assertEquals(PushStatus.SENT, logs.get(0).getStatus());
         assertEquals(201, logs.get(0).getHttpStatus());
@@ -127,7 +127,7 @@ class PushReminderDispatcherIntegrationTest {
         // odsayMaxAttempts=2 — 폴백 진입 시 총 2회 호출됨 (등록 시 1회 + dispatch 시 추가 2회 = 3회 호출 누적)
         verify(routeService, times(3)).refreshRouteSync(any(Schedule.class));
 
-        List<PushLog> logs = pushLogRepository.findAll();
+        List<PushLog> logs = pushLogRepository.findBySubscriptionId(subId(externalSubId));
         assertEquals(1, logs.size());
         assertEquals(PushStatus.SENT, logs.get(0).getStatus());
 
@@ -155,7 +155,7 @@ class PushReminderDispatcherIntegrationTest {
         Long scheduleDbId = schId(externalScheduleId);
         dispatcher.process(scheduleDbId);
 
-        List<PushLog> logs = pushLogRepository.findAll();
+        List<PushLog> logs = pushLogRepository.findBySubscriptionId(subId(externalSubId));
         assertEquals(1, logs.size());
         assertEquals(PushStatus.EXPIRED, logs.get(0).getStatus());
         assertEquals(410, logs.get(0).getHttpStatus());

--- a/backend/src/test/java/com/todayway/backend/push/service/PushReminderDispatcherIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/push/service/PushReminderDispatcherIntegrationTest.java
@@ -177,7 +177,14 @@ class PushReminderDispatcherIntegrationTest {
         OffsetDateTime origArrival = OffsetDateTime.now(KST).plusMinutes(60);
         String externalScheduleId = createDailySchedule(token, origArrival);
 
+        // 명세 v1.1.13 — userDepartureTime delta shift 검증을 위해 advance 전 값 캡처.
+        // baseline 은 DB fetch 값으로 통일 — test variable origArrival 은 ns precision 이지만
+        // DB DATETIME(3) ms 절단되어 1 초 차이가 생길 수 있음.
         Long scheduleDbId = schId(externalScheduleId);
+        Schedule before = scheduleRepository.findById(scheduleDbId).orElseThrow();
+        OffsetDateTime origArrivalFromDb = before.getArrivalTime();
+        OffsetDateTime origUserDepart = before.getUserDepartureTime();
+
         dispatcher.process(scheduleDbId);
 
         Schedule s = scheduleRepository.findById(scheduleDbId).orElseThrow();
@@ -186,6 +193,14 @@ class PushReminderDispatcherIntegrationTest {
         assertNotNull(s.getReminderAt(), "advance 후 reminderAt 재계산 (NULL 아님)");
         assertTrue(s.getReminderAt().isAfter(OffsetDateTime.now(KST)),
                 "advance 후 reminderAt 은 미래 시각");
+
+        // 명세 v1.1.13 — userDepartureTime 도 동일 delta 만큼 shift 되어야 departureAdvice 정합 유지.
+        assertTrue(s.getUserDepartureTime().isAfter(origUserDepart),
+                "userDepartureTime 도 advance 시 shift 되어야 함 (v1.1.13 §9.2 보강)");
+        long arrivalDeltaSec = java.time.Duration.between(origArrivalFromDb, s.getArrivalTime()).getSeconds();
+        long userDepartDeltaSec = java.time.Duration.between(origUserDepart, s.getUserDepartureTime()).getSeconds();
+        assertEquals(arrivalDeltaSec, userDepartDeltaSec,
+                "userDepartureTime delta == arrivalTime delta — silent corruption 방지 (v1.1.13)");
     }
 
     // ───── helpers ─────


### PR DESCRIPTION
## Summary
- 명세 §4.1 `GET /main` (게스트 허용) + §4.2 `GET /map/config` + §8.1 `POST /geocode` (cache + Kakao Local).
- `@CurrentMember(required=false)` 추가 — 게스트 허용 endpoint 지원 (default true 라 기존 사용처 영향 0).
- 셀프리뷰 16건 fix 모두 동일 PR 흡수 (사용자 발화 "이 PR 로 끝, 모든 거 담아").

## 도메인 작업
| 영역 | 내용 |
|---|---|
| §4.2 | MapConfigProperties (record, @Validated) + application.yml + GET /map/config 정적 응답 |
| §4.1 | MainService + NearestScheduleDto + Coordinate (NaN/range guard) + GET /main 게스트 허용 |
| §8.1 | GeocodeCache entity + Repository + KakaoLocalToGeocodeMapper + GeocodeService (TTL cache + race-safe UPSERT) + POST /geocode |

## 셀프리뷰 16건 fix (commit 10–15)

### 🔴 CRITICAL (production silent bug)
- **F-A** AnonymousAuthenticationToken → memberUid 흘러가던 silent gap. instanceof 명시 제외.
- **F-B** Coordinate compact constructor (NaN/Infinity/range) + NearestScheduleDto null 가드.
- **F-C** Kakao x/y malformed → NumberFormatException catch-all 500 → 502 EXTERNAL_ROUTE_API_FAILED 매핑.

### 🟠 HIGH
- **F-D** UPSERT race rollback-only → REQUIRES_NEW 별도 service + outer 1회 retry. PushService 도 같은 패턴 동시 fix.
- **F-F** 만료 JWT + permitAll endpoint 401 차단 → 게스트 흐름 graceful (PermitAllPaths 단일 source).
- **F-G** MainResponse @JsonInclude no-op 제거 + 테스트 명시 null 검증.
- **F-N** MainService 탈퇴 회원 valid JWT silent → WARN 로깅.
- **F-M** MapConfigProperties.DefaultCenter lat/lng @DecimalMin/@DecimalMax 검증.

### 🟡 MEDIUM
- **F-L** MapConfigProperties → record (불변).
- **F-P** GeocodeCache.match 9-arg → MatchedFields record (argument-swap 차단).
- **F-H/J/K/O/Q** rot 주석 / coupling claim / cross-ref 정정.
- **+** GlobalExceptionHandler 보강 (issue #16 HttpMessageNotReadableException 흡수, IllegalArgumentException → 400).

## 통합 테스트 (총 18건)
- MapControllerIntegrationTest 7건
- GeocodeControllerIntegrationTest 10건
- CurrentMemberArgumentResolverTest 6건
- JwtAuthenticationFilterTest 만료 + permitAll graceful 1건 추가

## Test plan
- [x] ./gradlew test 전체 GREEN (Testcontainers MySQL 8)
- [x] 명세 §4.1 / §4.2 / §8.1 v1.1.4 매핑표 1:1 검증 (plugin agent 4종 + 직접 layer + WebSearch)
- [x] silent failure catch-up 완료