### PR TITLE
fix(backend/schedule): cursor 페이지네이션 keyset 합성키 — 비대칭 누락 fix (closes #15)

### DIFF
--- a/backend/docs/api-spec.md
+++ b/backend/docs/api-spec.md
@@ -1,7 +1,7 @@
 # 오늘어디 (TodayWay) Backend API 명세
 
-> **버전**: v1.1.25-MVP
-> **최종 수정**: 2026-05-12 (황찬우 — §1.9 CORS 정책 신규 + §9.2 WEEKLY routine 요일 비교 Asia/Seoul 기준 명시. PR #29 unblock + 이슈 #36 fix.)
+> **버전**: v1.1.26-MVP
+> **최종 수정**: 2026-05-13 (황찬우 — §5.2 cursor 페이지네이션 keyset 합성키 (arrival_time, id) 명시. 이슈 #15 fix.)
 > **기준**: DB 스키마 v1.1-MVP (DB-SQL.txt, 2026-04-23)
 > **데모 일정**: 2026-05-22
 
@@ -41,6 +41,7 @@
 | **v1.1.23** | **2026-05-11** | **§1.6 `RESOURCE_NOT_FOUND` ErrorCode 추가 (이슈 #33). 매핑되지 않은 URL 호출 시 Spring 6.x 가 `NoResourceFoundException` throw → `GlobalExceptionHandler` catch-all 이 잡아 500 `INTERNAL_SERVER_ERROR` 로 폴백하던 결함 fix. 신규 핸들러는 404 + WARN 로깅 (`resourcePath` 한 줄, 스택 미포함 — 4xx 류 ERROR 가 운영 false alarm 의 원인이었음). `NoHandlerFoundException` 도 동시 매핑 (현 application.yml 미설정이라 미발생, future-proof). 405 `HttpRequestMethodNotSupportedException` 잘못 매핑 (400 → 405) 은 별 이슈로 분리.** |
 | **v1.1.22** | **2026-05-11** | **§3.3 회원 탈퇴 soft delete → hard delete 전환 (이슈 #31). soft delete + `login_id` UNIQUE 충돌로 동일 loginId 재가입 불가하던 버그 해소. DB FK ON DELETE CASCADE 가 refresh_token / schedule / push_subscription row 일괄 삭제 — 코드 cascade 메서드 (`ScheduleRepository.softDeleteByMemberId` / `PushSubscriptionRepository.revokeAllByMemberId`) 제거. push_log 는 FK 비대칭 동작 — `schedule_id` ON DELETE SET NULL (다른 회원의 schedule 삭제 시 이력 보존), `subscription_id` ON DELETE CASCADE (탈퇴 회원 본인의 발송 이력은 동반 삭제, 회원 데이터 완전 삭제 정책). schedule 개별 DELETE / push subscription unsubscribe 는 별개 정책으로 soft delete/revoke 유지. 멱등성 비고 (v1.1.7) 그대로 — 두 번째 DELETE 도 401 UNAUTHORIZED (member row 없음). V3 마이그레이션 (`V3__member_drop_deleted_at.sql`) 적용 시 옛 soft-deleted row 정리 (FK CASCADE 발동) + `deleted_at` 컬럼 drop.** |
 | **v1.1.24** | **2026-05-12** | **§1.9 CORS 정책 섹션 신규 추가 — `CorsConfigurationSource` Bean 등록 (`common.security.CorsProperties` + `SecurityConfig`). 화이트리스트 default `http://localhost:3000` (yml fallback, env `CORS_ALLOWED_ORIGINS` 콤마 구분 override), `allowCredentials=false` (JWT stateless 정합), `allowedHeaders="*"` (`Content-Type` / `Authorization` 커버), `maxAge=1800`. PR #29 (frontend 통합) unblock. 운영 도메인은 별 task (외부 노출) 진입 시 `CORS_ALLOWED_ORIGINS` env 로 보강.** |
+| **v1.1.26** | **2026-05-13** | **§5.2 cursor 페이지네이션 keyset 합성키 명시 (이슈 #15 fix). `ScheduleRepository.findPage` keyset 술어가 `s.id > :cursorId` 단독이라 정렬 `(arrival_time ASC, id ASC)` 과 어긋날 때 (arrival 이른 일정이 더 큰 id 보유) 다음 페이지에서 영구 누락. 술어를 `(arrivalTime > :cArr OR (arrivalTime = :cArr AND id > :cId))` 합성키로 교체. cursor 인코딩도 `id:N` (v1) → `v2:<ISO_UTC>|<id>` 로 변경, v1 cursor 는 `VALIDATION_ERROR` (400) 로 거부 — 명세 §1.5 opaque 정책상 클라이언트는 1페이지부터 재요청. 회귀 가드 `ScheduleControllerIntegrationTest.list_keysetHandlesAsymmetricArrivalAndId_doesNotDropSchedules` + `list_whenInvalidCursorFormat_returns400`.** |
 | **v1.1.25** | **2026-05-12** | **§9.2 WEEKLY routine 요일 비교 `Asia/Seoul` (KST) 기준 명시 (이슈 #36 fix). `RoutineCalculator.nextWeeklyOccurrence` 가 `cand.getDayOfWeek()` 를 사용하던 결함 — `OffsetDateTime` 영속화 후 displayed offset 이 UTC 로 reconstruct 되어 KST 가 아닌 UTC 기준 요일 평가 → KST 새벽 시간대 일정의 advance 가 `daysOfWeek` 에 없는 요일 (예: MON/WED/FRI 일정이 THU 로) 반환. `cand.atZoneSameInstant(KST).getDayOfWeek()` 로 정정. 회귀 가드 추가 (`PushReminderDispatcherIntegrationTest.S5B` 명시 KST 새벽 시각). 데모 시연 (정오) 직접 영향 ⚪ 낮음 — KST/UTC 동일 요일 시간대. DAILY/CUSTOM (`plusDays(N)` instant 기준) / `reminderAt` 계산 (instant 기준) 영향 0.** |
 
 ### 0.2 v1.0 → v1.1-MVP 주요 변경
@@ -680,9 +681,13 @@ SELECT * FROM schedule
 WHERE member_id = ?
   AND deleted_at IS NULL
   [AND arrival_time BETWEEN ? AND ?]
-ORDER BY arrival_time ASC
+  -- cursor 가 있으면 합성키 keyset (이슈 #15 fix, v1.1.26)
+  [AND (arrival_time > ? OR (arrival_time = ? AND id > ?))]
+ORDER BY arrival_time ASC, id ASC
 LIMIT ?
 ```
+
+> cursor 는 opaque token — 서버 내부 표현은 `Base64URL("v2:" + <arrival_time UTC ISO> + "|" + <id>)`. v1 (`id:N`) cursor 는 `VALIDATION_ERROR` (400) 로 거부. 정렬 tie-break (`id ASC`) 와 동일한 합성키 술어로 누락 방지.
 
 ---
 

--- a/backend/src/main/java/com/todayway/backend/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/repository/ScheduleRepository.java
@@ -20,6 +20,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     /**
      * 명세 §5.2 cursor 페이지네이션. ⚠️ JPQL은 @SQLRestriction 자동 적용 X — `deletedAt IS NULL` 명시 필수.
      * 정렬: arrival_time ASC, id ASC tie-break.
+     *
+     * <p>Keyset 술어는 정렬과 동일한 합성 키 {@code (arrivalTime, id)} 기준이어야 함 — 이슈 #15:
+     * id 단일 술어 시 arrival ASC 순서와 id 단조 증가가 어긋나면 일정 영구 누락.
+     * cursor 양쪽이 모두 null 인 경우만 1페이지로 처리 — service 가 동반 보장.
      */
     @Query("""
             SELECT s FROM Schedule s
@@ -27,12 +31,15 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
               AND s.deletedAt IS NULL
               AND (:from IS NULL OR s.arrivalTime >= :from)
               AND (:to IS NULL OR s.arrivalTime <= :to)
-              AND (:cursorId IS NULL OR s.id > :cursorId)
+              AND (:cursorArrival IS NULL
+                   OR s.arrivalTime > :cursorArrival
+                   OR (s.arrivalTime = :cursorArrival AND s.id > :cursorId))
             ORDER BY s.arrivalTime ASC, s.id ASC
             """)
     List<Schedule> findPage(@Param("memberId") Long memberId,
                             @Param("from") OffsetDateTime from,
                             @Param("to") OffsetDateTime to,
+                            @Param("cursorArrival") OffsetDateTime cursorArrival,
                             @Param("cursorId") Long cursorId,
                             Pageable pageable);
 

--- a/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/todayway/backend/schedule/service/ScheduleService.java
@@ -25,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.Base64;
 import java.util.List;
 
@@ -35,7 +37,8 @@ import java.util.List;
 public class ScheduleService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private static final String CURSOR_PREFIX = "id:";
+    private static final String CURSOR_PREFIX_V2 = "v2:";
+    private static final String CURSOR_DELIMITER = "|";
 
     private final MemberRepository memberRepository;
     private final ScheduleRepository scheduleRepository;
@@ -94,15 +97,22 @@ public class ScheduleService {
                                                  OffsetDateTime to,
                                                  CursorRequest cursor) {
         Long memberId = resolveMemberId(memberUid);
-        Long cursorId = decodeCursor(cursor.cursor());
+        CursorKey key = decodeCursor(cursor.cursor());
 
         // limit + 1 조회 → hasMore 판정 + 마지막 row 제거
-        List<Schedule> rows = scheduleRepository.findPage(memberId, from, to, cursorId,
+        List<Schedule> rows = scheduleRepository.findPage(
+                memberId, from, to,
+                key != null ? key.arrivalTime() : null,
+                key != null ? key.id() : null,
                 PageRequest.of(0, cursor.limit() + 1));
         boolean hasMore = rows.size() > cursor.limit();
         if (hasMore) rows = rows.subList(0, cursor.limit());
 
-        String nextCursor = hasMore ? encodeCursor(rows.get(rows.size() - 1).getId()) : null;
+        String nextCursor = null;
+        if (hasMore) {
+            Schedule last = rows.get(rows.size() - 1);
+            nextCursor = encodeCursor(last.getArrivalTime(), last.getId());
+        }
         List<ScheduleListItem> items = rows.stream().map(ScheduleListItem::from).toList();
         return CursorResponse.of(items, nextCursor);
     }
@@ -204,23 +214,46 @@ public class ScheduleService {
         }
     }
 
-    private static String encodeCursor(Long id) {
+    /**
+     * cursor 인코딩 — 이슈 #15 합성키 (arrivalTime, id) 기준.
+     * <p>arrivalTime 은 UTC 로 정규화 (DB 영속화 형식과 일치, 클라이언트 무관 — opaque token).
+     * v1 ({@code id:N}) cursor 는 이번 fix 로 폐기, 신규 prefix {@code v2:} 도입.
+     */
+    private static String encodeCursor(OffsetDateTime arrivalTime, Long id) {
+        String payload = CURSOR_PREFIX_V2
+                + arrivalTime.withOffsetSameInstant(ZoneOffset.UTC)
+                + CURSOR_DELIMITER + id;
         return Base64.getUrlEncoder().withoutPadding()
-                .encodeToString((CURSOR_PREFIX + id).getBytes(StandardCharsets.UTF_8));
+                .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static Long decodeCursor(String cursor) {
+    private static CursorKey decodeCursor(String cursor) {
         if (cursor == null || cursor.isBlank()) return null;
+        String decoded;
         try {
-            String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
-            if (!decoded.startsWith(CURSOR_PREFIX)) {
-                throw new BusinessException(ErrorCode.VALIDATION_ERROR);
-            }
-            return Long.parseLong(decoded.substring(CURSOR_PREFIX.length()));
+            decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
+        if (!decoded.startsWith(CURSOR_PREFIX_V2)) {
+            // 구버전 ({@code id:N}) cursor 또는 변조 — 명세 §1.5 opaque 정책상 1페이지부터 재요청 강제
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+        String body = decoded.substring(CURSOR_PREFIX_V2.length());
+        int sep = body.indexOf(CURSOR_DELIMITER);
+        if (sep <= 0 || sep == body.length() - 1) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
+        try {
+            OffsetDateTime arrival = OffsetDateTime.parse(body.substring(0, sep));
+            Long id = Long.parseLong(body.substring(sep + 1));
+            return new CursorKey(arrival, id);
+        } catch (DateTimeParseException | NumberFormatException e) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
     }
+
+    private record CursorKey(OffsetDateTime arrivalTime, Long id) {}
 
     private static com.todayway.backend.schedule.domain.RoutineType routineType(RoutineRuleDto r) {
         return r != null ? r.type() : null;

--- a/backend/src/test/java/com/todayway/backend/schedule/ScheduleControllerIntegrationTest.java
+++ b/backend/src/test/java/com/todayway/backend/schedule/ScheduleControllerIntegrationTest.java
@@ -146,6 +146,65 @@ class ScheduleControllerIntegrationTest {
     }
 
     @Test
+    void list_keysetHandlesAsymmetricArrivalAndId_doesNotDropSchedules() throws Exception {
+        // 이슈 #15 회귀 가드 — arrival ASC 순서와 id 단조 증가가 어긋날 때
+        // keyset 술어가 id 단독이면 일정 영구 누락. (arrivalTime, id) 합성 술어로 fix.
+        when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
+
+        String accessToken = signupAndGetToken("schasym01", "비대칭");
+
+        // A 먼저 등록 (arrival = NOW+10일 → id 더 작음)
+        mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createScheduleBody(arrivalIn(60 * 24 * 10))))
+                .andExpect(status().isCreated());
+        // B 나중 등록 (arrival = NOW+5일 → id 더 크지만 arrival 더 이름)
+        mockMvc.perform(post("/api/v1/schedules")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createScheduleBody(arrivalIn(60 * 24 * 5))))
+                .andExpect(status().isCreated());
+
+        // 1페이지 (limit=1) → arrival 더 이른 B 가 먼저 + nextCursor 발급
+        String page1 = mockMvc.perform(get("/api/v1/schedules?limit=1")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.hasMore").value(true))
+                .andReturn().getResponse().getContentAsString();
+        String firstId = objectMapper.readTree(page1).path("data").path("items").get(0).path("scheduleId").asText();
+        String nextCursor = objectMapper.readTree(page1).path("data").path("nextCursor").asText();
+
+        // 2페이지 → 남은 A 반환. id-only 술어였다면 firstId(=B, id 더 큼) 보다 큰 id 가 없어 빈 결과 → A 영구 누락.
+        String page2 = mockMvc.perform(get("/api/v1/schedules?limit=1&cursor=" + nextCursor)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(1))
+                .andExpect(jsonPath("$.data.hasMore").value(false))
+                .andReturn().getResponse().getContentAsString();
+        String secondId = objectMapper.readTree(page2).path("data").path("items").get(0).path("scheduleId").asText();
+
+        assertThat(secondId).isNotEqualTo(firstId);
+    }
+
+    @Test
+    void list_whenInvalidCursorFormat_returns400() throws Exception {
+        // v1 cursor (id:N base64) 또는 변조된 cursor → VALIDATION_ERROR.
+        // 명세 §1.5 opaque 정책상 클라이언트는 1페이지부터 재요청해야 함.
+        String accessToken = signupAndGetToken("schinval01", "잘못된");
+
+        // v1 cursor 시뮬레이션: Base64URL("id:1")
+        String legacyCursor = java.util.Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("id:1".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        mockMvc.perform(get("/api/v1/schedules?limit=10&cursor=" + legacyCursor)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
     void get_whenNotOwn_returns403Forbidden() throws Exception {
         when(routeService.refreshRouteSync(any(Schedule.class))).thenReturn(false);
 


### PR DESCRIPTION
## 문제 — 이슈 #15

`ScheduleRepository.findPage` 의 keyset 술어가 `s.id > :cursorId` 단독인데 정렬은 `ORDER BY arrival_time ASC, s.id ASC`. **arrival 순서와 id 순서가 어긋나면 일정 영구 누락**.

### 재현 시나리오
1. Schedule A 등록 (arrival = T+10일, id=10)
2. Schedule B 등록 (arrival = T+5일, id=11) ← 더 이른 도착, 하지만 id 더 큼
3. `GET /schedules?limit=1` → 정렬상 B 반환 + cursor=enc(11)
4. `GET /schedules?limit=1&cursor=enc(11)` → `s.id > 11` 술어로 A.id=10 매칭 실패 → **빈 결과, hasMore=false**
5. A 는 영영 안 보임

## 변경

### `ScheduleRepository.findPage`
JPQL keyset 술어를 합성키로 교체:
```jpql
AND (:cursorArrival IS NULL
     OR s.arrivalTime > :cursorArrival
     OR (s.arrivalTime = :cursorArrival AND s.id > :cursorId))
```
`cursorArrival` 파라미터 추가. 양쪽 모두 null 일 때만 1페이지 (서비스가 동반 보장).

### `ScheduleService`
- `encodeCursor(OffsetDateTime arrival, Long id)` — \`Base64URL(\"v2:\" + <arrivalISO_UTC> + \"|\" + <id>)\`
- `decodeCursor → CursorKey record` 반환 (arrivalTime + id)
- v1 (`id:N`) cursor / 변조 / format 오류 → `VALIDATION_ERROR` (400). 명세 §1.5 opaque 정책상 클라이언트는 1페이지부터 재요청
- `arrivalTime.withOffsetSameInstant(ZoneOffset.UTC)` 정규화 ([[project_timezone_offset_pattern]] 패턴 적용 — DB 영속화 형식 일치)

### `ScheduleControllerIntegrationTest`
- `list_keysetHandlesAsymmetricArrivalAndId_doesNotDropSchedules` — 이슈 #15 재현 시나리오 회귀 가드
- `list_whenInvalidCursorFormat_returns400` — v1 cursor 거부 가드 (Base64URL(\"id:1\") 시뮬)

### `api-spec.md` §5.2
- DB 매핑 SQL 에 keyset 합성키 + tie-break (`id ASC`) 명시
- 변경이력 v1.1.26 entry 추가 (2026-05-13)

## FE 영향 분석 (검증: feat/frontend HEAD b85252e)

**영향 0** 확정:
- `api.schedules.list()` 호출처 2곳 (`Calendar.js:801`, `HomeV2Route.jsx:78`) 모두 **인자 없이 호출** → cursor 송신 경로 0
- `nextCursor` / `hasMore` 응답 사용 코드 0건 (JSDoc/mock 외)
- `localStorage` / `sessionStorage` cursor 캐싱 0건
- 응답 schema `{ items, nextCursor, hasMore }` 변경 없음 — opaque 내용물만 v2 로 변경

## 의사결정 사항 (사전 합의)

| # | 결정 | 채택 |
|---|---|---|
| 1 | v1 cursor 처리 | **break clean** (400) — FE 송신 경로 0 으로 무비용 |
| 2 | v2 cursor 포맷 | `Base64URL(\"v2:\" + arrivalISO + \"|\" + id)` (디버그 친화) |
| 3 | api-spec 갱신 | **이 PR 동봉** + v1.1.26 bump |
| 4 | 테스트 깊이 | Testcontainers 통합 회귀 가드 (단위 X) |
| 5 | arrival 직렬화 | **UTC 정규화** (DB 영속화 형식 일치) |

## Test plan

- [x] `./gradlew build` — BUILD SUCCESSFUL 8m 8s (Testcontainers 통합 포함, 전체 테스트 PASS)
- [x] `list_keysetHandlesAsymmetricArrivalAndId_doesNotDropSchedules` — PASS (fix 전이라면 FAIL, 회귀 가드 가치 확인)
- [x] `list_whenInvalidCursorFormat_returns400` — PASS (v1 cursor 400 확인)
- [x] `list_returnsCursorPaginated` — PASS (기존 정상 시나리오 유지)
- [ ] (별 task) FE 가 cursor 페이징 미구현 — 일정 21번째 이후 미노출은 이번 PR scope 외, 후속 별 task 후보

## 잔여 / 알려진 한계

- FE 가 cursor 페이징 자체를 사용하지 않으므로 데모(D-9) 즉시 영향 미미. 다만 BE 정합성 가치 (장기 데이터 무결성) 는 그대로 유지
- cursor 변조로 임의 arrival 주입 시도 → `s.memberId = :memberId` 1차 필터가 본인 일정만 반환하므로 다른 사용자 노출 0 (안전)