### PR TITLE
fix(calendar): remove auto-focus on PlaceSearchOverlay mount

### DIFF
--- a/frontend/src/pages/Calendar.js
+++ b/frontend/src/pages/Calendar.js
@@ -74,7 +74,8 @@ function PlaceSearchOverlay({ field, onSelect, onClose }) {
   const timerRef  = useRef(null);
   const inputRef  = useRef(null);
 
-  useEffect(() => { inputRef.current?.focus(); }, []);
+  // 마운트 시 자동 포커스를 걸지 않음 — iOS Safari가 input을 viewport에 보이게 하려고
+  // 자동 스크롤하면서 페이지가 아래로 내려가는 문제 방지. 사용자가 직접 input을 탭해야 포커스됨.
 
   const dismiss = useCallback((cb) => {
     setClosing(true);


### PR DESCRIPTION
- iOS Safari에서 일정 등록 → 출발지/도착지 탭 시 화면이 처음부터 아래로 스크롤되어 헤더가 잘려 보이던 버그 수정
- 원인: PlaceSearchOverlay 마운트 useEffect에서 input에 자동 .focus() 호출 → iOS Safari가 input을 viewport에 보이게 하려고 자동 스크롤
- 해결: 마운트 시 자동 포커스 제거. 사용자가 input을 직접 탭해야 포커스됨
- clearQuery의 .focus()는 사용자 의도적 동작이라 유지