### PR TITLE
fix(backend/common): NoResourceFoundException 404 매핑 + RESOURCE_NOT_FOUND ErrorCode (closes #33)

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.22-MVP
-> **최종 수정**: 2026-05-11 (황찬우 — §3.3 회원 탈퇴 soft delete → hard delete 전환. FK CASCADE 가 refresh_token / schedule / push_subscription 일괄 삭제. 이슈 #31 fix.)
+> **버전**: v1.1.23-MVP
+> **최종 수정**: 2026-05-11 (황찬우 — §1.6 `RESOURCE_NOT_FOUND` ErrorCode 추가. 매핑되지 않은 URL 호출 시 500 → 404 정정. 이슈 #33 fix.)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -38,6 +38,7 @@
 | **v1.1.19** | **2026-05-08** | **§4.1 lat/lng XOR 검증 명시 — 둘 다 함께 또는 둘 다 누락만 허용. 한쪽만 채워 보낸 케이스는 400 VALIDATION_ERROR (silent default fallback 차단). NaN/±Infinity 도 400 명시. PR #27 review M2 코드 fix 의 명세 mirroring + 자체 review H1/L1/L3 (javadoc 운영 가정/XFF spoof 안내) 동반.** |
 | **v1.1.20** | **2026-05-08** | **§6.1 `transferCount` 정의 확정 — "이용 대중교통 노선 수 (= 탑승 횟수)". 응답 예시 (지하철 1노선 + 도보 = `transferCount: 1`) 와 정합. **환승 횟수 = `transferCount - 1`** 비고 추가 (0 노선 케이스는 `Math.max(0, n-1)` 권고). v1.1.4 의 "미확정" 표기 제거. 코드 동작 변경 X (현 합산 패턴 그대로 OK). §12 체크리스트 완료 표시 (push/map/geocode/ODsay 4행). Step 6 PR #11 follow-up 1번 자체 판단 처리 (이상진).** |
 | **v1.1.21** | **2026-05-08** | **§6.1 WALK 구간 `path` 출처 = TMAP 보행자 경로 (인도 곡선). 기존 v1.1.9 합성 직선 → `POST https://apis.openapi.sk.com/tmap/routes/pedestrian` 호출 결과(GeoJSON LineString features)로 승격 — 4차선 도로 가로지르는 비현실적 직선 시각화 차단. WALK 구간당 1회 추가 호출. 외부 API 의존성 +1 (`TMAP_APP_KEY` 환경변수). 모든 실패 (키 미설정 / 401/403 / timeout / 5xx / 응답 형식 위반) 는 graceful — v1.1.9 합성 직선 fallback. ErrorCode 신규 X. 시각 검증: `~/route-preview/odsay-tmap-walk.html` (이상진).** |
+| **v1.1.23** | **2026-05-11** | **§1.6 `RESOURCE_NOT_FOUND` ErrorCode 추가 (이슈 #33). 매핑되지 않은 URL 호출 시 Spring 6.x 가 `NoResourceFoundException` throw → `GlobalExceptionHandler` catch-all 이 잡아 500 `INTERNAL_SERVER_ERROR` 로 폴백하던 결함 fix. 신규 핸들러는 404 + WARN 로깅 (`resourcePath` 한 줄, 스택 미포함 — 4xx 류 ERROR 가 운영 false alarm 의 원인이었음). `NoHandlerFoundException` 도 동시 매핑 (현 application.yml 미설정이라 미발생, future-proof). 405 `HttpRequestMethodNotSupportedException` 잘못 매핑 (400 → 405) 은 별 이슈로 분리.** |
 | **v1.1.22** | **2026-05-11** | **§3.3 회원 탈퇴 soft delete → hard delete 전환 (이슈 #31). soft delete + `login_id` UNIQUE 충돌로 동일 loginId 재가입 불가하던 버그 해소. DB FK ON DELETE CASCADE 가 refresh_token / schedule / push_subscription row 일괄 삭제 — 코드 cascade 메서드 (`ScheduleRepository.softDeleteByMemberId` / `PushSubscriptionRepository.revokeAllByMemberId`) 제거. push_log 는 FK 비대칭 동작 — `schedule_id` ON DELETE SET NULL (다른 회원의 schedule 삭제 시 이력 보존), `subscription_id` ON DELETE CASCADE (탈퇴 회원 본인의 발송 이력은 동반 삭제, 회원 데이터 완전 삭제 정책). schedule 개별 DELETE / push subscription unsubscribe 는 별개 정책으로 soft delete/revoke 유지. 멱등성 비고 (v1.1.7) 그대로 — 두 번째 DELETE 도 401 UNAUTHORIZED (member row 없음). V3 마이그레이션 (`V3__member_drop_deleted_at.sql`) 적용 시 옛 soft-deleted row 정리 (FK CASCADE 발동) + `deleted_at` 컬럼 drop.** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
@@ -142,6 +143,7 @@ Authorization: Bearer {accessToken}
 | 404 | `ROUTE_NOT_CALCULATED` | 경로가 아직 계산되지 않음 |
 | 404 | `GEOCODE_NO_MATCH` | 지오코딩 결과 없음 |
 | 404 | `SUBSCRIPTION_NOT_FOUND` | 푸시 구독 없음 |
+| **404** | **`RESOURCE_NOT_FOUND`** | **매핑되지 않은 URL 경로 호출. `GlobalExceptionHandler` 가 `NoResourceFoundException` / `NoHandlerFoundException` 을 404 로 변환 — v1.1.23 추가** |
 | 409 | `LOGIN_ID_DUPLICATED` | 로그인 ID 중복 |
 | 502 | `EXTERNAL_ROUTE_API_FAILED` | ODsay 호출 실패 (5xx / 네트워크 장애 / 일반 4xx — 401/403 제외) |
 | **503** | **`EXTERNAL_AUTH_MISCONFIGURED`** | **외부 API 키 미설정 또는 인증 실패. 운영자 조치 필요 (일반 외부장애와 구분) — v1.1.4 추가** |

--- a/backend/src/main/java/com/todayway/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     ROUTE_NOT_CALCULATED(HttpStatus.NOT_FOUND, "경로가 계산되지 않았습니다"),
     GEOCODE_NO_MATCH(HttpStatus.NOT_FOUND, "지오코딩 결과가 없습니다"),
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "푸시 구독을 찾을 수 없습니다"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 자원을 찾을 수 없습니다"),
     LOGIN_ID_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다"),
     EXTERNAL_ROUTE_API_FAILED(HttpStatus.BAD_GATEWAY, "경로 API 호출에 실패했습니다"),
     EXTERNAL_AUTH_MISCONFIGURED(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 인증 설정에 문제가 있습니다"),

--- a/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/todayway/backend/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -93,6 +95,31 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException e) {
         ErrorCode code = ErrorCode.FORBIDDEN_RESOURCE;
+        return ResponseEntity.status(code.getStatus())
+                .body(ErrorResponse.of(code.name(), code.getMessage()));
+    }
+
+    /**
+     * 매핑되지 않은 URL 경로 호출 시 404 {@code RESOURCE_NOT_FOUND} 매핑 (명세 §1.6).
+     *
+     * <p>Spring 6.x default 흐름: {@link NoResourceFoundException}만 throw — static resource handler가
+     * 매핑 못 찾은 path 를 잡아 발생. {@link NoHandlerFoundException}은 {@code spring.mvc.throw-exception-if-no-handler-found}
+     * 활성화 시에만 발생하며 본 프로젝트 application.yml 에는 미설정이라 production 에서는 발생 X.
+     * 미래 설정 활성화 또는 다른 진입점 대비해 둘 다 매핑.
+     *
+     * <p>로그 레벨 WARN — 4xx 류는 클라이언트 측 오류라 ERROR 부적절 (catch-all 분기가 ERROR 로깅으로
+     * 5xx false alarm 유발한 이슈 #33 의 원인 자체). 스택 trace 는 {@code ResourceHttpRequestHandler}
+     * 내부 흐름이라 정보 가치 X — {@code resourcePath} 한 줄만 남겨 운영 가시성 (스캐닝/SPA bug/path drift
+     * 탐지) 확보.
+     */
+    @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+    public ResponseEntity<ErrorResponse> handleNoResourceFound(Exception e) {
+        if (e instanceof NoResourceFoundException nrfe) {
+            log.warn("NoResourceFound: path={}", nrfe.getResourcePath());
+        } else {
+            log.warn("NoHandlerFound: {}", e.getMessage());
+        }
+        ErrorCode code = ErrorCode.RESOURCE_NOT_FOUND;
         return ResponseEntity.status(code.getStatus())
                 .body(ErrorResponse.of(code.name(), code.getMessage()));
     }

--- a/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/todayway/backend/common/exception/GlobalExceptionHandlerTest.java
@@ -86,6 +86,23 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
+    // ─────────── 이슈 #33 — NoResourceFoundException 404 회귀 가드 ───────────
+
+    @Test
+    void 매핑되지_않은_GET_경로는_404_RESOURCE_NOT_FOUND로_변환된다() throws Exception {
+        mockMvc.perform(get("/dummy/no-such-path"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("RESOURCE_NOT_FOUND"))
+                .andExpect(jsonPath("$.error.message").value("요청한 자원을 찾을 수 없습니다"));
+    }
+
+    @Test
+    void 매핑되지_않은_POST_경로는_404_RESOURCE_NOT_FOUND로_변환된다() throws Exception {
+        mockMvc.perform(post("/dummy/no-such-path"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("RESOURCE_NOT_FOUND"));
+    }
+
     @RestController
     static class DummyController {
         @GetMapping("/dummy/business")


### PR DESCRIPTION
## 배경

이상진이 데모 SPA raw 페이지에서 명세에 없는 경로 (`POST /api/v1/schedules/{id}/route/refresh`) 호출 중 발견 ([#33](https://github.com/kookmin-sw/2026-capstone-53/issues/33)).

- Spring 6.x 가 매핑되지 않은 경로 호출 시 `NoResourceFoundException` throw
- 기존 `GlobalExceptionHandler` 에 전용 매핑 없어 catch-all `Exception` 핸들러가 잡음 → 500 `INTERNAL_SERVER_ERROR` + `log.error("예상치 못한 예외 발생", e)` 풀스택
- 사용자/운영자 관점: 단순 오타 경로가 5xx 처럼 보이고, ERROR 로그가 진짜 500 신호를 오염
- 이슈 #16 (`HttpMessageNotReadable → 500` 폴백) 과 동일 패턴의 별개 케이스

## 정책 결정 (명세 v1.1.23)

1. **ErrorCode 네이밍** = `RESOURCE_NOT_FOUND` — 도메인별 `*_NOT_FOUND` 5개와 톤 일치 (일반화된 단일 키)
2. **매핑 범위** = `NoResourceFoundException` + `NoHandlerFoundException` 둘 다 — 현 `application.yml` 에 `throw-exception-if-no-handler-found` 미설정이라 production 에서는 `NoResourceFoundException` 만 발생하지만 future-proof
3. **로그 레벨** = **WARN + `resourcePath` 한 줄 + 스택 미포함** — 4xx 류는 클라이언트 측 오류라 ERROR 부적절 (이게 운영 false alarm 원인 자체였음). `ResourceHttpRequestHandler` 내부 스택은 정보 가치 0, 미로깅은 스캐닝/SPA bug/path drift 가시성 손실
4. **회귀 가드** = `GlobalExceptionHandlerTest` 에 GET/POST 2건 (이상진 #16 close 코멘트에서 언급한 파일). `NoHandlerFoundException` 회귀 가드는 dead-test 회피 위해 생략
5. **method 무관 단일 핸들러** — `NoResourceFoundException` contract 가 method 정보 무관

## 변경

| 영역 | 변경 |
|---|---|
| `ErrorCode` | `RESOURCE_NOT_FOUND(NOT_FOUND, "요청한 자원을 찾을 수 없습니다")` 신규 — 도메인별 NOT_FOUND 5개 다음 위치 |
| `GlobalExceptionHandler` | `handleNoResourceFound` 핸들러 신규 — `NoResourceFoundException` / `NoHandlerFoundException` 묶음, AccessDenied(403) ↔ handleUnknown(500) 사이 위치 |
| `GlobalExceptionHandlerTest` | GET/POST 매핑 안 된 경로 회귀 가드 2건 추가 (총 5건 → 7건) |
| api-spec §1.6 v1.1.23 | ErrorCode 표 404 그룹에 `RESOURCE_NOT_FOUND` 행 추가 + 변경 이력 항목 |

## 테스트

- ✅ `./gradlew build` 통과 (`BUILD SUCCESSFUL in 6m 48s`)
- ✅ 모든 테스트 통과 (Testcontainers 통합 포함)
- 신규 회귀 가드 2건:
  - `매핑되지_않은_GET_경로는_404_RESOURCE_NOT_FOUND로_변환된다`
  - `매핑되지_않은_POST_경로는_404_RESOURCE_NOT_FOUND로_변환된다`

## 영향

- **API 시그니처 변경 없음** — 정상 경로 응답은 그대로, 매핑 안 된 경로만 500 → 404 정정
- **PR #29 (프론트엔드) 영향 없음** — 404 응답은 매핑 안 된 경로 호출 시에만 발생, 정상 흐름 무영향
- **운영 모니터링**: ERROR 로그 false alarm 차단. 매핑 안 된 경로 호출이 WARN 로 가시화되어 스캐닝/SPA bug/path drift 탐지 가능
- **운영 RDS 변경 없음** (코드 변경만)

## 후속

- **별 이슈 (본 PR scope 밖)**: `HttpRequestMethodNotSupportedException` 현재 400 `VALIDATION_ERROR` 잘못 매핑 → 표준 405 `METHOD_NOT_ALLOWED` 로 정정 필요. ErrorCode `METHOD_NOT_ALLOWED` 신규 + §1.6 갱신 동반. 결의 다름 (500 fallback X) 이라 분리.