### PR TITLE
feat(backend/route): TMAP 보행자 경로 통합 재머지 — PR #28 변경 feat/backend 반영 (명세 v1.1.21)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,9 @@ JWT_SECRET=changeme-base64-encoded-256bit-secret
 # --- 외부 API 키 (도메인 담당자가 본인 작업 시 채움) ---
 ODSAY_API_KEY=
 KAKAO_LOCAL_API_KEY=
+# TMAP 보행자 경로안내 — 명세 §6.1 v1.1.21 WALK 인도 곡선. 미설정 시 graceful fallback (직선).
+# https://openapi.sk.com 에서 "보행자 경로안내" 상품 신청 후 발급.
+TMAP_APP_KEY=
 
 # --- Web Push (VAPID 키페어 — `web-push generate-vapid-keys` 로 생성) ---
 VAPID_PUBLIC_KEY=

--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -868,7 +868,8 @@ Body  : { "startX", "startY", "endX", "endY", "reqCoordType":"WGS84GEO", "resCoo
 ```
 
 - 응답: GeoJSON `FeatureCollection` — `features[].geometry.type=="LineString"` 의 `coordinates[]` (이미 `[lng, lat]` 순서) 를 모든 LineString feature 에 대해 평탄화하여 한 WALK segment 의 path 로 합침.
-- 호출 빈도: WALK subPath 1개당 1회. 한 cache miss 사이클의 외부 API 호출 = ODsay × 2 (`searchPubTransPathT` + `loadLane`) + TMAP × N (N = WALK subPath 갯수, 보통 1-2).
+- 호출 빈도: WALK subPath 1개당 1회. 한 cache miss 사이클의 외부 API 호출 = ODsay × 2 (`searchPubTransPathT` + `loadLane`) + TMAP × N. N 은 환승 횟수에 비례: **환승 0회 → N=2** (출발 WALK + 도착 WALK) / **환승 1회 → N=3** (+ 환승 walk 1개) / **환승 2회 → N=4**.
+- 응답 지연 worst case (`tmap.timeout-seconds: 5` + 직렬 호출): 환승 0회 ≈ 20초 / 환승 1회 ≈ 25초 / 환승 2회 ≈ 30초. graceful fallback 으로 사용자에겐 직선 그려짐 정도지만 `GET /schedules/{id}/route` 동기 SLA 영향. P1 백로그: 첫 TMAP timeout 시 나머지 WALK 즉시 fallback (fail-fast) 또는 WALK 호출 비동기 fan-out (Java 21 Virtual Threads + `CompletableFuture.allOf`).
 - WALK 의 시작/끝 좌표는 v1.1.9 합성 알고리즘과 동일 (origin / 다음 transit `startX/Y` / 이전 transit `endX/Y` / destination). TMAP 응답 양 끝이 정확히 그 좌표와 일치하지 않을 수 있어 **양 끝에 시작/끝 좌표를 강제 prepend/append** — 정류장 좌표와 시각상 정확히 만나도록 보정.
 - **graceful fallback** — 다음 케이스에서 v1.1.9 합성 직선으로 fallback:
   - `TMAP_APP_KEY` 미설정 (호출 자체 skip — 401 비용 + 노이즈 회피)

--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.20-MVP
-> **최종 수정**: 2026-05-08 (이상진 — §6.1 transferCount 정의 확정 (이용 노선 수, 환승 횟수 = transferCount - 1) + §12 체크리스트 완료 표시. Step 6 PR #11 follow-up 1번 자체 판단 처리.)
+> **버전**: v1.1.21-MVP
+> **최종 수정**: 2026-05-08 (이상진 — §6.1 WALK 구간 path 출처 = TMAP 보행자 경로 (인도 곡선). 외부 API 의존성 추가, graceful fallback 으로 v1.1.9 합성 직선 보존.)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -37,6 +37,7 @@
 | **v1.1.18** | **2026-05-07** | **§8.1 `GeocodeCacheCleanupScheduler` 추가 — 매일 04:00 KST `@Scheduled` 로 `cached_at < NOW() - INTERVAL 30 DAY` row 삭제. read filter TTL 과 같은 cutoff. 운영 1년+ 누적 시 row/UNIQUE 인덱스 비대화 차단. `geocode.cleanup.{enabled,cron}` 환경변수 외부화. PR #27 외부 리뷰 (황찬우) G3 흡수.** |
 | **v1.1.19** | **2026-05-08** | **§4.1 lat/lng XOR 검증 명시 — 둘 다 함께 또는 둘 다 누락만 허용. 한쪽만 채워 보낸 케이스는 400 VALIDATION_ERROR (silent default fallback 차단). NaN/±Infinity 도 400 명시. PR #27 review M2 코드 fix 의 명세 mirroring + 자체 review H1/L1/L3 (javadoc 운영 가정/XFF spoof 안내) 동반.** |
 | **v1.1.20** | **2026-05-08** | **§6.1 `transferCount` 정의 확정 — "이용 대중교통 노선 수 (= 탑승 횟수)". 응답 예시 (지하철 1노선 + 도보 = `transferCount: 1`) 와 정합. **환승 횟수 = `transferCount - 1`** 비고 추가 (0 노선 케이스는 `Math.max(0, n-1)` 권고). v1.1.4 의 "미확정" 표기 제거. 코드 동작 변경 X (현 합산 패턴 그대로 OK). §12 체크리스트 완료 표시 (push/map/geocode/ODsay 4행). Step 6 PR #11 follow-up 1번 자체 판단 처리 (이상진).** |
+| **v1.1.21** | **2026-05-08** | **§6.1 WALK 구간 `path` 출처 = TMAP 보행자 경로 (인도 곡선). 기존 v1.1.9 합성 직선 → `POST https://apis.openapi.sk.com/tmap/routes/pedestrian` 호출 결과(GeoJSON LineString features)로 승격 — 4차선 도로 가로지르는 비현실적 직선 시각화 차단. WALK 구간당 1회 추가 호출. 외부 API 의존성 +1 (`TMAP_APP_KEY` 환경변수). 모든 실패 (키 미설정 / 401/403 / timeout / 5xx / 응답 형식 위반) 는 graceful — v1.1.9 합성 직선 fallback. ErrorCode 신규 X. 시각 검증: `~/route-preview/odsay-tmap-walk.html` (이상진).** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
 
@@ -856,9 +857,26 @@ LIMIT ?
 | `stationStart` | `subPath.startName` (SUBWAY 한정) | BUS는 from과 중복이라 null |
 | `stationEnd` | `subPath.endName` (SUBWAY 한정) | |
 | `stationCount` | `subPath.stationCount` | |
-| `path` | (transit) `loadLane.result.lane[i].section[].graphPos[]` 평탄화 (도로 곡선)<br>(WALK) 좌표 키 없음 → 합성 (아래 알고리즘) | `[lng, lat]` 배열. loadLane 실패/누락 시 `passStopList` 직선으로 graceful fallback (v1.1.10) |
+| `path` | (transit) `loadLane.result.lane[i].section[].graphPos[]` 평탄화 (도로 곡선)<br>(WALK) **TMAP `routes/pedestrian` 호출 (인도 곡선, v1.1.21)** → 실패/미설정 시 v1.1.9 합성 직선 fallback | `[lng, lat]` 배열. loadLane 실패/누락 시 `passStopList` 직선으로 graceful fallback (v1.1.10) |
 
-🆕 **v1.1.9 — WALK 구간 path 보충 알고리즘** (ODsay WALK subPath는 `startX/Y`/`endX/Y` 키가 없음):
+🆕 **v1.1.21 — WALK 구간 `path` 출처 = TMAP 보행자 경로 (인도 곡선)**:
+
+```
+POST https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1&format=json
+Header: appKey: {TMAP_APP_KEY}
+Body  : { "startX", "startY", "endX", "endY", "reqCoordType":"WGS84GEO", "resCoordType":"WGS84GEO", "startName", "endName" }
+```
+
+- 응답: GeoJSON `FeatureCollection` — `features[].geometry.type=="LineString"` 의 `coordinates[]` (이미 `[lng, lat]` 순서) 를 모든 LineString feature 에 대해 평탄화하여 한 WALK segment 의 path 로 합침.
+- 호출 빈도: WALK subPath 1개당 1회. 한 cache miss 사이클의 외부 API 호출 = ODsay × 2 (`searchPubTransPathT` + `loadLane`) + TMAP × N (N = WALK subPath 갯수, 보통 1-2).
+- WALK 의 시작/끝 좌표는 v1.1.9 합성 알고리즘과 동일 (origin / 다음 transit `startX/Y` / 이전 transit `endX/Y` / destination). TMAP 응답 양 끝이 정확히 그 좌표와 일치하지 않을 수 있어 **양 끝에 시작/끝 좌표를 강제 prepend/append** — 정류장 좌표와 시각상 정확히 만나도록 보정.
+- **graceful fallback** — 다음 케이스에서 v1.1.9 합성 직선으로 fallback:
+  - `TMAP_APP_KEY` 미설정 (호출 자체 skip — 401 비용 + 노이즈 회피)
+  - TMAP 401/403/timeout/5xx
+  - 응답 본문 빈 / GeoJSON 형식 위반 / `features[]` 배열 없음 / LineString feature 0개
+- TMAP 보행자 경로안내 신청: SK Open API 콘솔 (`https://openapi.sk.com`) → 상품 마켓 → "보행자 경로안내 V1" 사용 신청 → 발급된 AppKey 를 `TMAP_APP_KEY` 환경변수로 주입.
+
+🆕 **v1.1.9 — WALK 구간 좌표 결정 알고리즘** (ODsay WALK subPath 는 `startX/Y`/`endX/Y` 키가 없음 — TMAP 호출 시작/끝 좌표 결정에 그대로 사용):
 
 - **첫 WALK** (subPath[0]이 WALK일 때): `origin` → 다음 transit subPath의 `startX/Y`
 - **중간 WALK**: 이전 transit subPath의 `endX/Y` → 다음 transit subPath의 `startX/Y`

--- a/backend/src/main/java/com/todayway/backend/external/ExternalApiConfig.java
+++ b/backend/src/main/java/com/todayway/backend/external/ExternalApiConfig.java
@@ -2,10 +2,15 @@ package com.todayway.backend.external;
 
 import com.todayway.backend.external.kakao.KakaoLocalProperties;
 import com.todayway.backend.external.odsay.OdsayProperties;
+import com.todayway.backend.external.tmap.TmapProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({OdsayProperties.class, KakaoLocalProperties.class})
+@EnableConfigurationProperties({
+        OdsayProperties.class,
+        KakaoLocalProperties.class,
+        TmapProperties.class,
+})
 public class ExternalApiConfig {
 }

--- a/backend/src/main/java/com/todayway/backend/external/ExternalApiException.java
+++ b/backend/src/main/java/com/todayway/backend/external/ExternalApiException.java
@@ -25,7 +25,8 @@ public class ExternalApiException extends RuntimeException {
     /** 외부 API 출처 (exhaustive switch에 사용 가능). */
     public enum Source {
         ODSAY,
-        KAKAO_LOCAL
+        KAKAO_LOCAL,
+        TMAP
     }
 
     private final Source source;

--- a/backend/src/main/java/com/todayway/backend/external/tmap/TmapClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/tmap/TmapClient.java
@@ -1,0 +1,151 @@
+package com.todayway.backend.external.tmap;
+
+import com.todayway.backend.external.ExternalApiException;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.net.SocketTimeoutException;
+import java.util.Map;
+
+/**
+ * TMAP 보행자 경로안내 API 클라이언트. 명세 §6.1 v1.1.21 — WALK 구간 인도 곡선 제공자.
+ *
+ * <p>호출: {@code POST /tmap/routes/pedestrian?version=1&format=json}, {@code appKey} 헤더 + body 좌표.
+ * 응답 GeoJSON FeatureCollection — caller (OdsayResponseMapper) 가 LineString feature 의 coordinates 를
+ * 평탄화해서 {@code RouteSegment.path} 채움.
+ *
+ * <p>호출자 정책 (명세 §6.1 v1.1.21):
+ * <ul>
+ *   <li>모든 실패 (401/403/timeout/5xx/응답 형식 위반) → graceful — caller 가 catch 후 v1.1.9 의
+ *       합성 직선 알고리즘으로 fallback. WALK 곡선 누락은 시각 품질 저하일 뿐이라 사용자 영향 작음.</li>
+ *   <li>401/403 도 ODsay 처럼 503 격상하지 않음 — TMAP 키 미설정도 정상 시작 (다른 도메인 작업자 영향 X).</li>
+ * </ul>
+ */
+@Component
+public class TmapClient {
+
+    private static final Logger log = LoggerFactory.getLogger(TmapClient.class);
+    private static final ExternalApiException.Source SOURCE = ExternalApiException.Source.TMAP;
+
+    private final TmapProperties properties;
+    private final RestClient restClient;
+
+    @Autowired
+    public TmapClient(TmapProperties properties) {
+        this(properties, RestClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .requestFactory(createRequestFactory(properties.getTimeoutSeconds()))
+                .build());
+    }
+
+    /** 테스트용 — MockRestServiceServer 주입. */
+    TmapClient(TmapProperties properties, RestClient restClient) {
+        this.properties = properties;
+        this.restClient = restClient;
+    }
+
+    /**
+     * appKey 설정 여부. caller (OdsayResponseMapper) 가 호출 전 short-circuit 으로 사용 —
+     * 키 미설정 시 401 받는 비용 + warn 로그 노이즈 회피. 정상 dev 환경 (TMAP 키 없음) 에서도
+     * silent fallback.
+     */
+    public boolean isConfigured() {
+        String key = properties.getAppKey();
+        return key != null && !key.isBlank();
+    }
+
+    /**
+     * Apache HttpClient 5 + 커넥션 풀 기반 RequestFactory. {@link com.todayway.backend.external.odsay.OdsayClient}
+     * 와 동일 패턴 — {@code RequestConfig.Builder.setConnectTimeout} 은 5.2+ 에서 deprecated 되어
+     * {@code ConnectionConfig.Builder} 로 옮길 수 있으나, 두 client 동시 갱신을 위한 별 PR 백로그.
+     */
+    @SuppressWarnings("deprecation")
+    private static ClientHttpRequestFactory createRequestFactory(int timeoutSeconds) {
+        Timeout timeout = Timeout.ofSeconds(timeoutSeconds);
+        HttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                .setMaxConnTotal(20)
+                .setMaxConnPerRoute(10)
+                .build();
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setConnectTimeout(timeout)
+                        .setResponseTimeout(timeout)
+                        .build())
+                .build();
+        return new HttpComponentsClientHttpRequestFactory(httpClient);
+    }
+
+    /**
+     * 보행자 경로 호출. 응답 raw JSON 반환. caller 가 GeoJSON 파싱 책임.
+     *
+     * @param startLng 출발 경도
+     * @param startLat 출발 위도
+     * @param endLng   도착 경도
+     * @param endLat   도착 위도
+     * @return TMAP 응답 raw JSON 문자열 (FeatureCollection)
+     * @throws ExternalApiException 모든 호출 실패 — caller 가 graceful fallback 처리
+     */
+    public String routesPedestrian(double startLng, double startLat, double endLng, double endLat) {
+        log.debug("TMAP pedestrian: ({},{})→({},{})", startLng, startLat, endLng, endLat);
+        Map<String, Object> body = Map.of(
+                "startX", startLng, "startY", startLat,
+                "endX", endLng, "endY", endLat,
+                "reqCoordType", "WGS84GEO",
+                "resCoordType", "WGS84GEO",
+                "startName", "start",
+                "endName", "end"
+        );
+        try {
+            String resp = restClient.post()
+                    .uri("/routes/pedestrian?version=1&format=json")
+                    .header("appKey", properties.getAppKey())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(String.class);
+            if (resp == null || resp.isBlank()) {
+                throw new ExternalApiException(SOURCE, ExternalApiException.Type.SERVER_ERROR,
+                        null, "TMAP 응답 본문이 비어있음", null);
+            }
+            log.debug("TMAP 응답 수신: {} bytes", resp.length());
+            return resp;
+        } catch (RestClientResponseException e) {
+            // 보안: cause body 에 좌표/키 일부 포함 가능 → 보존 X.
+            HttpStatusCode status = e.getStatusCode();
+            ExternalApiException.Type type = status.is4xxClientError()
+                    ? ExternalApiException.Type.CLIENT_ERROR
+                    : ExternalApiException.Type.SERVER_ERROR;
+            throw new ExternalApiException(SOURCE, type, status.value(),
+                    "TMAP 호출 실패: HTTP " + status, null);
+        } catch (ResourceAccessException e) {
+            Throwable rootCause = NestedExceptionUtils.getMostSpecificCause(e);
+            ExternalApiException.Type type = rootCause instanceof SocketTimeoutException
+                    ? ExternalApiException.Type.TIMEOUT
+                    : ExternalApiException.Type.NETWORK;
+            String causeName = rootCause != null ? rootCause.getClass().getSimpleName() : "ResourceAccessException";
+            throw new ExternalApiException(SOURCE, type, null,
+                    "TMAP 통신 실패 (" + causeName + ")", null);
+        } catch (RestClientException e) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
+                    "TMAP 호출 중 예외 (" + e.getClass().getSimpleName() + ")", null);
+        }
+    }
+}

--- a/backend/src/main/java/com/todayway/backend/external/tmap/TmapClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/tmap/TmapClient.java
@@ -104,6 +104,13 @@ public class TmapClient {
      * @throws ExternalApiException 모든 호출 실패 — caller 가 graceful fallback 처리
      */
     public String routesPedestrian(double startLng, double startLat, double endLng, double endLat) {
+        // defensive — caller 가 isConfigured() 검증 우회해 직접 호출 시 null appKey 가
+        // RestClient.header("appKey", null) 에서 NPE 던지지 않게 ExternalApiException 으로 정상화.
+        // mapper 의 catch 분기가 graceful fallback 으로 흡수.
+        if (!isConfigured()) {
+            throw new ExternalApiException(SOURCE, ExternalApiException.Type.CLIENT_ERROR,
+                    null, "TMAP_APP_KEY 미설정", null);
+        }
         log.debug("TMAP pedestrian: ({},{})→({},{})", startLng, startLat, endLng, endLat);
         Map<String, Object> body = Map.of(
                 "startX", startLng, "startY", startLat,

--- a/backend/src/main/java/com/todayway/backend/external/tmap/TmapClient.java
+++ b/backend/src/main/java/com/todayway/backend/external/tmap/TmapClient.java
@@ -35,7 +35,10 @@ import java.util.Map;
  * <ul>
  *   <li>모든 실패 (401/403/timeout/5xx/응답 형식 위반) → graceful — caller 가 catch 후 v1.1.9 의
  *       합성 직선 알고리즘으로 fallback. WALK 곡선 누락은 시각 품질 저하일 뿐이라 사용자 영향 작음.</li>
- *   <li>401/403 도 ODsay 처럼 503 격상하지 않음 — TMAP 키 미설정도 정상 시작 (다른 도메인 작업자 영향 X).</li>
+ *   <li>{@link com.todayway.backend.external.odsay.OdsayClient} 와 달리 401/403 도 503
+ *       {@code EXTERNAL_AUTH_MISCONFIGURED} 로 격상하지 않는다 — TMAP 키 미설정도 정상 시작
+ *       (다른 도메인 작업자 영향 X). 모든 4xx/5xx/timeout 은 mapper 의 catch 분기에서 v1.1.9
+ *       합성 직선으로 흡수.</li>
  * </ul>
  */
 @Component
@@ -151,6 +154,10 @@ public class TmapClient {
             throw new ExternalApiException(SOURCE, type, null,
                     "TMAP 통신 실패 (" + causeName + ")", null);
         } catch (RestClientException e) {
+            // SSL handshake / 직렬화 / 기타 RestClientException subclass 는 4xx/5xx 와 달리 응답
+            // 본문이 message 에 들어갈 위험이 작음. 그러나 일관성 + 보안 보수적 정책으로 cause=null
+            // 유지하고, root-cause 진단을 위해 logger 에 stack 한 번만 출력 (e 를 last vararg).
+            log.warn("TMAP 호출 중 예외 — class={}", e.getClass().getSimpleName(), e);
             throw new ExternalApiException(SOURCE, ExternalApiException.Type.NETWORK, null,
                     "TMAP 호출 중 예외 (" + e.getClass().getSimpleName() + ")", null);
         }

--- a/backend/src/main/java/com/todayway/backend/external/tmap/TmapProperties.java
+++ b/backend/src/main/java/com/todayway/backend/external/tmap/TmapProperties.java
@@ -22,7 +22,7 @@ public class TmapProperties {
     /** TMAP App Key. {@code ${TMAP_APP_KEY:}} 로 주입. 빈 값 허용 (graceful fallback). */
     private String appKey;
 
-    /** {@code https://apis.openapi.sk.com/tmap}. */
+    /** {@code application.yml} 에서 주입 (디폴트 {@code https://apis.openapi.sk.com/tmap}). */
     private String baseUrl;
 
     /** 호출 timeout. WALK 구간 한 번 호출이 ODsay searchPubTransPathT 와 같은 사이클에 포함되므로 짧게. */

--- a/backend/src/main/java/com/todayway/backend/external/tmap/TmapProperties.java
+++ b/backend/src/main/java/com/todayway/backend/external/tmap/TmapProperties.java
@@ -1,0 +1,31 @@
+package com.todayway.backend.external.tmap;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * TMAP 외부 API 설정. {@code application.yml}의 {@code tmap.*} 키에서 주입.
+ * 명세 §6.1 v1.1.21 — WALK 구간 인도 곡선 제공자.
+ *
+ * <p>{@code appKey}는 빈 값 허용 — 다른 도메인 작업자가 TMAP 키 없이도 백엔드 시작 가능해야 한다
+ * (ODsay/Kakao Local 패턴과 일관). 빈 값일 때 호출 시 401 → graceful fallback 으로 흡수.
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "tmap")
+public class TmapProperties {
+
+    /** TMAP App Key. {@code ${TMAP_APP_KEY:}} 로 주입. 빈 값 허용 (graceful fallback). */
+    private String appKey;
+
+    /** {@code https://apis.openapi.sk.com/tmap}. */
+    private String baseUrl;
+
+    /** 호출 timeout. WALK 구간 한 번 호출이 ODsay searchPubTransPathT 와 같은 사이클에 포함되므로 짧게. */
+    @Min(1)
+    private int timeoutSeconds = 5;
+}

--- a/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
@@ -3,6 +3,8 @@ package com.todayway.backend.route;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.external.ExternalApiException;
+import com.todayway.backend.external.tmap.TmapClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -48,6 +50,7 @@ import java.util.List;
 public class OdsayResponseMapper {
 
     private final ObjectMapper objectMapper;
+    private final TmapClient tmapClient;
 
     /**
      * @param pathRawJson  {@code searchPubTransPathT} raw 응답
@@ -117,7 +120,8 @@ public class OdsayResponseMapper {
                 double[] nextPoint = transitIdx < transitStarts.size()
                         ? transitStarts.get(transitIdx)
                         : new double[]{destLng, destLat};
-                segments.add(buildWalkSegment(sectionTime, distance, lastPoint, nextPoint));
+                List<double[]> walkPath = resolveWalkPath(lastPoint, nextPoint);
+                segments.add(buildWalkSegment(sectionTime, distance, walkPath));
                 lastPoint = nextPoint;
             } else {
                 List<double[]> graphPath = transitIdx < lanePaths.size()
@@ -262,8 +266,7 @@ public class OdsayResponseMapper {
         return starts;
     }
 
-    private static RouteSegment buildWalkSegment(int sectionTime, int distance,
-                                                 double[] from, double[] to) {
+    private static RouteSegment buildWalkSegment(int sectionTime, int distance, List<double[]> path) {
         // WALK는 lineName/lineId/stationStart/stationEnd/stationCount 모두 null
         // (RouteSegment의 @JsonInclude(NON_NULL)이 응답 직렬화 시 키 자체 제거)
         return new RouteSegment(
@@ -271,11 +274,72 @@ public class OdsayResponseMapper {
                 null, null,            // from/to (정류장명) — WALK엔 의미 없음
                 null, null,            // lineName/lineId
                 null, null, null,      // stationStart/stationEnd/stationCount
-                List.of(
-                        new double[]{from[0], from[1]},
-                        new double[]{to[0], to[1]}
-                )
+                path
         );
+    }
+
+    /**
+     * 명세 §6.1 v1.1.21 — WALK 구간 path 결정.
+     * <ol>
+     *   <li>{@link TmapClient#routesPedestrian} 호출 → GeoJSON LineString features 의 좌표 평탄화</li>
+     *   <li>실패 (키 미설정 / 401/403/timeout/5xx / 응답 형식 위반) → v1.1.9 합성 직선 fallback</li>
+     * </ol>
+     * 성공 시 양 끝에 from/to 강제 prepend/append — TMAP 응답 양 끝이 정확히 from/to 와 일치하지 않을
+     * 수 있어 transit 정류장 좌표와 시각상 정확히 만나도록 보정.
+     */
+    private List<double[]> resolveWalkPath(double[] from, double[] to) {
+        List<double[]> fallback = List.of(
+                new double[]{from[0], from[1]},
+                new double[]{to[0], to[1]}
+        );
+        if (!tmapClient.isConfigured()) {
+            return fallback;
+        }
+        try {
+            String raw = tmapClient.routesPedestrian(from[0], from[1], to[0], to[1]);
+            List<double[]> coords = parseTmapLineString(raw);
+            if (coords.size() < 2) {
+                return fallback;
+            }
+            // 양 끝 강제 prepend/append — 정류장 좌표 정확 매칭.
+            List<double[]> result = new ArrayList<>(coords.size() + 2);
+            result.add(new double[]{from[0], from[1]});
+            result.addAll(coords);
+            result.add(new double[]{to[0], to[1]});
+            return result;
+        } catch (ExternalApiException e) {
+            log.debug("TMAP WALK 호출 실패 — graceful fallback 직선: type={} status={}",
+                    e.getType(), e.getHttpStatus());
+            return fallback;
+        } catch (RuntimeException e) {
+            log.debug("TMAP 응답 파싱 실패 — graceful fallback 직선: cause={}",
+                    e.getClass().getSimpleName());
+            return fallback;
+        }
+    }
+
+    /** TMAP GeoJSON FeatureCollection → LineString features 의 coordinates 평탄화. */
+    private List<double[]> parseTmapLineString(String rawJson) {
+        JsonNode root = parse(rawJson);
+        JsonNode features = root.path("features");
+        if (!features.isArray()) {
+            return List.of();
+        }
+        List<double[]> coords = new ArrayList<>();
+        for (JsonNode f : features) {
+            if (!"LineString".equals(f.path("geometry").path("type").asText())) {
+                continue;
+            }
+            for (JsonNode pt : f.path("geometry").path("coordinates")) {
+                if (!pt.isArray() || pt.size() < 2) continue;
+                double lng = pt.get(0).asDouble();
+                double lat = pt.get(1).asDouble();
+                if (Double.isFinite(lng) && Double.isFinite(lat)) {
+                    coords.add(new double[]{lng, lat});
+                }
+            }
+        }
+        return coords;
     }
 
     private static RouteSegment buildTransitSegment(SegmentMode mode, int sectionTime,

--- a/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
@@ -318,7 +318,20 @@ public class OdsayResponseMapper {
         }
     }
 
-    /** TMAP GeoJSON FeatureCollection → LineString features 의 coordinates 평탄화. */
+    /**
+     * TMAP GeoJSON FeatureCollection → LineString features 의 coordinates 평탄화. graceful —
+     * 손상된 좌표는 silent skip (전체 fallback 으로 떨어지지 않음, 정상 좌표만 살림). 모든 좌표가
+     * skip 되면 caller(resolveWalkPath)의 {@code coords.size() < 2} 가드가 fallback 트리거.
+     *
+     * <p>좌표 단위 invariant:
+     * <ol>
+     *   <li>{@link JsonNode#isNumber} — non-numeric (string/object/null) silent {@code 0.0}
+     *       반환 차단 → 좌표 (0,0) 적도/대서양 점프 방지.</li>
+     *   <li>{@link Double#isFinite} — NaN/Infinity 차단.</li>
+     *   <li>한국 service area bbox — transit graphPos 와 같은 invariant. 외국 좌표 silent 통과 차단
+     *       (TMAP 한국 전용 서비스라 위반 빈도 0 이지만 일관성).</li>
+     * </ol>
+     */
     private List<double[]> parseTmapLineString(String rawJson) {
         JsonNode root = parse(rawJson);
         JsonNode features = root.path("features");
@@ -332,11 +345,15 @@ public class OdsayResponseMapper {
             }
             for (JsonNode pt : f.path("geometry").path("coordinates")) {
                 if (!pt.isArray() || pt.size() < 2) continue;
-                double lng = pt.get(0).asDouble();
-                double lat = pt.get(1).asDouble();
-                if (Double.isFinite(lng) && Double.isFinite(lat)) {
-                    coords.add(new double[]{lng, lat});
-                }
+                JsonNode lngNode = pt.get(0);
+                JsonNode latNode = pt.get(1);
+                if (!lngNode.isNumber() || !latNode.isNumber()) continue;
+                double lng = lngNode.asDouble();
+                double lat = latNode.asDouble();
+                if (!Double.isFinite(lng) || !Double.isFinite(lat)) continue;
+                if (lng < SERVICE_LNG_MIN || lng > SERVICE_LNG_MAX
+                        || lat < SERVICE_LAT_MIN || lat > SERVICE_LAT_MAX) continue;
+                coords.add(new double[]{lng, lat});
             }
         }
         return coords;

--- a/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
+++ b/backend/src/main/java/com/todayway/backend/route/OdsayResponseMapper.java
@@ -284,8 +284,9 @@ public class OdsayResponseMapper {
      *   <li>{@link TmapClient#routesPedestrian} 호출 → GeoJSON LineString features 의 좌표 평탄화</li>
      *   <li>실패 (키 미설정 / 401/403/timeout/5xx / 응답 형식 위반) → v1.1.9 합성 직선 fallback</li>
      * </ol>
-     * 성공 시 양 끝에 from/to 강제 prepend/append — TMAP 응답 양 끝이 정확히 from/to 와 일치하지 않을
-     * 수 있어 transit 정류장 좌표와 시각상 정확히 만나도록 보정.
+     * 성공 시 양 끝에 from/to 강제 prepend/append — 관측 기반 보정 (TMAP 이 가까운 보행 도로
+     * 진입점으로 snap 하는 경우 응답 양 끝이 from/to 와 미세 차이 가능). transit 정류장 좌표와
+     * 시각상 정확히 만나도록 보장.
      */
     private List<double[]> resolveWalkPath(double[] from, double[] to) {
         List<double[]> fallback = List.of(
@@ -299,6 +300,9 @@ public class OdsayResponseMapper {
             String raw = tmapClient.routesPedestrian(from[0], from[1], to[0], to[1]);
             List<double[]> coords = parseTmapLineString(raw);
             if (coords.size() < 2) {
+                // L1 — features 누락 / LineString 0개 / 좌표 invariant 모두 skip 의 합성 결과. 응답 형식
+                // 검증 필요한 신호로 1회 log (운영 INFO 안 보이지만 fallback 빈도 추적은 L2 백로그).
+                log.debug("TMAP 응답 LineString 좌표 < 2 — graceful fallback 직선");
                 return fallback;
             }
             // 양 끝 강제 prepend/append — 정류장 좌표 정확 매칭.
@@ -329,11 +333,18 @@ public class OdsayResponseMapper {
      *       반환 차단 → 좌표 (0,0) 적도/대서양 점프 방지.</li>
      *   <li>{@link Double#isFinite} — NaN/Infinity 차단.</li>
      *   <li>한국 service area bbox — transit graphPos 와 같은 invariant. 외국 좌표 silent 통과 차단
-     *       (TMAP 한국 전용 서비스라 위반 빈도 0 이지만 일관성).</li>
+     *       (TMAP 한국 전용 서비스라 기대값 0).</li>
      * </ol>
      */
     private List<double[]> parseTmapLineString(String rawJson) {
-        JsonNode root = parse(rawJson);
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(rawJson);
+        } catch (JsonProcessingException e) {
+            // M1 — TMAP 호출 흐름 별도 라벨링. ODsay 의 parse() 와 메시지 구별 (운영 디버깅 시 어느
+            // 외부 API 회귀인지 즉시 식별).
+            throw new IllegalStateException("TMAP 응답 JSON 파싱 실패", e);
+        }
         JsonNode features = root.path("features");
         if (!features.isArray()) {
             return List.of();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -54,6 +54,11 @@ kakao-local:
   base-url: https://dapi.kakao.com/v2/local
   timeout-seconds: 5
 
+tmap:                                            # 명세 §6.1 v1.1.21 — WALK 인도 곡선 제공자
+  app-key: ${TMAP_APP_KEY:}
+  base-url: https://apis.openapi.sk.com/tmap
+  timeout-seconds: 5
+
 vapid:
   public-key: ${VAPID_PUBLIC_KEY:}
   private-key: ${VAPID_PRIVATE_KEY:}

--- a/backend/src/test/java/com/todayway/backend/external/tmap/TmapClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/tmap/TmapClientTest.java
@@ -1,0 +1,130 @@
+package com.todayway.backend.external.tmap;
+
+import com.todayway.backend.external.ExternalApiException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * 명세 §6.1 v1.1.21 — TmapClient 단위 테스트 (MockRestServiceServer).
+ *
+ * 회귀 방지:
+ * 1. POST 메서드 + appKey 헤더 (TMAP 공식 규약)
+ * 2. {@code routes/pedestrian?version=1&format=json} 정확한 URI
+ * 3. 모든 catch 에서 cause == null (응답 body 누출 차단), 메시지에 좌표/키 없음
+ * 4. {@code isConfigured()} — 빈/null appKey 일 때 false
+ */
+class TmapClientTest {
+
+    private MockRestServiceServer server;
+    private TmapClient client;
+
+    @BeforeEach
+    void setUp() {
+        TmapProperties props = new TmapProperties();
+        props.setAppKey("tmap-test-app-key");
+        props.setBaseUrl("https://apis.openapi.sk.com/tmap");
+        props.setTimeoutSeconds(5);
+
+        RestClient.Builder builder = RestClient.builder().baseUrl(props.getBaseUrl());
+        server = MockRestServiceServer.bindTo(builder).build();
+        client = new TmapClient(props, builder.build());
+    }
+
+    @Test
+    void POST_routes_pedestrian_appKey_헤더_정합() {
+        server.expect(requestTo(Matchers.containsString("/routes/pedestrian?version=1&format=json")))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("appKey", "tmap-test-app-key"))
+                .andExpect(header(HttpHeaders.CONTENT_TYPE, Matchers.containsString("application/json")))
+                .andRespond(withSuccess(
+                        "{\"type\":\"FeatureCollection\",\"features\":[]}",
+                        MediaType.APPLICATION_JSON));
+
+        String body = client.routesPedestrian(126.9969, 37.6103, 127.0124, 37.6612);
+
+        assertThat(body).contains("FeatureCollection");
+        server.verify();
+    }
+
+    @Test
+    void 빈_응답_body면_SERVER_ERROR_던지고_cause는_null() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.routesPedestrian(126.99, 37.61, 127.0, 37.66));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
+        assertThat(ex.getSource()).isEqualTo(ExternalApiException.Source.TMAP);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void HTTP_403이면_CLIENT_ERROR와_httpStatus_보존_cause는_null_좌표키_미노출() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.FORBIDDEN).body("INVALID_API_KEY"));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.routesPedestrian(126.99, 37.61, 127.0, 37.66));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.CLIENT_ERROR);
+        assertThat(ex.getHttpStatus()).isEqualTo(403);
+        assertThat(ex.getCause()).isNull();
+        assertThat(ex.getMessage())
+                .doesNotContain("appKey")
+                .doesNotContain("tmap-test-app-key")
+                .doesNotContain("https://");
+    }
+
+    @Test
+    void HTTP_500이면_SERVER_ERROR_재시도_가능_분류() {
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.routesPedestrian(126.99, 37.61, 127.0, 37.66));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
+        assertThat(ex.getHttpStatus()).isEqualTo(500);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void isConfigured_빈_키_또는_null_이면_false() {
+        TmapProperties empty = new TmapProperties();
+        empty.setAppKey("");
+        empty.setBaseUrl("https://apis.openapi.sk.com/tmap");
+        TmapClient unconfigured = new TmapClient(empty, RestClient.builder().build());
+        assertThat(unconfigured.isConfigured()).isFalse();
+
+        TmapProperties whitespace = new TmapProperties();
+        whitespace.setAppKey("   ");
+        whitespace.setBaseUrl("https://apis.openapi.sk.com/tmap");
+        TmapClient whitespaceClient = new TmapClient(whitespace, RestClient.builder().build());
+        assertThat(whitespaceClient.isConfigured()).isFalse();
+
+        // 본 테스트 클래스의 setUp 에서 키 박혀있어 true
+        assertThat(client.isConfigured()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/todayway/backend/external/tmap/TmapClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/tmap/TmapClientTest.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
+import java.net.SocketTimeoutException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
@@ -143,6 +145,24 @@ class TmapClientTest {
         assertThat(ex).isNotNull();
         assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.SERVER_ERROR);
         assertThat(ex.getHttpStatus()).isEqualTo(500);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void SocketTimeoutException은_TIMEOUT_분류_L5() {
+        // L5 — ResourceAccessException 의 root cause 가 SocketTimeoutException 이면 TIMEOUT 분류.
+        // 운영 모니터링에서 timeout 알림 / 재시도 정책 분기에 사용. 분류가 깨져도 mapper 가 catch
+        // 해서 사용자 영향 없지만, 메트릭/알람 회귀 가드.
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(req -> { throw new SocketTimeoutException("read timeout"); });
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.routesPedestrian(126.99, 37.61, 127.0, 37.66));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.TIMEOUT);
+        assertThat(ex.getSource()).isEqualTo(ExternalApiException.Source.TMAP);
         assertThat(ex.getCause()).isNull();
     }
 

--- a/backend/src/test/java/com/todayway/backend/external/tmap/TmapClientTest.java
+++ b/backend/src/test/java/com/todayway/backend/external/tmap/TmapClientTest.java
@@ -96,6 +96,42 @@ class TmapClientTest {
     }
 
     @Test
+    void HTTP_401이면_CLIENT_ERROR_분류() {
+        // 키 만료/invalid — graceful fallback 분기 (mapper 가 catch 후 v1.1.9 직선 반환)
+        server.expect(requestTo(Matchers.any(String.class)))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED).body("AUTH_FAILED"));
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> client.routesPedestrian(126.99, 37.61, 127.0, 37.66));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.CLIENT_ERROR);
+        assertThat(ex.getHttpStatus()).isEqualTo(401);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void appKey_미설정_시_routesPedestrian_즉시_CLIENT_ERROR_throw_NPE_방지() {
+        // M2 — caller 가 isConfigured() 검증 우회해 직접 호출 시 RestClient.header(name, null) 의
+        // NPE 방지. graceful 정상화 — mapper catch 후 fallback.
+        TmapProperties unconfigured = new TmapProperties();
+        unconfigured.setBaseUrl("https://apis.openapi.sk.com/tmap");
+        // appKey 빈 문자열 (또는 null) — isConfigured()=false
+        TmapClient noKeyClient = new TmapClient(unconfigured, RestClient.builder().build());
+
+        ExternalApiException ex = catchThrowableOfType(
+                ExternalApiException.class,
+                () -> noKeyClient.routesPedestrian(126.99, 37.61, 127.0, 37.66));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.getType()).isEqualTo(ExternalApiException.Type.CLIENT_ERROR);
+        assertThat(ex.getSource()).isEqualTo(ExternalApiException.Source.TMAP);
+        assertThat(ex.getCause()).isNull();
+        // 실 RestClient 호출 X (HTTP 트래픽 0, 본 테스트는 server stub 도 X)
+    }
+
+    @Test
     void HTTP_500이면_SERVER_ERROR_재시도_가능_분류() {
         server.expect(requestTo(Matchers.any(String.class)))
                 .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));

--- a/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
@@ -576,6 +576,85 @@ class OdsayResponseMapperTest {
     }
 
     @Test
+    void TMAP_features_배열_없을때_fallback_직선() throws IOException {
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        // FeatureCollection 형식이지만 features 키 없음 — graceful fallback 직선 (2점)
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble()))
+                .thenReturn("{\"type\":\"FeatureCollection\"}");
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        assertThat(route.segments().get(0).path()).hasSize(2);
+    }
+
+    @Test
+    void TMAP_Point_feature만_있으면_LineString_없어_fallback() throws IOException {
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        // TMAP 응답에 시작/끝 Point feature 만 있고 LineString 0개 — coords.size() < 2 → fallback
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble()))
+                .thenReturn("""
+                        {"type":"FeatureCollection","features":[
+                          {"type":"Feature","geometry":{"type":"Point","coordinates":[127.0,37.6]}},
+                          {"type":"Feature","geometry":{"type":"Point","coordinates":[127.01,37.61]}}
+                        ]}
+                        """);
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        assertThat(route.segments().get(0).path()).hasSize(2);
+    }
+
+    @Test
+    void TMAP_좌표가_NaN이거나_string이거나_서비스영역_밖이면_silent_skip() throws IOException {
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        // 5점 중 정상 2점 + 비정상 3점 (string / NaN / 외국). 정상만 추출 + 양 끝 prepend/append → 4점
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble()))
+                .thenReturn("""
+                        {"type":"FeatureCollection","features":[
+                          {"type":"Feature","geometry":{"type":"LineString","coordinates":[
+                            ["abc","def"],
+                            [127.0,37.61],
+                            ["NaN",37.61],
+                            [127.001,37.612],
+                            [200.0,37.61]
+                          ]}}
+                        ]}
+                        """);
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // 정상 2점 + 양 끝 prepend/append = 4점 (적도/대서양 (0,0) 추가 없이 silent skip 검증)
+        var path = route.segments().get(0).path();
+        assertThat(path).hasSize(4);
+        // (0,0) 좌표 silent 추가 없음 — 모든 점이 한국 service area 안
+        for (double[] p : path) {
+            assertThat(p[0]).isBetween(124.0, 132.0);
+            assertThat(p[1]).isBetween(33.0, 39.0);
+        }
+    }
+
+    @Test
     void TMAP_isConfigured_false_시_호출_안하고_바로_fallback() throws IOException {
         com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
         org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(false);

--- a/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
@@ -21,6 +21,13 @@ import static org.mockito.Mockito.mock;
  */
 class OdsayResponseMapperTest {
 
+    /**
+     * 국민대(126.997, 37.611) → 서울시청(126.978, 37.5665) ODsay 실 응답.
+     * subPath 3개 구성: WALK(시청앞 가는 정류장까지) → BUS 1711번 → WALK(시청까지). transit 1개라 lane 1개.
+     * 본 fixture 가 변경/교체되면 아래 좌표·점수·이름 단정이 silent 깨질 수 있어 — 갱신 시
+     * BUS 시작점 / 끝점 좌표 (`126.994769, 37.61072` / `126.976851, 37.565929`), WALK 갯수,
+     * `transferCount=1` 등 fixture 메타데이터 동시 점검 필수.
+     */
     private static final String FIXTURE_PATH = "src/test/resources/fixtures/odsay-kookmin-to-cityhall.json";
 
     // 국민대→서울시청 좌표 (WALK path 보충 검증용)
@@ -28,6 +35,12 @@ class OdsayResponseMapperTest {
     private static final double ORIGIN_LAT = 37.611;
     private static final double DEST_LNG = 126.978;
     private static final double DEST_LAT = 37.5665;
+
+    // BUS 1711번 시작 정류장 (청덕초 부근) / 끝 정류장 (시청앞.덕수궁) 좌표 — fixture 의존.
+    private static final double BUS_START_LNG = 126.994769;
+    private static final double BUS_START_LAT = 37.61072;
+    private static final double BUS_END_LNG = 126.976851;
+    private static final double BUS_END_LAT = 37.565929;
 
     private OdsayResponseMapper mapper;
 
@@ -508,6 +521,84 @@ class OdsayResponseMapperTest {
     }
 
     // ─────────── §6.1 v1.1.21 — TMAP WALK 곡선 ───────────
+
+    @Test
+    void TMAP_호출_좌표_인자_순서_정확성_M3_ArgumentCaptor() throws IOException {
+        // M3 — mapper 가 routesPedestrian 에 (lng, lat) 순서로 from/to 를 정확히 전달하는지 검증.
+        // swap 회귀 (예: from-to 뒤바뀜 / lat-lng 뒤바뀜) 시각상 시각상 시각으로만 발견되는데 그 시점엔
+        // 운영 후. unit 단계에서 ArgumentCaptor 로 차단.
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble()))
+                .thenReturn("{\"type\":\"FeatureCollection\",\"features\":[]}");
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        org.mockito.ArgumentCaptor<Double> sLng = org.mockito.ArgumentCaptor.forClass(Double.class);
+        org.mockito.ArgumentCaptor<Double> sLat = org.mockito.ArgumentCaptor.forClass(Double.class);
+        org.mockito.ArgumentCaptor<Double> eLng = org.mockito.ArgumentCaptor.forClass(Double.class);
+        org.mockito.ArgumentCaptor<Double> eLat = org.mockito.ArgumentCaptor.forClass(Double.class);
+        org.mockito.Mockito.verify(tmap, org.mockito.Mockito.times(2)).routesPedestrian(
+                sLng.capture(), sLat.capture(), eLng.capture(), eLat.capture());
+
+        // 첫 WALK: origin → BUS startX/Y
+        assertThat(sLng.getAllValues().get(0)).isEqualTo(ORIGIN_LNG);
+        assertThat(sLat.getAllValues().get(0)).isEqualTo(ORIGIN_LAT);
+        assertThat(eLng.getAllValues().get(0)).isEqualTo(BUS_START_LNG);
+        assertThat(eLat.getAllValues().get(0)).isEqualTo(BUS_START_LAT);
+        // 마지막 WALK: BUS endX/Y → destination
+        assertThat(sLng.getAllValues().get(1)).isEqualTo(BUS_END_LNG);
+        assertThat(sLat.getAllValues().get(1)).isEqualTo(BUS_END_LAT);
+        assertThat(eLng.getAllValues().get(1)).isEqualTo(DEST_LNG);
+        assertThat(eLat.getAllValues().get(1)).isEqualTo(DEST_LAT);
+    }
+
+    @Test
+    void TMAP_두_WALK가_각자_다른_응답_받는다_cross_talk_M4() throws IOException {
+        // M4 — 첫 WALK 와 마지막 WALK 가 같은 stub 결과 받으면 mapper 가 첫 결과를 모든 WALK 에
+        // 재사용해도 단위 테스트 통과. 다른 GeoJSON 두 개로 chain stub → 두 segment path 가 서로
+        // 다른 중간 좌표 보유하는지 검증.
+        String json1 = """
+                {"type":"FeatureCollection","features":[
+                  {"type":"Feature","geometry":{"type":"LineString","coordinates":[[126.995,37.610],[126.9955,37.6105]]}}
+                ]}
+                """;
+        String json2 = """
+                {"type":"FeatureCollection","features":[
+                  {"type":"Feature","geometry":{"type":"LineString","coordinates":[[126.977,37.566],[126.9775,37.5665]]}}
+                ]}
+                """;
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble()))
+                .thenReturn(json1).thenReturn(json2);
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // 첫 WALK 의 중간 좌표는 json1 의 점들 (126.995 ~)
+        var path0 = route.segments().get(0).path();
+        assertThat(path0).hasSize(4);  // origin + 2 + busStart
+        assertThat(path0.get(1)).containsExactly(126.995, 37.610);
+        assertThat(path0.get(2)).containsExactly(126.9955, 37.6105);
+
+        // 마지막 WALK 의 중간 좌표는 json2 의 점들 (126.977 ~) — cross-talk 없으면 두 path 가 다른 좌표
+        var path2 = route.segments().get(2).path();
+        assertThat(path2).hasSize(4);  // busEnd + 2 + dest
+        assertThat(path2.get(1)).containsExactly(126.977, 37.566);
+        assertThat(path2.get(2)).containsExactly(126.9775, 37.5665);
+    }
 
     @Test
     void TMAP_isConfigured_true_정상응답_시_WALK_path_가_GeoJSON_좌표로_채워진다() throws IOException {

--- a/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
+++ b/backend/src/test/java/com/todayway/backend/route/OdsayResponseMapperTest.java
@@ -1,6 +1,7 @@
 package com.todayway.backend.route;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todayway.backend.external.tmap.TmapClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link OdsayResponseMapper} 단위 테스트.
@@ -31,7 +33,10 @@ class OdsayResponseMapperTest {
 
     @BeforeEach
     void setUp() {
-        mapper = new OdsayResponseMapper(new ObjectMapper());
+        // Mockito mock 의 default — isConfigured()=false → WALK 가 v1.1.9 합성 직선 fallback
+        // (기존 테스트 expectation 과 호환). TMAP 호출 동작은 별도 신규 테스트에서 검증.
+        TmapClient tmapClient = mock(TmapClient.class);
+        mapper = new OdsayResponseMapper(new ObjectMapper(), tmapClient);
     }
 
     @Test
@@ -500,6 +505,93 @@ class OdsayResponseMapperTest {
         Route route = mapper.toRoute(pathRaw, laneRaw, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
 
         assertThat(route.segments().get(1).path()).hasSize(18);
+    }
+
+    // ─────────── §6.1 v1.1.21 — TMAP WALK 곡선 ───────────
+
+    @Test
+    void TMAP_isConfigured_true_정상응답_시_WALK_path_가_GeoJSON_좌표로_채워진다() throws IOException {
+        // GeoJSON LineString 2 features: [(127.0,37.61),(127.001,37.612)] + [(127.001,37.612),(127.002,37.613)]
+        // → 평탄화 후 4점, 양 끝에 from/to 강제 prepend/append → 6점.
+        String tmapJson = """
+                {
+                  "type": "FeatureCollection",
+                  "features": [
+                    {"type":"Feature","geometry":{"type":"LineString","coordinates":[[127.0,37.61],[127.001,37.612]]}},
+                    {"type":"Feature","geometry":{"type":"LineString","coordinates":[[127.001,37.612],[127.002,37.613]]}}
+                  ]
+                }
+                """;
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble())).thenReturn(tmapJson);
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // 첫 WALK — 합성 직선 2점 → TMAP 4점 + 양 끝 강제 = 6점
+        RouteSegment seg0 = route.segments().get(0);
+        assertThat(seg0.mode()).isEqualTo(SegmentMode.WALK);
+        assertThat(seg0.path()).hasSize(6);
+        // 양 끝 = origin / 다음 transit startX/Y (강제 prepend/append)
+        assertThat(seg0.path().get(0)).containsExactly(ORIGIN_LNG, ORIGIN_LAT);
+        assertThat(seg0.path().get(seg0.path().size() - 1)).containsExactly(126.994769, 37.61072);
+
+        // TMAP 호출 N+1 회 (subPath 의 WALK 갯수 = 2)
+        org.mockito.Mockito.verify(tmap, org.mockito.Mockito.times(2)).routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble());
+    }
+
+    @Test
+    void TMAP_호출_실패시_v1_1_9_합성_직선_fallback() throws IOException {
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(true);
+        org.mockito.Mockito.when(tmap.routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble()))
+                .thenThrow(new com.todayway.backend.external.ExternalApiException(
+                        com.todayway.backend.external.ExternalApiException.Source.TMAP,
+                        com.todayway.backend.external.ExternalApiException.Type.SERVER_ERROR,
+                        503, "TMAP 5xx", null));
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // TMAP 실패 → fallback 직선 2점 (기존 동작과 동일)
+        RouteSegment seg0 = route.segments().get(0);
+        assertThat(seg0.path()).hasSize(2);
+        assertThat(seg0.path().get(0)).containsExactly(ORIGIN_LNG, ORIGIN_LAT);
+        assertThat(seg0.path().get(1)).containsExactly(126.994769, 37.61072);
+    }
+
+    @Test
+    void TMAP_isConfigured_false_시_호출_안하고_바로_fallback() throws IOException {
+        com.todayway.backend.external.tmap.TmapClient tmap = mock(com.todayway.backend.external.tmap.TmapClient.class);
+        org.mockito.Mockito.when(tmap.isConfigured()).thenReturn(false);
+        OdsayResponseMapper customMapper = new OdsayResponseMapper(new ObjectMapper(), tmap);
+
+        String raw = Files.readString(Path.of(FIXTURE_PATH));
+        Route route = customMapper.toRoute(raw, null, ORIGIN_LNG, ORIGIN_LAT, DEST_LNG, DEST_LAT);
+
+        // 호출 자체가 일어나면 안 됨 — 401 비용 + warn 로그 노이즈 회피
+        org.mockito.Mockito.verify(tmap, org.mockito.Mockito.never()).routesPedestrian(
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble(),
+                org.mockito.ArgumentMatchers.anyDouble());
+        // fallback 직선 2점
+        assertThat(route.segments().get(0).path()).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
## 배경

PR #28 (TMAP 통합) 이 base=`feat/backend-step8-map-geocode` (stack) 으로 머지되었으나, step8 가 그 머지 **이전** 에 이미 `feat/backend` 로 머지된 상태였음 → PR #28 의 5 커밋이 `feat/backend` 에 들어가지 않음. step8 브랜치 정리 후 발견.

## 조치

PR #28 의 5 커밋을 `feat/backend` 기준 새 브랜치에 cherry-pick (충돌 0건) → 본 PR 로 정상 재머지.

| Cherry-picked commit (PR #28 sha → 본 PR sha) | 내용 |
|---|---|
| `52f39d5` → `36d9c3b` | feat: TMAP 통합 (명세 v1.1.21) |
| `0246f5e` → `791117e` | fix: 1차 self-review (M1+M2+L1+L3+L4) |
| `b1c0587` → `441655c` | fix: 정밀 review C1+M1+M2+L1+L2+L3 — javadoc/메시지/관측성 |
| `4008da3` → `b94b11a` | test: 정밀 review M3+M4+L4+L5 — 회귀 가드 강화 |
| `9d64c53` → `b330041` | docs: 황찬우 review A4 — TMAP 호출 빈도/응답 지연 정확화 |

## Summary (원 PR #28 내용)

명세 §6.1 v1.1.21 — WALK 구간 path 출처를 v1.1.9 합성 직선 → **TMAP `routes/pedestrian` 인도 곡선** 으로 승격.

- 신규 외부 API client: `TmapClient` + `TmapProperties` + `ExternalApiException.Source.TMAP`
- WALK 분기 갱신: `OdsayResponseMapper.resolveWalkPath` — GeoJSON LineString 평탄화 + 양 끝 강제 prepend/append
- graceful fallback: 모든 실패 (키 미설정 / 401/403/timeout/5xx / 응답 형식 위반) → v1.1.9 합성 직선
- 명세 §6.1 v1.1.21 갱신 + 호출 빈도 환승 횟수별 N 값 명시 + worst case latency
- 외부 의존성: `TMAP_APP_KEY` 환경변수 (SK Open API 콘솔 → 상품 마켓 → "보행자 경로안내 V1")

## Test plan

- [x] `./gradlew test` BUILD SUCCESSFUL (cherry-pick 후 재검증, 단위 + 통합 전체)
- [x] cherry-pick 충돌 0건 (`feat/backend` 위 깨끗하게 적용)
- [x] PR #28 의 4 review 흡수 (★C1 + M1~M4 + L1~L5 + 황찬우 A4) 모두 보존
- [ ] EC2 배포 후 운영 IP whitelist 등록 (TMAP 콘솔)
- [ ] `TMAP_APP_KEY` 운영 secrets 주입 (`/etc/todayway/app.env`)

## 처리 약속

본 PR 머지 후 `feat/backend-route-tmap-walk-curve-v2` 브랜치는 즉시 삭제. 다음부터 stack base 만들지 않음 (메모리 갱신 완료).