### PR TITLE
feat(landing): v4 motion · 화면 크기 고정 · 성능 최적화

### DIFF
--- a/assets/landing.css
+++ b/assets/landing.css
@@ -31,6 +31,76 @@
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* ═══════════════ Too-small viewport overlay ═══════════════
+ * 1024×640 이하에서 사이트 전체 가리고 안내만 보여줌 */
+.too-small {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background:
+    radial-gradient(ellipse at 50% 30%, color-mix(in srgb, var(--blue) 18%, transparent), transparent 60%),
+    var(--paper);
+  background-image:
+    radial-gradient(ellipse at 50% 30%, color-mix(in srgb, var(--blue) 18%, transparent), transparent 60%),
+    url("landing/scene-1-calendar/notebook-paper.jpg");
+  background-size: cover, 800px auto;
+  background-repeat: no-repeat, repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+}
+.too-small[hidden] { display: none; }
+.too-small-inner {
+  max-width: 360px;
+  width: 100%;
+  text-align: center;
+  font-family: "Gaegu", "Gowun Dodum", sans-serif;
+  color: var(--ink);
+}
+.too-small-logo {
+  width: 180px;
+  height: auto;
+  margin: 0 auto 28px;
+  display: block;
+  filter: drop-shadow(0 6px 14px rgba(37, 99, 235, 0.18));
+}
+.too-small h2 {
+  font-family: "Gaegu", sans-serif;
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 1.25;
+  margin-bottom: 16px;
+  color: var(--ink);
+  word-break: keep-all;
+}
+.too-small p {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ink-soft);
+  margin-bottom: 28px;
+  word-break: keep-all;
+}
+.too-small p strong {
+  font-weight: 700;
+  color: var(--blue);
+}
+.too-small-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 22px;
+  background: var(--ink);
+  color: var(--paper);
+  border-radius: 999px;
+  font-family: "Gaegu", sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+  text-decoration: none;
+  transition: transform 0.2s, background 0.2s;
+}
+.too-small-cta:hover { transform: translateY(-2px); background: var(--blue); }
+
 html {
   scroll-behavior: smooth;
   -webkit-text-size-adjust: 100%;
@@ -88,6 +158,9 @@ body::before {
   background:
     radial-gradient(ellipse at 50% 50%, transparent 55%, rgba(80, 60, 20, 0.10) 100%);
 }
+
+/* product frame 의 sub copy 만 가운데 정렬 (인라인 style 대체) */
+.frame-sub-center { margin-left: auto; margin-right: auto; text-align: center; }
 
 /* ═══════════════ Topbar ═══════════════ */
 .topbar {
@@ -191,7 +264,7 @@ body::before {
 .rail-line {
   position: relative;
   width: 40px;
-  height: 56vh;
+  height: 480px;
   max-height: 420px;
   min-height: 240px;
   margin: 6px 0;
@@ -254,7 +327,7 @@ body::before {
 
 /* ═══════════════ HERO ═══════════════ */
 .hero {
-  min-height: 100vh;
+  min-height: 820px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -273,7 +346,7 @@ body::before {
 }
 .hero-greeting {
   font-family: var(--hand);
-  font-size: clamp(22px, 2.4vw, 30px);
+  font-size: 28px;
   color: var(--ink-mute);
   margin-bottom: 20px;
   letter-spacing: 0.01em;
@@ -295,7 +368,7 @@ body::before {
   transform: rotate(-1deg);
 }
 .hero-brand {
-  width: clamp(420px, 60vw, 720px);
+  width: 640px;
   height: auto;
   margin-bottom: 32px;
   filter: drop-shadow(0 8px 20px rgba(37, 99, 235, 0.18));
@@ -317,7 +390,7 @@ body::before {
   display: inline-flex;
   align-items: center;
   padding: 6px 16px;
-  font-size: clamp(15px, 1.3vw, 18px);
+  font-size: 17px;
   font-weight: 700;
   color: var(--blue-deep);
   background: color-mix(in srgb, var(--blue) 14%, white);
@@ -341,7 +414,7 @@ body::before {
 
 .hero-tag {
   font-family: var(--hand);
-  font-size: clamp(20px, 2vw, 26px);
+  font-size: 24px;
   color: var(--ink-soft);
   line-height: 1.5;
   max-width: 540px;
@@ -431,7 +504,7 @@ body::before {
 }
 .hero-doodle.hd-headline {
   top: 8%; left: 4%;
-  width: clamp(150px, 16vw, 220px);
+  width: 200px;
   --r: -8deg;
   opacity: 0.95;
 }
@@ -502,12 +575,13 @@ body::before {
   position: relative;
   width: 100%;
   /* 6 씬 × ~100vh + 여유 */
-  height: 700vh;
+  /* 6 frame × ~1.4 viewport 씩 머묾 — 각 frame 1148px 스크롤 dwell */
+  height: 8200px;
 }
 .stage-pin {
   position: sticky;
   top: 0;
-  height: 100vh;
+  height: 820px;
   width: 100%;
   overflow: hidden;
 }
@@ -588,7 +662,7 @@ body::before {
 .frame-title {
   font-family: var(--hand);
   font-weight: 700;
-  font-size: clamp(34px, 5vw, 64px);
+  font-size: 58px;
   line-height: 1.15;
   letter-spacing: -0.01em;
   color: var(--ink);
@@ -611,7 +685,7 @@ body::before {
 }
 .frame-sub {
   font-family: var(--hand);
-  font-size: clamp(18px, 1.6vw, 22px);
+  font-size: 21px;
   line-height: 1.6;
   color: var(--ink-soft);
   max-width: 38ch;
@@ -741,12 +815,12 @@ body::before {
   padding: 0 12px;
 }
 .map-extra-coords {
-  width: clamp(220px, 38%, 320px);
+  width: 300px;
   height: auto;
   transform: rotate(-2deg);
 }
 .map-extra-geo {
-  width: clamp(140px, 24%, 210px);
+  width: 200px;
   height: auto;
   transform: rotate(3deg);
 }
@@ -860,7 +934,7 @@ body::before {
 }
 .frame-route-visual {
   position: relative;
-  height: calc(100vh - 200px);
+  height: 620px;
   max-height: 640px;
   display: flex;
   justify-content: center;
@@ -1133,7 +1207,7 @@ body::before {
   gap: 24px;
 }
 .frame-product .frame-title {
-  font-size: clamp(28px, 4vw, 50px);
+  font-size: 46px;
   text-align: center;
 }
 .frame-product-text {
@@ -1385,7 +1459,7 @@ body::before {
 }
 .closing-title {
   font-family: var(--hand);
-  font-size: clamp(36px, 5vw, 64px);
+  font-size: 58px;
   font-weight: 700;
   color: var(--ink);
   letter-spacing: -0.01em;

--- a/assets/landing.js
+++ b/assets/landing.js
@@ -39,6 +39,33 @@
     const hasST = hasGSAP && typeof window.ScrollTrigger !== "undefined";
     if (hasST) window.gsap.registerPlugin(window.ScrollTrigger);
 
+    /* ─────────────── 화면 크기 고정 (CSS zoom) ───────────────
+     * 디자인 기준 1440 × 820. viewport 다르면 zoom 비율로 1:1 스케일.
+     * zoom 은 transform 과 달리 sticky/containing block 안 깨뜨림.
+     * too-small 진입/탈출 시 모든 캐시 + ScrollTrigger 강제 재계산. */
+    const DESIGN_W = 1440;
+    const DESIGN_H = 820;
+    const MIN_W = 1280;
+    const MIN_H = 720;
+    const tooSmall = document.getElementById("too-small");
+    let isTooSmall = false;
+    function applyZoom() {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      const small = w < MIN_W || h < MIN_H;
+      if (small) {
+        document.body.style.zoom = "";
+        if (tooSmall) tooSmall.hidden = false;
+        isTooSmall = true;
+        return;
+      }
+      if (tooSmall) tooSmall.hidden = true;
+      isTooSmall = false;
+      const z = Math.min(w / DESIGN_W, h / DESIGN_H);
+      document.body.style.zoom = String(z);
+    }
+    applyZoom();
+
     /* ─────────────── Topbar scrolled ─────────────── */
     const topbar = $("#topbar");
     const onTopbar = () => topbar && topbar.classList.toggle("scrolled", window.scrollY > 16);
@@ -55,7 +82,6 @@
       scrollProg.style.transform = `scaleX(${p})`;
     }
     addEventListener("scroll", updateProg, { passive: true });
-    addEventListener("resize", () => { refreshDocH(); updateProg(); });
     refreshDocH();
     updateProg();
 
@@ -83,7 +109,6 @@
       }
     }
     addEventListener("scroll", updateRail, { passive: true });
-    addEventListener("resize", () => { refreshDocH(); refreshRail(); updateRail(); });
     refreshRail();
     updateRail();
 
@@ -93,17 +118,18 @@
       tl.from(".hero-greeting", { y: 24, autoAlpha: 0, duration: 0.9 })
         .from(".hero-brand", { y: 40, autoAlpha: 0, scale: 0.92, duration: 1.2 }, "-=0.4")
         .from(".hero-tag", { y: 20, autoAlpha: 0, duration: 0.8 }, "-=0.6")
-        .from(".hero-meta > *", { y: 16, autoAlpha: 0, duration: 0.6, stagger: 0.05 }, "-=0.5")
-        .from(".hero-char", { x: 60, y: 30, autoAlpha: 0, rotate: 10, duration: 1.0 }, "-=0.6")
-        .from(".hero-char-left", { x: -60, autoAlpha: 0, rotate: -20, duration: 1.0 }, "<");
+        .from(".hero-meta > *", { y: 16, autoAlpha: 0, duration: 0.6, stagger: 0.05 }, "-=0.5");
+      // hero-char 가 존재할 때만 (HTML 에서 doodle 로 대체되어 빠질 수 있음)
+      if ($(".hero-char")) {
+        tl.from(".hero-char", { x: 60, y: 30, autoAlpha: 0, rotate: 10, duration: 1.0 }, "-=0.6");
+      }
     }
 
     /* ─────────────── 마우스 parallax (hero 캐릭터) ─────────────── */
     const hero = $(".hero");
     const heroChar = $(".hero-char");
-    const heroCharLeft = $(".hero-char-left");
     const heroBrand = $(".hero-brand");
-    if (hero && !reduce) {
+    if (hero && !reduce && (heroChar || heroBrand)) {
       let mx = 0, my = 0, raf = null;
       hero.addEventListener("mousemove", (e) => {
         const r = hero.getBoundingClientRect();
@@ -118,7 +144,6 @@
       function applyParallax() {
         raf = null;
         if (heroChar) heroChar.style.transform = `translate3d(${mx * -18}px, ${my * -12}px, 0) rotate(-4deg)`;
-        if (heroCharLeft) heroCharLeft.style.transform = `translate3d(${mx * 14}px, ${my * 18}px, 0) rotate(-12deg)`;
         if (heroBrand) heroBrand.style.transform = `translate3d(${mx * -6}px, ${my * -4}px, 0)`;
       }
     }
@@ -139,12 +164,33 @@
       const journeyH = () => journey.offsetHeight;
       const segLen = () => (journeyH() - innerHeight) / segCount;
 
-      // 전체 ScrollTrigger — frame switching (가벼운 onUpdate)
       let cachedVisualH = 0;
       function refreshVisualH() {
         const v = $(".frame-route-visual");
         cachedVisualH = v ? v.offsetHeight : 0;
       }
+
+      // ★ 반드시 ScrollTrigger.create 전에 선언 — 초기화 시 onUpdate 가 즉시 호출되므로 TDZ 에러 방지
+      const ranOnce = new WeakSet();
+      function onFrameActivate(frame) {
+        if (ranOnce.has(frame)) return;
+        ranOnce.add(frame);
+        const countEls = $$("[data-count]", frame);
+        if (!countEls.length || !hasGSAP) return;
+        countEls.forEach((el) => {
+          const to = parseFloat(el.dataset.count);
+          if (isNaN(to)) return;
+          const obj = { v: 0 };
+          window.gsap.to(obj, {
+            v: to,
+            duration: 1.0,
+            ease: "power3.out",
+            onUpdate() { el.textContent = Math.round(obj.v); },
+          });
+        });
+      }
+
+      // 전체 ScrollTrigger — frame switching (ranOnce / onFrameActivate 가 위에 선언되어 있어 안전)
       window.ScrollTrigger.create({
         trigger: journey,
         start: "top top",
@@ -160,12 +206,10 @@
             setActiveFrame(i);
             onFrameActivate(frames[i]);
           }
-          // route sprite — route frame 안에 있을 때 항상 재생 보장
           if (runSprite) {
             if (i === 2 && !runSprite.on) runSprite.play();
             else if (i !== 2 && runSprite.on) runSprite.stop();
           }
-          // route runner 위치 — transform 으로 GPU 가속
           if (i === 2 && runner && cachedVisualH > 0) {
             const local = clamp(p * segCount - 2, 0, 1);
             runner.style.transform = `translate(-50%, calc(-50% + ${local * cachedVisualH}px))`;
@@ -174,34 +218,9 @@
       });
       refreshVisualH();
 
-      // 첫 frame 초기 활성
+      // 첫 frame 초기 활성 + countup
       setActiveFrame(0);
-
-      // 각 frame 활성화 시 가벼운 reveal — GSAP 없이 CSS 전환 + 카운트업만
-      const ranOnce = new WeakSet();
-      function onFrameActivate(frame) {
-        if (ranOnce.has(frame)) return;
-        ranOnce.add(frame);
-        // count up — frame 안의 [data-count]
-        $$("[data-count]", frame).forEach((el) => {
-          const to = parseFloat(el.dataset.count);
-          const obj = { v: 0 };
-          window.gsap.to(obj, {
-            v: to,
-            duration: 1.0,
-            ease: "power3.out",
-            onUpdate() { el.textContent = Math.round(obj.v); },
-          });
-        });
-      }
-      // 첫 frame 즉시
       if (frames[0]) onFrameActivate(frames[0]);
-      // 이후 frame 들은 ScrollTrigger onUpdate 에서 처리
-
-      // 첫 frame 은 즉시 reveal
-      if (frames[0]) {
-        frames[0].classList.add("active");
-      }
     } else if (frames.length) {
       // GSAP 없으면 모든 frame 보이게
       frames.forEach((f) => f.classList.add("active"));
@@ -242,10 +261,43 @@
       });
     });
 
+    /* ─────────────── resize 핸들러 ───────────────
+     * 일반 resize: zoom 만 재계산 + 캐시 갱신 + ScrollTrigger refresh
+     * 단, **too-small <-> 큰 화면 경계 통과** 시: ScrollTrigger 가 zoom 전환의
+     *   극단 상태를 깨끗이 못 따라가서 frame 활성 stuck 문제 발생. 가장 확실한 해법은 reload. */
+    let resizeT = null;
+    let lastTooSmall = isTooSmall;
+    function onResize() {
+      if (resizeT) clearTimeout(resizeT);
+      resizeT = setTimeout(() => {
+        const wasTooSmall = lastTooSmall;
+        applyZoom();
+        // too-small 경계를 통과한 경우 = 어떤 방향이든 reload 가 가장 안정적
+        if (wasTooSmall !== isTooSmall) {
+          lastTooSmall = isTooSmall;
+          window.location.reload();
+          return;
+        }
+        lastTooSmall = isTooSmall;
+        // 일반 resize: 캐시 갱신만
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          refreshDocH();
+          refreshRail();
+          if (typeof refreshVisualH === "function") refreshVisualH();
+          if (hasST) {
+            window.ScrollTrigger.refresh();
+            window.ScrollTrigger.update();
+          }
+          updateRail();
+          updateProg();
+        }));
+      }, 150);
+    }
+    window.addEventListener("resize", onResize);
+
     /* ─────────────── 로드 안정화 ─────────────── */
     addEventListener("load", () => {
-      updateRail();
-      if (hasST) window.ScrollTrigger.refresh();
+      onResize();
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,21 @@
   </head>
   <body>
 
+    <!-- 화면이 너무 작을 때 안내 overlay (JS 가 너비/높이 검사 후 표시) -->
+    <div id="too-small" class="too-small" hidden>
+      <div class="too-small-inner">
+        <img class="too-small-logo" src="assets/images/todayway-typo.svg" alt="오늘어디?" />
+        <h2>이 사이트는<br/>큰 화면에서 봐주세요</h2>
+        <p>
+          가로 <strong>1280px</strong> · 세로 <strong>720px</strong> 이상의<br/>
+          데스크톱 / 태블릿 가로 화면에서 가장 잘 보입니다.
+        </p>
+        <a class="too-small-cta" href="https://github.com/kookmin-sw/2026-capstone-53" target="_blank" rel="noopener">
+          GitHub 에서 프로젝트 보기 <span aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </div>
+
     <!-- 상단 스크롤 progress bar -->
     <div class="scroll-progress" id="scrollProg" aria-hidden="true"></div>
 
@@ -61,6 +76,10 @@
         GitHub <span aria-hidden="true">↗</span>
       </a>
     </header>
+
+    <!-- 페이지 본문 wrapper — topbar/rail/too-small/scrollProg 같은 fixed 요소와 분리.
+         현재 zoom 은 body 에 적용 중이라 별도 스타일은 없지만, 추후 정렬·전환 단위로 활용 가능. -->
+    <div id="page-stage">
 
     <!-- ═══════════════ HERO ═══════════════ -->
     <section class="hero" id="top">
@@ -250,7 +269,7 @@
               <h2 class="frame-title">
                 매일 마주칠 <span class="underline accent">실제 화면</span>들.
               </h2>
-              <p class="frame-sub" style="margin-left:auto;margin-right:auto;text-align:center;">
+              <p class="frame-sub frame-sub-center">
                 다음 일정 카드 · 월간 캘린더 · 합성 경로 지도 · 설정
               </p>
             </div>
@@ -373,6 +392,8 @@
         <span>오늘 어디로 출발할까요?</span>
       </div>
     </footer>
+
+    </div><!-- /#page-stage -->
 
     <script src="assets/landing.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- **6 frame 스크롤 스토리텔링** — sticky stage 안에서 GSAP ScrollTrigger scrubbed 로 fade·morph
- **모든 viewport 동일 레이아웃** — 1440×820 fix px + body zoom min(w/W, h/H) 으로 monitor 크기 무관하게 동일 비례
- **1280×720 미만은 안내 화면** — '큰 화면에서 봐주세요' overlay (모바일 / 작은 창)
- **콘솔 에러·경고·404 0개**

## 주요 수정 사항

### 모션
- TDZ 버그 수정 — `ranOnce` / `onFrameActivate` 를 `ScrollTrigger.create` 앞에 선언 (이전엔 frame 4 부터 안 보였음)
- route runner sprite 가 frame 2 안에서 항상 재생 보장
- frame 머무는 scroll 시간 늘림 (journey 5740 → 8200px) — 한 프레임당 1.4 viewport
- 좌측 rail 캐릭터 6프레임 walk sprite + 발자국 progress fill
- Hero intro stagger + 마우스 parallax
- 상단 스크롤 progress bar (GPU transform)
- 77분 number countup

### 화면 크기 정책
- 디자인 1440×820 fix px (clamp / vw / vh 일체 제거)
- `body { zoom: min(w/1440, h/820) }` 어떤 모니터에서도 동일 비례 + 동일 위치
- 1280×720 미만: too-small overlay + GitHub 링크
- too-small 경계 통과 시 안전 reload (ScrollTrigger 상태 깔끔 복원)
- resize 핸들러 단일 통합 (분산된 3개 → 1개, rAF×2 reflow 대기 후 cache 일괄 갱신)

### 콘텐츠
- '캘린더 기반 경로 추천' 메인 컨셉 강조 (hero pills + frame 01 / 03 텍스트)
- 핀 라벨 핀 머리 위로 정렬
- product / map / route 텍스트를 기능 소개 스타일로 다듬음

### 성능
- `background-attachment: fixed` 제거 → fixed pseudo 레이어 (스크롤 paint 비용 차단)
- inactive frame 의 `drop-shadow` filter 제거
- transform·scale 기반 애니메이션 (paint 비용 없음)
- Lenis 제거 — 네이티브 스크롤이 메인스레드 막힐 때 더 안정적

## 검증한 viewport
| Viewport | zoom | 결과 |
|---|---|---|
| 1024 × 720 | (off) | too-small overlay |
| 1280 × 720 | 0.88 | OK |
| 1366 × 768 | 0.94 | OK |
| 1440 × 900 | 1.00 | 기준 |
| 1920 × 1080 | 1.32 | OK |
| 2560 × 1440 | 1.76 | OK |
| 3440 × 1440 | 1.76 | OK (울트라와이드) |

## Test plan
- [ ] 1280 이상 viewport 에서 모든 frame (calendar / map / route / alert / product / team) 활성 확인
- [ ] route 진입 시 캐릭터 sprite 달리기 + 경로 따라 이동
- [ ] 핀 라벨 (국민대 정문 / 강남역) 핀 머리 위로 깨끗하게 표시
- [ ] 1280×720 미만 viewport 에서 too-small overlay 표시
- [ ] 큰 화면 → too-small → 큰 화면 resize 시 사이트 깨짐 없이 복원
- [ ] 콘솔 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)