### PR TITLE
fix(landing): 알림 문구 + 팀 캐릭터 크기 미세조정

### DIFF
--- a/assets/landing.css
+++ b/assets/landing.css
@@ -1258,11 +1258,17 @@ body::before {
   object-fit: contain;
   object-position: bottom center;
 }
-/* 남성 캐릭터(team-char-2/3)는 캔버스를 더 꽉 채워서 시각적으로 더 커보임 → 15% 축소 */
-.team-polaroid-photo img[src*="team-char-2"],
-.team-polaroid-photo img[src*="team-char-3"] {
+/* 남성 캐릭터(team-char-2/3)는 캔버스를 더 꽉 채워서 시각적으로 더 커보임 → 15% 축소.
+ * `team-char-` prefix 매칭이 female-team-char- 도 잡으니 :not 으로 제외. */
+.team-polaroid-photo img[src*="/team-char-2"],
+.team-polaroid-photo img[src*="/team-char-3"] {
   height: 85%;
   max-width: 62%;
+}
+/* 원수현(female-team-char-2)만 살짝 키움 */
+.team-polaroid-photo img[src*="female-team-char-2"] {
+  height: 100%;
+  max-width: 71%;
 }
 .team-polaroid-tape {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
               <h2 class="frame-title">
                 <span class="accent">5분 전,</span><br/>
                 준비하라고<br/>
-                <span class="underline">톡 알려드려요.</span>
+                <span class="underline">알림으로 알려드려요.</span>
               </h2>
               <p class="frame-sub">
                 도착 시각을 맞추기 위해 <strong>오늘 출발해야 하는 시각</strong>을 매일 계산해


### PR DESCRIPTION
## 변경

- **알림 frame 문구**: "톡 알려드려요" → "알림으로 알려드려요"
  - 의미 명확화. 밑줄(amber background)은 inline-block + ::after 구조라 자동 확장
- **원수현 캐릭터 크기**: 다른 3명 대비 시각적으로 작게 보여서 살짝 키움 (height 100% / max-width 71%)
- **CSS selector 수정**: `[src*=\"team-char-2\"]` 가 의도치 않게 `female-team-char-2` 도 매칭하던 문제 → `[src*=\"/team-char-2\"]` 로 슬래시 포함해 명시

## Test plan

- [ ] PR 머지 후 GitHub Pages 자동 빌드 (1~2분)
- [ ] 알림 frame 헤딩 "알림으로 알려드려요" + 밑줄 정상 표시
- [ ] 팀 frame 4명 캐릭터 크기 균형 확인

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)